### PR TITLE
Fix infinite loop when single logout enabled

### DIFF
--- a/templates/auth0-singlelogout-handler.php
+++ b/templates/auth0-singlelogout-handler.php
@@ -2,7 +2,7 @@
 <script type="text/javascript">
 (function(){
 
-  var uuids = '<?php echo $profile->user_id; ?>';
+  var uuids = '<?php echo $user_profile->user_id; ?>';
   document.addEventListener("DOMContentLoaded", function() {
     var lock = new Auth0Lock('<?php echo $client_id; ?>', '<?php echo $domain; ?>');
     lock.$auth0.getSSOData(function(err, data) {


### PR DESCRIPTION
When single logout is enabled, this handler references an undefined variable forcing the user to be logged out.  The variable is defined in `/lib/WP_Auth0_LoginManager.php` as `$user_profile`  not `$profile` as currently written in handler logic.