### PR TITLE
Add auth0_before_login hook and exception type

### DIFF
--- a/lib/exceptions/WP_Auth0_BeforeLoginException.php
+++ b/lib/exceptions/WP_Auth0_BeforeLoginException.php
@@ -1,0 +1,3 @@
+<?php
+
+class WP_Auth0_BeforeLoginException extends Exception {}


### PR DESCRIPTION
Allows 3rd party plugins to run, check other conditions and throw an exception if login is to be prevented. Includes special logout display and link for these cases.  I am trying to integrate the Auth0 login plugin with the WP-Members 'hold registrations for admin approval' feature, and this hook gets me most of the way there.

I included a small refactor of the actual logic for doing the wordpress login into a do_login() function.

I just picked "before_login" as the first name that came to mind -- feel free to suggest a better one.
