### PR TITLE
Fix login URL

### DIFF
--- a/lib/WP_Auth0_Api_Client.php
+++ b/lib/WP_Auth0_Api_Client.php
@@ -222,10 +222,10 @@ class WP_Auth0_Api_Client {
 						'name' => $name,
 						'callbacks' => array(
 							home_url( '/index.php?auth0=1' ),
-							home_url( '/wp-login.php' )
+							wp_login_url()
 						),
 						"allowed_origins"=>array(
-							home_url( '/wp-login.php' ),
+							wp_login_url(),
 							admin_url( '/admin.php?page=wpa0-setup&step=2&profile=social' )
 						),
 						"allowed_logout_urls" => array(

--- a/lib/WP_Auth0_Lock10_Options.php
+++ b/lib/WP_Auth0_Lock10_Options.php
@@ -39,7 +39,7 @@ class WP_Auth0_Lock10_Options {
   }
 
   public function get_implicit_callback_url() {
-    return home_url( '/wp-login.php' );
+    return wp_login_url();
   }
 
   public function get_sso() {

--- a/lib/WP_Auth0_Lock_Options.php
+++ b/lib/WP_Auth0_Lock_Options.php
@@ -39,7 +39,7 @@ class WP_Auth0_Lock_Options {
   }
 
 	public function get_implicit_callback_url() {
-		return home_url( '/wp-login.php' );
+		return wp_login_url();
 	}
 
 	public function get_sso() {


### PR DESCRIPTION
Replaces usages of `home_url( '/wp-login.php' )` with `wp_login_url()`.

This generates the correct redirect URL if WordPress is not installed in the root directory: https://codex.wordpress.org/Giving_WordPress_Its_Own_Directory