### PR TITLE
Lock 10 Fix for Single Log Out

### DIFF
--- a/lib/WP_Auth0_LoginManager.php
+++ b/lib/WP_Auth0_LoginManager.php
@@ -85,7 +85,11 @@ class WP_Auth0_LoginManager {
 		$logout_url = wp_logout_url( get_permalink() ) . '&SLO=1';
 
 		wp_enqueue_script( 'wpa0_lock', $cdn, 'jquery' );
-		include WPA0_PLUGIN_DIR . 'templates/auth0-singlelogout-handler.php';
+		if ($this->a0_options->get('use_lock_10')) {
+            include WPA0_PLUGIN_DIR . 'templates/auth0-singlelogout-handler-lock10.php';
+        } else {
+            include WPA0_PLUGIN_DIR . 'templates/auth0-singlelogout-handler.php';
+        }
 	}
 
 	public function logout() {

--- a/templates/auth0-singlelogout-handler-lock10.php
+++ b/templates/auth0-singlelogout-handler-lock10.php
@@ -1,0 +1,21 @@
+<script id="auth0" src="<?php echo $cdn ?>"></script>
+<script type="text/javascript">
+(function(){
+
+  var uuids = '<?php echo $user_profile->user_id; ?>';
+  document.addEventListener("DOMContentLoaded", function() {
+    var client = new Auth0({
+          domain:       '<?php echo $domain; ?>',
+          clientID:     '<?php echo $client_id; ?>',
+          responseType: 'token'
+        });
+
+        client.getSSOData(function(err, data) {
+          if (!err && ( !data.sso || uuids != data.lastUsedUserID) ) {
+            window.location = '<?php echo html_entity_decode( $logout_url ); ?>';
+          }
+        });
+  });
+
+})();
+</script>

--- a/templates/auth0-singlelogout-handler.php
+++ b/templates/auth0-singlelogout-handler.php
@@ -4,8 +4,13 @@
 
   var uuids = '<?php echo $user_profile->user_id; ?>';
   document.addEventListener("DOMContentLoaded", function() {
-    var lock = new Auth0Lock('<?php echo $client_id; ?>', '<?php echo $domain; ?>');
-    lock.$auth0.getSSOData(function(err, data) {
+    var client = new Auth0({
+      domain:       '<?php echo $domain; ?>',
+      clientID:     '<?php echo $client_id; ?>',
+      responseType: 'token'
+    });
+
+    client.getSSOData(function(err, data) {
       if (!err && ( !data.sso || uuids != data.lastUsedUserID) ) {
 
         window.location = '<?php echo html_entity_decode( $logout_url ); ?>';

--- a/templates/auth0-singlelogout-handler.php
+++ b/templates/auth0-singlelogout-handler.php
@@ -4,13 +4,8 @@
 
   var uuids = '<?php echo $user_profile->user_id; ?>';
   document.addEventListener("DOMContentLoaded", function() {
-    var client = new Auth0({
-      domain:       '<?php echo $domain; ?>',
-      clientID:     '<?php echo $client_id; ?>',
-      responseType: 'token'
-    });
-
-    client.getSSOData(function(err, data) {
+    var lock = new Auth0Lock('<?php echo $client_id; ?>', '<?php echo $domain; ?>');
+    lock.$auth0.getSSOData(function(err, data) {
       if (!err && ( !data.sso || uuids != data.lastUsedUserID) ) {
 
         window.location = '<?php echo html_entity_decode( $logout_url ); ?>';


### PR DESCRIPTION
Following the same pattern [here](https://github.com/auth0/wp-auth0/blob/master/lib/WP_Auth0_LoginManager.php#L53) to include a compatible Lock 10 version of `auth0-singlelogout-handler-lock10.php` when Lock 10 is enabled in the Auth0 Wordpress plugin settings. Please see support ticket #19829

