### PR TITLE
Add filter to allow auto-provisioning of users, idenpendent of WP setting

### DIFF
--- a/lib/WP_Auth0_Options.php
+++ b/lib/WP_Auth0_Options.php
@@ -16,7 +16,7 @@ class WP_Auth0_Options extends WP_Auth0_Options_Generic {
 		if ( is_multisite() ) {
 			return users_can_register_signup_filter();
 		}
-		return get_site_option( 'users_can_register', 0 ) == 1;
+		return apply_filters( 'wp_auth0_is_registration_enabled', (get_site_option('users_can_register', 0) == 1) );
 	}
 
 	public function get_enabled_connections() {


### PR DESCRIPTION
We needed to keep WP registration closed, but enabled auto-provisioning of users via SSO (trusted sources). I've simply added a filter to enabled us to do that.

I did see that you had an option in the settings to enabled auto-provisioning of users, independently of WP registration setting. So, there is probably a reason why you removed the functionality.

Would it be possible to merge in this change to allow us to use & update the plugin w/o the need to modify it? Please let us know. Thanks!
