### PR TITLE
Must check if user exists.

### DIFF
--- a/WP_Auth0.php
+++ b/WP_Auth0.php
@@ -686,15 +686,12 @@ function get_currentauth0userinfo() {
     global $wpdb;
 
     get_currentuserinfo();
-    if ($current_user instanceof WP_User && $current_user->ID > 0 ) {
+    if ($current_user instanceof WP_User && $current_user->ID > 0) {
         $sql = 'SELECT auth0_obj
                 FROM ' . $wpdb->auth0_user .'
                 WHERE wp_id = %d';
         $result = $wpdb->get_row($wpdb->prepare($sql, $current_user->ID));
         if (is_null($result) || $result instanceof WP_Error ) {
-
-            self::insertAuth0Error('get_currentauth0userinfo',$result);
-
             return null;
         }
         $currentauth0_user = unserialize($result->auth0_obj);

--- a/lib/WP_Auth0_Users.php
+++ b/lib/WP_Auth0_Users.php
@@ -36,7 +36,6 @@ class WP_Auth0_Users {
 		if (empty($username) || username_exists($username)) {
 			$username = $email;
 		}
-		
 		// Create the user data array for updating first- and lastname
 		$user_data = array(
 			'user_email' => $email,

--- a/lib/WP_Auth0_Users.php
+++ b/lib/WP_Auth0_Users.php
@@ -33,9 +33,10 @@ class WP_Auth0_Users {
 		}
 
 		$username = $userinfo->nickname;
-		if (empty($username)) {
+		if (empty($username) || username_exists($username)) {
 			$username = $email;
 		}
+		
 		// Create the user data array for updating first- and lastname
 		$user_data = array(
 			'user_email' => $email,


### PR DESCRIPTION
When logging in with LinkedIn, if username (nickname) already exists it won't create a new wordpress account. Set username to email (change_this_email@" . uniqid() .".com) if username exists.