### PR TITLE
Fixed logging into an existing user when existing username exists (on user creation)

### DIFF
--- a/WP_Auth0.php
+++ b/WP_Auth0.php
@@ -686,15 +686,12 @@ function get_currentauth0userinfo() {
     global $wpdb;
 
     get_currentuserinfo();
-    if ($current_user instanceof WP_User && $current_user->ID > 0 ) {
+    if ($current_user instanceof WP_User && $current_user->ID > 0) {
         $sql = 'SELECT auth0_obj
                 FROM ' . $wpdb->auth0_user .'
                 WHERE wp_id = %d';
         $result = $wpdb->get_row($wpdb->prepare($sql, $current_user->ID));
         if (is_null($result) || $result instanceof WP_Error ) {
-
-            self::insertAuth0Error('get_currentauth0userinfo',$result);
-
             return null;
         }
         $currentauth0_user = unserialize($result->auth0_obj);

--- a/lib/WP_Auth0_Users.php
+++ b/lib/WP_Auth0_Users.php
@@ -33,9 +33,10 @@ class WP_Auth0_Users {
 		}
 
 		$username = $userinfo->nickname;
-		if (empty($username)) {
+		if (empty($username) || username_exists($username)) {
 			$username = $email;
 		}
+		
 		// Create the user data array for updating first- and lastname
 		$user_data = array(
 			'user_email' => $email,


### PR DESCRIPTION
Check if username exists when creating a new user. If username is the same as an admin user, it'll log you in as admin instead of creating a new user. You must check if username exists before calling wp_insert_user().

Fixed error message output (self::insertAuth0Error doesn't exist) in get_currentauth0userinfo.