### PR TITLE
Added Scope Resolution to unserialize function call

### DIFF
--- a/WP_Auth0.php
+++ b/WP_Auth0.php
@@ -350,7 +350,7 @@ if ( ! function_exists( 'get_currentauth0userinfo' ) ) {
 
 		$result = get_currentauth0user();
 		if ($result) {
-			$currentauth0_user = unserialize( $result->auth0_obj );
+			$currentauth0_user = WP_Auth0_Serializer::unserialize( $result->auth0_obj );
 		}
 
 		return $currentauth0_user;


### PR DESCRIPTION
The un-scoped call to unserialize has been observed to call functions from other plugins. Adding Scope Resolution ensures the correct function is called.