### PR TITLE
Release 3.2.22

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## [3.2.22](https://github.com/auth0/wp-auth0/tree/3.2.22) (2017-06-26)
+[Full Changelog](https://github.com/auth0/wp-auth0/compare/3.2.21...3.2.22)
+
+**Fixed**
+- Fixed migration for older plugins that use base64 secret [\#324](https://github.com/auth0/wp-auth0/pull/324) ([cocojoe](https://github.com/cocojoe))
+
 ## [3.2.21](https://github.com/auth0/wp-auth0/tree/3.2.21) (2017-06-14)
 [Full Changelog](https://github.com/auth0/wp-auth0/compare/3.2.5...3.2.21)
 

--- a/WP_Auth0.php
+++ b/WP_Auth0.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: PLUGIN_NAME
  * Description: PLUGIN_DESCRIPTION
- * Version: 3.2.21
+ * Version: 3.2.22
  * Author: Auth0
  * Author URI: https://auth0.com
  */
@@ -11,7 +11,7 @@ define( 'WPA0_PLUGIN_DIR', trailingslashit( plugin_dir_path( __FILE__ ) ) );
 define( 'WPA0_PLUGIN_URL', trailingslashit( plugin_dir_url( __FILE__ ) ) );
 define( 'WPA0_LANG', 'wp-auth0' );
 define( 'AUTH0_DB_VERSION', 14 );
-define( 'WPA0_VERSION', '3.2.21' );
+define( 'WPA0_VERSION', '3.2.22' );
 
 /**
  * Main plugin class

--- a/WP_Auth0.php
+++ b/WP_Auth0.php
@@ -10,7 +10,7 @@ define( 'WPA0_PLUGIN_FILE', __FILE__ );
 define( 'WPA0_PLUGIN_DIR', trailingslashit( plugin_dir_path( __FILE__ ) ) );
 define( 'WPA0_PLUGIN_URL', trailingslashit( plugin_dir_url( __FILE__ ) ) );
 define( 'WPA0_LANG', 'wp-auth0' );
-define( 'AUTH0_DB_VERSION', 13 );
+define( 'AUTH0_DB_VERSION', 14 );
 define( 'WPA0_VERSION', '3.2.21' );
 
 /**

--- a/lib/WP_Auth0_DBManager.php
+++ b/lib/WP_Auth0_DBManager.php
@@ -133,6 +133,14 @@ class WP_Auth0_DBManager {
       }
     }
 
+	if ( $this->current_db_version < 14 && is_null($options->get('client_secret_b64_encoded' ))) {
+		if ( $options->get('client_id' )) {
+			$options->set('client_secret_b64_encoded', true);
+		} else {
+			$options->set('client_secret_b64_encoded', false);
+		}
+	}
+
 		$this->current_db_version = AUTH0_DB_VERSION;
 		update_option( 'auth0_db_version', AUTH0_DB_VERSION );
 	}

--- a/lib/WP_Auth0_Options.php
+++ b/lib/WP_Auth0_Options.php
@@ -58,7 +58,7 @@ class WP_Auth0_Options extends WP_Auth0_Options_Generic {
 			'auto_login_method' => '',
 			'client_id' => '',
 			'client_secret' => '',
-			'client_secret_b64_encoded' => false,
+			'client_secret_b64_encoded' => null,
 			'domain' => '',
 			'form_title' => '',
 			'icon_url' => '',

--- a/lib/admin/WP_Auth0_Admin_Basic.php
+++ b/lib/admin/WP_Auth0_Admin_Basic.php
@@ -174,9 +174,8 @@ class WP_Auth0_Admin_Basic extends WP_Auth0_Admin_Generic {
 
 		// Only replace the secret or token if a new value was set. If not, we will keep the last one entered.
 		$input['client_secret'] = ( !empty( $input['client_secret'] ) ? $input['client_secret'] : $old_options['client_secret'] );
-		$input['client_secret_b64_encoded'] = ( isset( $input['client_secret_b64_encoded'] ) ? $input['client_secret_b64_encoded'] : 0 );
+		$input['client_secret_b64_encoded'] = ( isset( $input['client_secret_b64_encoded'] ) ? $input['client_secret_b64_encoded'] == 1 : false );
 		$input['auth0_app_token'] = ( !empty( $input['auth0_app_token'] ) ? $input['auth0_app_token'] : $old_options['auth0_app_token'] );
-
 
 		$error = '';
 		$completeBasicData = true;

--- a/lib/php-jwt/Authentication/JWT.php
+++ b/lib/php-jwt/Authentication/JWT.php
@@ -75,7 +75,7 @@ class JWT
 
             // Check the signature
             if (!JWT::verify("$headb64.$bodyb64", $sig, $key, $header->alg)) {
-                throw new SignatureInvalidException('Signature verification failed, disabling "Settings \ Basic \ Client Secret Base64 Encoded" may resolve this issue.');
+                throw new SignatureInvalidException('Signature verification failed, check "Client Secret Base64 Encoded" value matches your Auth0 client.');
             }
 
             // Check if the nbf if it is defined. This is the time that the


### PR DESCRIPTION
**Fixed**
- Fixed migration for older plugins that use base64 secret [\#324](https://github.com/auth0/wp-auth0/pull/324) ([cocojoe](https://github.com/cocojoe))