### PR TITLE
Disable base64_encoded by default

### DIFF
--- a/lib/WP_Auth0_Options.php
+++ b/lib/WP_Auth0_Options.php
@@ -58,7 +58,7 @@ class WP_Auth0_Options extends WP_Auth0_Options_Generic {
 			'auto_login_method' => '',
 			'client_id' => '',
 			'client_secret' => '',
-			'client_secret_b64_encoded' => true,
+			'client_secret_b64_encoded' => false,
 			'domain' => '',
 			'form_title' => '',
 			'icon_url' => '',


### PR DESCRIPTION
Since all new clients created are not base64 encoded, it does not make
sense to keep this turned on by default.