### PR TITLE
Prevent script errors throughout the admin panel when anonymous data metrics are disabled

### DIFF
--- a/lib/WP_Auth0_Metrics.php
+++ b/lib/WP_Auth0_Metrics.php
@@ -66,6 +66,15 @@ class WP_Auth0_Metrics {
       </script>
     <?php
 		}
+		else {
+?>
+      <script>
+        function metricsTrack() {
+          // Metrics are disabled
+        }
+      </script>
+    <?php
+		}
 	}
 
 }


### PR DESCRIPTION
The `metricsTrack` function, used throughout the admin panel, is undefined if the setting to allow anonymous analytics is disabled. This change defines a no-op function of the same name when analytics are disabled to avoid the script errors.

More than just a few errors in the console, this problem was causing the switches on the Connections page to not work. Analytics click handlers on the switches were tossing an exception which blocked the code that handled the switch functionality.