### PR TITLE
Release 3.2.24

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Change Log
 
+## [3.2.24](https://github.com/auth0/wp-auth0/tree/3.2.23) (2017-08-14)
+[Full Changelog](https://github.com/auth0/wp-auth0/compare/3.2.23...3.2.24)
+
+**Changed**
+- More generous JWT leeway [\#332](https://github.com/auth0/wp-auth0/pull/332) ([cocojoe](https://github.com/cocojoe))
+
+**Removed**
+- Remove client_id/secret validation since it is not allowed anymore [\#334](https://github.com/auth0/wp-auth0/pull/334) ([glena](https://github.com/glena))
+
 ## [3.2.23](https://github.com/auth0/wp-auth0/tree/3.2.23) (2017-07-18)
 [Full Changelog](https://github.com/auth0/wp-auth0/compare/3.2.22...3.2.23)
 

--- a/WP_Auth0.php
+++ b/WP_Auth0.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: PLUGIN_NAME
  * Description: PLUGIN_DESCRIPTION
- * Version: 3.2.23
+ * Version: 3.2.24
  * Author: Auth0
  * Author URI: https://auth0.com
  */
@@ -11,7 +11,7 @@ define( 'WPA0_PLUGIN_DIR', trailingslashit( plugin_dir_path( __FILE__ ) ) );
 define( 'WPA0_PLUGIN_URL', trailingslashit( plugin_dir_url( __FILE__ ) ) );
 define( 'WPA0_LANG', 'wp-auth0' );
 define( 'AUTH0_DB_VERSION', 14 );
-define( 'WPA0_VERSION', '3.2.23' );
+define( 'WPA0_VERSION', '3.2.24' );
 
 /**
  * Main plugin class

--- a/lib/admin/WP_Auth0_Admin_Basic.php
+++ b/lib/admin/WP_Auth0_Admin_Basic.php
@@ -195,18 +195,7 @@ class WP_Auth0_Admin_Basic extends WP_Auth0_Admin_Generic {
 			$this->add_validation_error( $error );
 			$completeBasicData = false;
 		}
-
-		if ( $completeBasicData ) {
-			$response = WP_Auth0_Api_Client::get_token( $input['domain'], $input['client_id'], $input['client_secret'] );
-
-			if ( $response instanceof WP_Error ) {
-				$error = $response->get_error_message();
-				$this->add_validation_error( $error );
-			} elseif ( 200 !== (int) $response['response']['code'] ) {
-				$error = __( 'The client id or secret is not valid.', WPA0_LANG );
-				$this->add_validation_error( $error );
-			}
-		}
+		
 		return $input;
 	}
 

--- a/lib/php-jwt/Authentication/JWT.php
+++ b/lib/php-jwt/Authentication/JWT.php
@@ -80,7 +80,7 @@ class JWT
 
             // Check if the nbf if it is defined. This is the time that the
             // token can actually be used. If it's not yet that time, abort. Small leeway for clock skew.
-            if (isset($payload->nbf) && $payload->nbf > time() + 2) {
+            if (isset($payload->nbf) && $payload->nbf > time() + 15) {
                 throw new BeforeValidException(
                     'Cannot handle token prior to (nbf) ' . date(DateTime::ISO8601, $payload->nbf)
                 );
@@ -89,14 +89,14 @@ class JWT
             // Check that this token has been created before 'now'. This prevents
             // using tokens that have been created for later use (and haven't
             // correctly used the nbf claim). Small leeway for clock skew.
-            if (isset($payload->iat) && $payload->iat > time() + 2) {
+            if (isset($payload->iat) && $payload->iat > time() + 15) {
                 throw new BeforeValidException(
                     'Cannot handle token prior to (iat) ' . date(DateTime::ISO8601, $payload->iat)
                 );
             }
 
             // Check if this token has expired. Small leeway for clock skew.
-            if (isset($payload->exp) && time() >= $payload->exp + 2) {
+            if (isset($payload->exp) && time() >= $payload->exp + 15) {
                 throw new ExpiredException('Expired token');
             }
         }


### PR DESCRIPTION
**Changed**
- More generous JWT leeway [\#332](https://github.com/auth0/wp-auth0/pull/332) ([cocojoe](https://github.com/cocojoe))

**Removed**
- Remove client_id/secret validation since it is not allowed anymore [\#334](https://github.com/auth0/wp-auth0/pull/334) ([glena](https://github.com/glena))