### PR TITLE
Tolerate Multisite deployments

### DIFF
--- a/lib/WP_Auth0_DBManager.php
+++ b/lib/WP_Auth0_DBManager.php
@@ -162,6 +162,7 @@ class WP_Auth0_DBManager {
         'compare' => 'IN',
 			) );
 		}
+		$query['blog_id'] = 0;
 
 		$results = get_users( $query );
 

--- a/lib/WP_Auth0_UsersRepo.php
+++ b/lib/WP_Auth0_UsersRepo.php
@@ -148,7 +148,11 @@ class WP_Auth0_UsersRepo {
 	public function find_auth0_user( $id ) {
 		global $wpdb;
 
-		$users = get_users( array( 'meta_key' => $wpdb->prefix.'auth0_id', 'meta_value' => $id) ); 
+	$users = get_users( array( 
+		'meta_key' => $wpdb->prefix.'auth0_id',
+		'meta_value' => $id,
+		'blog_id' => 0)
+	); 
 
 		if ( $users instanceof WP_Error ) {
 			WP_Auth0_ErrorManager::insert_auth0_error( '_find_auth0_user', $userRow );


### PR DESCRIPTION
WordPress Multisite allows users to move between blogs in the network, but the `get_users` query will only return users who registered on _the currently active blog_. 

Auth0 needs to take care of this edge case, because when merging with an existing user, it crashes with `Email already exists` where the user is already signed up to another blog in the network.

It appears that passing `blog_id = 0` switches off the filter and allows you to query all existing users.