### PR TITLE
When activating using wp-cli the plugin should not redirect

### DIFF
--- a/WP_Auth0.php
+++ b/WP_Auth0.php
@@ -171,7 +171,7 @@ class WP_Auth0 {
 
 	function on_activate_redirect( $plugin ) {
 
-		if ( $plugin == plugin_basename( __FILE__ ) ) {
+		if ( !defined( 'WP_CLI' ) && $plugin == plugin_basename( __FILE__ ) ) {
 
 			$this->router->setup_rewrites();
 			flush_rewrite_rules();


### PR DESCRIPTION
When activating using [wp-cli](http://wp-cli.org/) the plugin should not redirect.

See https://github.com/wp-cli/wp-cli/blob/16bb1aac5bc188b42c0037a255f60efdf1f0db93/php/wp-cli.php#L4

This change fixes the following warning on plugin activation:

````
Warning: Some code is trying to do a URL redirect. Backtrace:
#0  WP_CLI\Utils\wp_redirect_handler(http:/wp-admin/admin.php?page=wpa0) called at [/var/www/html/wp-includes/class-wp-hook.php:300]
#1  WP_Hook->apply_filters(http:/wp-admin/admin.php?page=wpa0, Array ([0] => http:/wp-admin/admin.php?page=wpa0,[1] => 302)) called at [/var/www/html/wp-includes/plugin.php:203]
#2  apply_filters(wp_redirect, http:/wp-admin/admin.php?page=wpa0, 302) called at [/var/www/html/wp-includes/pluggable.php:1190]
#3  wp_redirect(http:/wp-admin/admin.php?page=wpa0) called at [/var/www/html/wp-content/plugins/auth0/WP_Auth0.php:188]
#4  WP_Auth0->on_activate_redirect(auth0/WP_Auth0.php) called at [/var/www/html/wp-includes/class-wp-hook.php:300]
#5  WP_Hook->apply_filters(, Array ([0] => auth0/WP_Auth0.php,[1] => )) called at [/var/www/html/wp-includes/class-wp-hook.php:323]
#6  WP_Hook->do_action(Array ([0] => auth0/WP_Auth0.php,[1] => )) called at [/var/www/html/wp-includes/plugin.php:453]
#7  do_action(activated_plugin, auth0/WP_Auth0.php, ) called at [/var/www/html/wp-admin/includes/plugin.php:618]
#8  activate_plugin(auth0/WP_Auth0.php, , ) called at [phar:///usr/local/bin/wp/vendor/wp-cli/extension-command/src/Plugin_Command.php:284]
#9  Plugin_Command->activate(Array ([0] => auth0), Array ())
#10 call_user_func(Array ([0] => Plugin_Command Object ([ * item_type] => plugin,[ * upgrade_refresh] => wp_update_plugins,[ * upgrade_transient] => update_plugins,[ * obj_fields] => Array ([0] => name,[1] => status,[2] => update,[3] => version),[ * chained_command] => ,[ WP_CLI\CommandWithUpgrade map] => Array ([short] => Array ([inactive] => I,[active] => A,[active-network] => N,[must-use] => M,[parent] => P),[long] => Array ([inactive] => Inactive,[active] => Active,[active-network] => Network Active,[must-use] => Must Use,[parent] => Parent)),[fetcher] => WP_CLI\Fetchers\Plugin Object ([ * msg] => The '%s' plugin could not be found.)),[1] => activate), Array ([0] => auth0), Array ()) called at [phar:///usr/local/bin/wp/php/WP_CLI/Dispatcher/CommandFactory.php:81]
#11 WP_CLI\Dispatcher\CommandFactory::WP_CLI\Dispatcher\{closure}(Array ([0] => auth0), Array ())
#12 call_user_func(Closure Object (), Array ([0] => auth0), Array ()) called at [phar:///usr/local/bin/wp/php/WP_CLI/Dispatcher/Subcommand.php:401]
#13 WP_CLI\Dispatcher\Subcommand->invoke(Array ([0] => auth0), Array (), Array ()) called at [phar:///usr/local/bin/wp/php/WP_CLI/Runner.php:323]
#14 WP_CLI\Runner->run_command(Array ([0] => plugin,[1] => activate,[2] => auth0), Array ()) called at [phar:///usr/local/bin/wp/php/WP_CLI/Runner.php:330]
#15 WP_CLI\Runner->_run_command() called at [phar:///usr/local/bin/wp/php/WP_CLI/Runner.php:985]
#16 WP_CLI\Runner->start() called at [phar:///usr/local/bin/wp/php/WP_CLI/Bootstrap/LaunchRunner.php:23]
#17 WP_CLI\Bootstrap\LaunchRunner->process(WP_CLI\Bootstrap\BootstrapState Object ([ WP_CLI\Bootstrap\BootstrapState state] => Array ())) called at [phar:///usr/local/bin/wp/php/bootstrap.php:75]
#18 WP_CLI\bootstrap() called at [phar:///usr/local/bin/wp/php/wp-cli.php:23]
#19 include(phar:///usr/local/bin/wp/php/wp-cli.php) called at [phar:///usr/local/bin/wp/php/boot-phar.php:8]
#20 include(phar:///usr/local/bin/wp/php/boot-phar.php) called at [/usr/local/bin/wp:4]
````