### PR TITLE
Decode the json string 'language_dictionary'

### DIFF
--- a/lib/WP_Auth0_Lock10_Options.php
+++ b/lib/WP_Auth0_Lock10_Options.php
@@ -128,7 +128,7 @@ class WP_Auth0_Lock10_Options {
       $options_obj['language'] = $settings['language'];
     }
     if (isset($settings['language_dictionary']) && !empty($settings['language_dictionary'])) {
-      $options_obj['languageDictionary'] = $settings['language_dictionary'];
+      $options_obj['languageDictionary'] = json_decode($settings['language_dictionary']);
     }
 
     if ( isset( $settings['form_title'] ) && trim( $settings['form_title'] ) !== '' ) {


### PR DESCRIPTION
The json string retrieved from settings ($settings['language_dictionary']) is never decoded. This decodes the json string so it actually becomes an array in $settings.