### PR TITLE
Release 3.2.21

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Change Log
 
+## [3.2.21](https://github.com/auth0/wp-auth0/tree/3.2.21) (2017-06-14)
+[Full Changelog](https://github.com/auth0/wp-auth0/compare/3.2.5...3.2.21)
+
+**Added**
+- Improve redirect_login error logging, JWT leeway [\#317](https://github.com/auth0/wp-auth0/pull/317) ([cocojoe](https://github.com/cocojoe))
+
+**Changed**
+- Expand internal login error with hint to disable base 64 encoding [\#318](https://github.com/auth0/wp-auth0/pull/318) ([cocojoe](https://github.com/cocojoe))
+- Disable base64_encoded by default [\#313](https://github.com/auth0/wp-auth0/pull/313) ([thameera](https://github.com/thameera))
+
 ## [3.2.5](https://github.com/auth0/wp-auth0/tree/3.2.5) (2016-09-07)
 [Full Changelog](https://github.com/auth0/wp-auth0/compare/3.2.0...3.2.5)
 

--- a/README.md
+++ b/README.md
@@ -81,6 +81,23 @@ If the filter returns null, it will lookup by email as stated in the [How doe it
     }   
 ```
 
+### Customize autologin connection
+
+This filter will allow to programatically set which connection the plugin should use when autologin is enabled.
+
+```
+    add_filter( 'auth0_get_auto_login_connection', 'auth0_get_auto_login_connection', 1, 1 );
+
+    function auth0_get_auto_login_connection($connection) {
+
+        if ( /* check some condition */ ) {
+            return 'twitter';
+        }
+
+        return $connection;
+    }
+```
+
 ## API authentication
 
 The last version of the plugin provides the ability integrate with **wp-jwt-auth** plugin to authenticate api calls via a HTTP Authorization Header.

--- a/WP_Auth0.php
+++ b/WP_Auth0.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: PLUGIN_NAME
  * Description: PLUGIN_DESCRIPTION
- * Version: 3.2.18
+ * Version: 3.2.19
  * Author: Auth0
  * Author URI: https://auth0.com
  */
@@ -11,7 +11,7 @@ define( 'WPA0_PLUGIN_DIR', trailingslashit( plugin_dir_path( __FILE__ ) ) );
 define( 'WPA0_PLUGIN_URL', trailingslashit( plugin_dir_url( __FILE__ ) ) );
 define( 'WPA0_LANG', 'wp-auth0' );
 define( 'AUTH0_DB_VERSION', 13 );
-define( 'WPA0_VERSION', '3.2.18' );
+define( 'WPA0_VERSION', '3.2.19' );
 
 /**
  * Main plugin class

--- a/WP_Auth0.php
+++ b/WP_Auth0.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: PLUGIN_NAME
  * Description: PLUGIN_DESCRIPTION
- * Version: 3.2.20
+ * Version: 3.2.21
  * Author: Auth0
  * Author URI: https://auth0.com
  */
@@ -11,7 +11,7 @@ define( 'WPA0_PLUGIN_DIR', trailingslashit( plugin_dir_path( __FILE__ ) ) );
 define( 'WPA0_PLUGIN_URL', trailingslashit( plugin_dir_url( __FILE__ ) ) );
 define( 'WPA0_LANG', 'wp-auth0' );
 define( 'AUTH0_DB_VERSION', 13 );
-define( 'WPA0_VERSION', '3.2.20' );
+define( 'WPA0_VERSION', '3.2.21' );
 
 /**
  * Main plugin class

--- a/lib/WP_Auth0_LoginManager.php
+++ b/lib/WP_Auth0_LoginManager.php
@@ -129,13 +129,15 @@ class WP_Auth0_LoginManager {
 			}
 			$state = base64_encode( json_encode( $stateObj ) );
 
+      $connection = apply_filters( 'auth0_get_auto_login_connection', $this->a0_options->get( 'auto_login_method' ) );
+
 			// Create the link to log in.
 			$login_url = "https://". $this->a0_options->get( 'domain' ) .
 				"/authorize?response_type=code&scope=openid%20profile".
 				"&client_id=".$this->a0_options->get( 'client_id' ) .
 				"&redirect_uri=".home_url( '/index.php?auth0=1' ) .
 				"&state=".urlencode( $state ).
-				"&connection=".$this->a0_options->get( 'auto_login_method' ).
+				"&connection=". trim($connection) .
 				"&auth0Client=" . WP_Auth0_Api_Client::get_info_headers();
 
 			wp_redirect( $login_url );


### PR DESCRIPTION
**Added**
- Improve redirect_login error logging, JWT leeway [\#317](https://github.com/auth0/wp-auth0/pull/317) ([cocojoe](https://github.com/cocojoe))

**Changed**
- Expand internal login error with hint to disable base 64 encoding [\#318](https://github.com/auth0/wp-auth0/pull/318) ([cocojoe](https://github.com/cocojoe))
- Disable base64_encoded by default [\#313](https://github.com/auth0/wp-auth0/pull/313) ([thameera](https://github.com/thameera))