### PR TITLE
Fix callback URL used with wordpress as headless CMS

### DIFF
--- a/lib/WP_Auth0_Lock10_Options.php
+++ b/lib/WP_Auth0_Lock10_Options.php
@@ -35,11 +35,11 @@ class WP_Auth0_Lock10_Options {
   public function get_code_callback_url() {
     $protocol = $this->_get_boolean( $this->wp_options->get( 'force_https_callback' ) ) ? 'https' : null;
 
-    return home_url( '/index.php?auth0=1', $protocol );
+    return site_url( '/index.php?auth0=1', $protocol );
   }
 
   public function get_implicit_callback_url() {
-    return home_url( '/wp-login.php' );
+    return site_url( '/wp-login.php' );
   }
 
   public function get_sso() {


### PR DESCRIPTION
- whenever site_url != home_url
- resolves #341 