### PR TITLE
Fixed logout bug and get state bug.

### DIFF
--- a/WP_Auth0.php
+++ b/WP_Auth0.php
@@ -222,15 +222,20 @@ class WP_Auth0 {
 
         $sso = WP_Auth0_Options::get( 'sso' );
         $auto_login = absint(WP_Auth0_Options::get( 'auto_login' ));
-        if ($auto_login) {
-            wp_redirect(home_url());
-            die();
-        }
-        if ($sso) {
-            wp_redirect("https://". WP_Auth0_Options::get('domain') . "/v2/logout?returnTo=" . urlencode(home_url()));
-            die();
-        }
 
+        if (isset($_REQUEST['redirect_to']))
+            $redirect_to = $_REQUEST['redirect_to'];
+        else
+            $redirect_to = home_url();
+
+        if ($sso) {
+            wp_redirect("https://". WP_Auth0_Options::get('domain') . "/v2/logout?returnTo=" . urlencode($redirect_to));
+            die();
+        }
+        if ($auto_login) {
+            wp_redirect($redirect_to);
+            die();
+        }
     }
 
     public static function render_back_to_auth0() {
@@ -602,7 +607,7 @@ class WP_Auth0 {
         require_once WPA0_PLUGIN_DIR . 'lib/php-jwt/Authentication/JWT.php';
 
         $token = $_POST["token"];
-        $stateFromGet = json_decode($_POST["state"]);
+        $stateFromGet = json_decode(stripcslashes($_POST["state"]));
 
         $secret = WP_Auth0_Options::get('client_secret');
         $secret = base64_decode(strtr($secret, '-_', '+/'));


### PR DESCRIPTION
1. Changed logout() function to honor "redirect_to" query string. Also check for SSO first before auto login.
2. Fixed bug. You must strip slashes for $_POST["state"]. Changed to: json_decode(stripcslashes($_POST["state"]));