### PR TITLE
Added translation support for a few user-facing exception messages

### DIFF
--- a/lib/WP_Auth0_LoginManager.php
+++ b/lib/WP_Auth0_LoginManager.php
@@ -481,7 +481,9 @@ class WP_Auth0_LoginManager {
 			catch ( WP_Auth0_CouldNotCreateUserException $e ) {
 				throw new WP_Auth0_LoginFlowValidationException( $e->getMessage() );
 			} catch ( WP_Auth0_RegistrationNotEnabledException $e ) {
-				throw new WP_Auth0_LoginFlowValidationException( 'Could not create user. The registration process is not available. Please contact your site’s administrator.' );
+				$msg = __( 'Could not create user. The registration process is not available. Please contact your site’s administrator.', 'wp-auth0' );
+				
+				throw new WP_Auth0_LoginFlowValidationException( $msg );
 			} catch ( WP_Auth0_EmailNotVerifiedException $e ) {
 				$this->dieWithVerifyEmail( $e->userinfo, $e->id_token );
 			}

--- a/lib/WP_Auth0_UsersRepo.php
+++ b/lib/WP_Auth0_UsersRepo.php
@@ -117,7 +117,9 @@ class WP_Auth0_UsersRepo {
 			$auth0_id = get_user_meta( $joinUser->ID, $wpdb->prefix.'auth0_id', true);
 
 			if ($auth0_id) { // if it has an a0 id, we cant join it
-				throw new WP_Auth0_CouldNotCreateUserException('There is a user with the same email');
+				$msg = __( 'There is a user with the same email', 'wp-auth0' );
+				
+				throw new WP_Auth0_CouldNotCreateUserException( $msg );
 			}
 		}
 
@@ -142,7 +144,9 @@ class WP_Auth0_UsersRepo {
 			if ( is_wp_error( $user_id ) ) {
 				throw new WP_Auth0_CouldNotCreateUserException( $user_id->get_error_message() );
 			}elseif ( $user_id == -2 ) {
-				throw new WP_Auth0_CouldNotCreateUserException( 'Could not create user. The registration process were rejected. Please verify that your account is whitelisted for this system. Please contact your site’s administrator.' );
+				$msg = __( 'Could not create user. The registration process were rejected. Please verify that your account is whitelisted for this system. Please contact your site’s administrator.', 'wp-auth0' );
+				
+				throw new WP_Auth0_CouldNotCreateUserException( $msg );
 			}elseif ( $user_id <0 ) {
 				throw new WP_Auth0_CouldNotCreateUserException();
 			}


### PR DESCRIPTION
A few of the user-facing exception messages regarding existing accounts and inability to sign up were not translatable. This does not affect developer-facing exceptions.

This issue was first encountered in #308 to which a fix has not yet been determined. I was unable to change the default "Could not create user. The registration process is not available. Please contact your site’s administrator." message to say something more specific like "Billing login is available only for subscription managers."

See #311 for the rationale of using 'wp-auth0' rather than `WPA0_LANG` in this commit.