### PR TITLE
Add title to back link

### DIFF
--- a/templates/auth0-login-form.php
+++ b/templates/auth0-login-form.php
@@ -7,6 +7,7 @@ $wordpress_login_enabled = WP_Auth0_Options::get('wordpress_login_enabled') == 1
 
 $domain = WP_Auth0_Options::get('domain');
 $cdn = WP_Auth0_Options::get('cdn_url');
+$dict = WP_Auth0_Options::get('dict');
 
 $allow_signup = WP_Auth0_Options::is_wp_registration_enabled();
 

--- a/templates/back-to-auth0.php
+++ b/templates/back-to-auth0.php
@@ -1,8 +1,13 @@
+<?php
+if (empty($title)) {
+    $title = "Auth0";
+}
+?>
 <style>
     #loginform{
         display: block !important;
     }
 </style>
 <div id="extra-options">
-    <a href="?">← Back to Auth0 login</a>
+    <a href="?">← Back to <?= $title ?> login</a>
 </div>


### PR DESCRIPTION
Better way to see. Note that when translating lock, the `$title` variable is empty by default.