### PR TITLE
Fix use "self" outside class scope.

### DIFF
--- a/WP_Auth0.php
+++ b/WP_Auth0.php
@@ -793,7 +793,7 @@ function get_currentauth0userinfo() {
         $result = $wpdb->get_row($wpdb->prepare($sql, $current_user->ID));
         if (is_null($result) || $result instanceof WP_Error ) {
 
-            self::insertAuth0Error('get_currentauth0userinfo',$result);
+            WP_Auth0::insertAuth0Error('get_currentauth0userinfo',$result);
 
             return null;
         }


### PR DESCRIPTION
The WP_Auth0 class implement `insertAuth0Error` method.
The function `get_currentauth0userinfo` is defined outside class, but it calls `insertAuth0Error` using `self` not `WP_Auth0`.