### PR TITLE
Improve redirect_login error logging, JWT leeway

### DIFF
--- a/lib/WP_Auth0_LoginManager.php
+++ b/lib/WP_Auth0_LoginManager.php
@@ -237,8 +237,13 @@ class WP_Auth0_LoginManager {
 				$data->id_token = null;
 				$response = WP_Auth0_Api_Client::get_user_info( $domain, $data->access_token );
 			} else {
-				// grab the user ID from the id_token to call get_user
-				$decodedToken = JWT::decode( $data->id_token, $this->a0_options->get_client_secret_as_key(), array( 'HS256' ) );
+				try {
+					// grab the user ID from the id_token to call get_user
+					$decodedToken = JWT::decode( $data->id_token, $this->a0_options->get_client_secret_as_key(), array( 'HS256' ) );
+				} catch (Exception $e) {
+					WP_Auth0_ErrorManager::insert_auth0_error('redirect_login/decode', $e->getMessage());
+					throw new WP_Auth0_LoginFlowValidationException(__('Error: There was an issue decoding the token', WPA0_LANG));
+				}
 
 				// validate that this JWT was made for us
 				if ( $this->a0_options->get( 'client_id' ) !== $decodedToken->aud ) {

--- a/lib/php-jwt/Authentication/JWT.php
+++ b/lib/php-jwt/Authentication/JWT.php
@@ -79,24 +79,24 @@ class JWT
             }
 
             // Check if the nbf if it is defined. This is the time that the
-            // token can actually be used. If it's not yet that time, abort.
-            if (isset($payload->nbf) && $payload->nbf > time()) {
+            // token can actually be used. If it's not yet that time, abort. Small leeway for clock skew.
+            if (isset($payload->nbf) && $payload->nbf > time() + 2) {
                 throw new BeforeValidException(
-                    'Cannot handle token prior to ' . date(DateTime::ISO8601, $payload->nbf)
+                    'Cannot handle token prior to (nbf) ' . date(DateTime::ISO8601, $payload->nbf)
                 );
             }
 
             // Check that this token has been created before 'now'. This prevents
             // using tokens that have been created for later use (and haven't
-            // correctly used the nbf claim).
-            if (isset($payload->iat) && $payload->iat > time()) {
+            // correctly used the nbf claim). Small leeway for clock skew.
+            if (isset($payload->iat) && $payload->iat > time() + 2) {
                 throw new BeforeValidException(
-                    'Cannot handle token prior to ' . date(DateTime::ISO8601, $payload->iat)
+                    'Cannot handle token prior to (iat) ' . date(DateTime::ISO8601, $payload->iat)
                 );
             }
 
-            // Check if this token has expired.
-            if (isset($payload->exp) && time() >= $payload->exp) {
+            // Check if this token has expired. Small leeway for clock skew.
+            if (isset($payload->exp) && time() >= $payload->exp + 2) {
                 throw new ExpiredException('Expired token');
             }
         }


### PR DESCRIPTION
JWTDecode exceptions are now caught and logged in Auth0 Error Log, which should aid CS in debugging in general.  A leeway (could be increased) for clock skew has been added to iat, nbf and exp claims. 
Related to a current ZD Ticket