### PR TITLE
Release 3.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Change Log
 
+## [3.3.2](https://github.com/auth0/wp-auth0/tree/3.3.2) (2017-10-05)
+[Full Changelog](https://github.com/auth0/wp-auth0/compare/3.3.2...3.2.24)
+
+**Added**
+- Added translation support for a few user-facing exception messages [\#312](https://github.com/auth0/wp-auth0/pull/312) ([idpaterson](https://github.com/idpaterson))
+
+**Changed**
+- Use literal 'wp-auth0' rather than WPA0_LANG constant [\#311](https://github.com/auth0/wp-auth0/pull/311) ([idpaterson](https://github.com/idpaterson))
+
+**Fixed**
+- Properly handle auto login configuration + custom parse url hash in login page ([glena](https://github.com/glena))
+- Implicit mode in auto login ([glena](https://github.com/glena))
+
+**Notes**
+There is a jump in version due to a release issue which required bumping the version a few times. 
+
 ## [3.2.24](https://github.com/auth0/wp-auth0/tree/3.2.23) (2017-08-14)
 [Full Changelog](https://github.com/auth0/wp-auth0/compare/3.2.23...3.2.24)
 

--- a/WP_Auth0.php
+++ b/WP_Auth0.php
@@ -9,7 +9,7 @@
 define( 'WPA0_PLUGIN_FILE', __FILE__ );
 define( 'WPA0_PLUGIN_DIR', trailingslashit( plugin_dir_path( __FILE__ ) ) );
 define( 'WPA0_PLUGIN_URL', trailingslashit( plugin_dir_url( __FILE__ ) ) );
-define( 'WPA0_LANG', 'wp-auth0' );
+define( 'WPA0_LANG', 'wp-auth0' ); // deprecated; do not use for translations
 define( 'AUTH0_DB_VERSION', 14 );
 define( 'WPA0_VERSION', '3.3.1' );
 

--- a/WP_Auth0.php
+++ b/WP_Auth0.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: PLUGIN_NAME
  * Description: PLUGIN_DESCRIPTION
- * Version: 3.3.1
+ * Version: 3.3.2
  * Author: Auth0
  * Author URI: https://auth0.com
  */
@@ -11,7 +11,7 @@ define( 'WPA0_PLUGIN_DIR', trailingslashit( plugin_dir_path( __FILE__ ) ) );
 define( 'WPA0_PLUGIN_URL', trailingslashit( plugin_dir_url( __FILE__ ) ) );
 define( 'WPA0_LANG', 'wp-auth0' ); // deprecated; do not use for translations
 define( 'AUTH0_DB_VERSION', 14 );
-define( 'WPA0_VERSION', '3.3.1' );
+define( 'WPA0_VERSION', '3.3.2' );
 
 /**
  * Main plugin class

--- a/lib/WP_Auth0_Api_Operations.php
+++ b/lib/WP_Auth0_Api_Operations.php
@@ -179,7 +179,7 @@ class WP_Auth0_Api_Operations {
 			$connections = WP_Auth0_Api_Client::search_connection( $domain, $app_token, $strategy );
 
 			// if ( ! $connections ) {
-			//  $error = __( 'There was an error searching your active social connections.', WPA0_LANG );
+			//  $error = __( 'There was an error searching your active social connections.', 'wp-auth0' );
 			//  $this->add_validation_error( $error );
 			//
 			//  $input[$main_key] = 0;
@@ -229,7 +229,7 @@ class WP_Auth0_Api_Operations {
 					$response = WP_Auth0_Api_Client::update_connection($domain, $app_token, $selected_connection->id, $data);
 
 					if ( false === $response ) {
-						$error = __( 'There was an error updating your social connection', WPA0_LANG );
+						$error = __( 'There was an error updating your social connection', 'wp-auth0' );
 						throw new Exception( $error );
 
 						$input[$main_key] = 0;
@@ -256,7 +256,7 @@ class WP_Auth0_Api_Operations {
 					$response = WP_Auth0_Api_Client::update_connection($domain, $app_token, $selected_connection->id, $data);
 
 					if ( false === $response ) {
-						$error = __( 'There was an error updating your social connection', WPA0_LANG );
+						$error = __( 'There was an error updating your social connection', 'wp-auth0' );
 						throw new Exception( $error );
 
 						$input[$main_key] = 0;
@@ -277,7 +277,7 @@ class WP_Auth0_Api_Operations {
 					);
 
 					if ( false === WP_Auth0_Api_Client::create_connection($domain, $app_token, $data) ) {
-						$error = __( 'There was an error creating your social connection', WPA0_LANG );
+						$error = __( 'There was an error creating your social connection', 'wp-auth0' );
 						throw new Exception( $error );
 
 						$input[$main_key] = 0;
@@ -297,7 +297,7 @@ class WP_Auth0_Api_Operations {
 					}
 
 					if ( false === $a = WP_Auth0_Api_Client::update_connection($domain, $app_token, $selected_connection->id, $data) ) {
-						$error = __( 'There was an error disabling your social connection for this app.', WPA0_LANG );
+						$error = __( 'There was an error disabling your social connection for this app.', 'wp-auth0' );
 						throw new Exception( $error );
 						$input[$main_key] = 1;
 					}
@@ -319,7 +319,7 @@ class WP_Auth0_Api_Operations {
 			$rule = WP_Auth0_Api_Client::create_rule( $domain, $app_token, $rule_name, $rule_script );
 
 			if ( $rule === false ) {
-				$error = __( 'There was an error creating the Auth0 rule. You can do it manually from your Auth0 dashboard.', WPA0_LANG );
+				$error = __( 'There was an error creating the Auth0 rule. You can do it manually from your Auth0 dashboard.', 'wp-auth0' );
 				throw new Exception( $error );
 			} else {
 				return $rule->id;
@@ -327,7 +327,7 @@ class WP_Auth0_Api_Operations {
 		}
 		else {
 			if ( false === WP_Auth0_Api_Client::delete_rule($domain, $app_token, $rule_id) ) {
-				$error = __( 'There was an error deleting the Auth0 rule. You can do it manually from your Auth0 dashboard.', WPA0_LANG );
+				$error = __( 'There was an error deleting the Auth0 rule. You can do it manually from your Auth0 dashboard.', 'wp-auth0' );
 				throw new Exception( $error );
 			}
 			return null;

--- a/lib/WP_Auth0_EditProfile.php
+++ b/lib/WP_Auth0_EditProfile.php
@@ -38,7 +38,7 @@ class WP_Auth0_EditProfile {
 		$auth0_repeat_password = isset( $_POST['auth0_repeat_password'] ) ? $_POST['auth0_repeat_password'] : null;
 
 		if ( $auth0_password != $auth0_repeat_password ) {
-			$errors->add( 'auth0_password', __( '<strong>ERROR</strong>: The password does not match' ), array( 'form-field' => 'auth0_password' ) );
+			$errors->add( 'auth0_password', __( '<strong>ERROR</strong>: The password does not match', 'wp-auth0' ), array( 'form-field' => 'auth0_password' ) );
 		}
 	}
 
@@ -296,17 +296,17 @@ class WP_Auth0_EditProfile {
 			}
 
 			if ( $connection === null ) {
-				$errors->add( 'user_email', __( "<strong>ERROR</strong>: You can't change your email if you are using a social connection." ), array( 'form-field' => 'email' ) );
+				$errors->add( 'user_email', __( "<strong>ERROR</strong>: You can't change your email if you are using a social connection.", "wp-auth0" ), array( 'form-field' => 'email' ) );
 				return false;
 			}
 
 			if ( ! is_email( $_POST['email'] ) ) {
-				$errors->add( 'user_email', __( "<strong>ERROR</strong>: The email address isn&#8217;t correct." ), array( 'form-field' => 'email' ) );
+				$errors->add( 'user_email', __( "<strong>ERROR</strong>: The email address isn&#8217;t correct.", "wp-auth0" ), array( 'form-field' => 'email' ) );
 				return false;
 			}
 
 			if ( $wpdb->get_var( $wpdb->prepare( "SELECT user_email FROM {$wpdb->users} WHERE user_email=%s", $_POST['email'] ) ) ) {
-				$errors->add( 'user_email', __( "<strong>ERROR</strong>: The email address is already used." ), array( 'form-field' => 'email' ) );
+				$errors->add( 'user_email', __( "<strong>ERROR</strong>: The email address is already used.", "wp-auth0" ), array( 'form-field' => 'email' ) );
 				delete_option( $current_user->ID . '_new_email' );
 				return;
 			}

--- a/lib/WP_Auth0_Embed_Widget.php
+++ b/lib/WP_Auth0_Embed_Widget.php
@@ -32,8 +32,8 @@ class WP_Auth0_Embed_Widget extends WP_Widget {
 		wp_enqueue_script( 'wpa0_admin', WPA0_PLUGIN_URL . 'assets/js/admin.js', array( 'jquery' ) );
 		wp_enqueue_style( 'media' );
 		wp_localize_script( 'wpa0_admin', 'wpa0', array(
-				'media_title' => __( 'Choose your icon', WPA0_LANG ),
-				'media_button' => __( 'Choose icon', WPA0_LANG ),
+				'media_title' => __( 'Choose your icon', 'wp-auth0' ),
+				'media_button' => __( 'Choose icon', 'wp-auth0' ),
 			) );
 		require WPA0_PLUGIN_DIR . 'templates/a0-widget-setup-form.php';
 	}

--- a/lib/WP_Auth0_Metrics.php
+++ b/lib/WP_Auth0_Metrics.php
@@ -66,6 +66,15 @@ class WP_Auth0_Metrics {
       </script>
     <?php
 		}
+		else {
+?>
+      <script>
+        function metricsTrack() {
+          // Metrics are disabled
+        }
+      </script>
+    <?php
+		}
 	}
 
 }

--- a/lib/WP_Auth0_Settings_Section.php
+++ b/lib/WP_Auth0_Settings_Section.php
@@ -43,26 +43,26 @@ class WP_Auth0_Settings_Section {
 			$main_menu = 'wpa0-setup';
 		}
 
-		add_menu_page( __( 'Auth0', WPA0_LANG ), __( 'Auth0', WPA0_LANG ), 'manage_options', $main_menu,
+		add_menu_page( __( 'Auth0', 'wp-auth0' ), __( 'Auth0', 'wp-auth0' ), 'manage_options', $main_menu,
 			( $show_initial_setup ? array( $this->initial_setup, 'render_setup_page' ) : array( $this->auth0_admin, 'render_settings_page' ) ), WP_Auth0::get_plugin_dir_url() . 'assets/img/a0icon.png', 85.55 );
 
 		if ( $show_initial_setup ) {
-			add_submenu_page( $main_menu, __( 'Auth0 for WordPress - Setup Wizard', WPA0_LANG ), __( 'Setup Wizard', WPA0_LANG ), 'manage_options', 'wpa0-setup', array( $this->initial_setup, 'render_setup_page' ) );
-			add_submenu_page( $main_menu, __( 'Settings', WPA0_LANG ), __( 'Settings', WPA0_LANG ), 'manage_options', 'wpa0', array( $this->auth0_admin, 'render_settings_page' ) );
+			add_submenu_page( $main_menu, __( 'Auth0 for WordPress - Setup Wizard', 'wp-auth0' ), __( 'Setup Wizard', 'wp-auth0' ), 'manage_options', 'wpa0-setup', array( $this->initial_setup, 'render_setup_page' ) );
+			add_submenu_page( $main_menu, __( 'Settings', 'wp-auth0' ), __( 'Settings', 'wp-auth0' ), 'manage_options', 'wpa0', array( $this->auth0_admin, 'render_settings_page' ) );
 		} else {
-			add_submenu_page( $main_menu, __( 'Settings', WPA0_LANG ), __( 'Settings', WPA0_LANG ), 'manage_options', 'wpa0', array( $this->auth0_admin, 'render_settings_page' ) );
+			add_submenu_page( $main_menu, __( 'Settings', 'wp-auth0' ), __( 'Settings', 'wp-auth0' ), 'manage_options', 'wpa0', array( $this->auth0_admin, 'render_settings_page' ) );
 
-			add_submenu_page( $main_menu, __( 'Help', WPA0_LANG ), __( 'Help', WPA0_LANG ), 'manage_options', 'wpa0-help', array( $this, 'redirect_to_help' ) );
+			add_submenu_page( $main_menu, __( 'Help', 'wp-auth0' ), __( 'Help', 'wp-auth0' ), 'manage_options', 'wpa0-help', array( $this, 'redirect_to_help' ) );
 
-			add_submenu_page( $main_menu, __( 'Auth0 for WordPress - Setup Wizard', WPA0_LANG ), __( 'Setup Wizard', WPA0_LANG ), 'manage_options', 'wpa0-setup', array( $this->initial_setup, 'render_setup_page' ) );
+			add_submenu_page( $main_menu, __( 'Auth0 for WordPress - Setup Wizard', 'wp-auth0' ), __( 'Setup Wizard', 'wp-auth0' ), 'manage_options', 'wpa0-setup', array( $this->initial_setup, 'render_setup_page' ) );
 		}
 
-		add_submenu_page( $main_menu, __( 'Export Users Data', WPA0_LANG ), __( 'Export Users Data', WPA0_LANG ), 'manage_options', 'wpa0-users-export', array( $this->users_exporter, 'render_export_users' ) );
-		add_submenu_page( $main_menu, __( 'Error Log', WPA0_LANG ), __( 'Error Log', WPA0_LANG ), 'manage_options', 'wpa0-errors', array( $this->error_log, 'render_settings_page' ) );
-		add_submenu_page( $main_menu, __( 'Import-Export settings', WPA0_LANG ), __( 'Import-Export settings', WPA0_LANG ), 'manage_options', 'wpa0-import-settings', array( $this->import_settings, 'render_import_settings_page' ) );
+		add_submenu_page( $main_menu, __( 'Export Users Data', 'wp-auth0' ), __( 'Export Users Data', 'wp-auth0' ), 'manage_options', 'wpa0-users-export', array( $this->users_exporter, 'render_export_users' ) );
+		add_submenu_page( $main_menu, __( 'Error Log', 'wp-auth0' ), __( 'Error Log', 'wp-auth0' ), 'manage_options', 'wpa0-errors', array( $this->error_log, 'render_settings_page' ) );
+		add_submenu_page( $main_menu, __( 'Import-Export settings', 'wp-auth0' ), __( 'Import-Export settings', 'wp-auth0' ), 'manage_options', 'wpa0-import-settings', array( $this->import_settings, 'render_import_settings_page' ) );
 
 		if ( WP_Auth0_Configure_JWTAUTH::is_jwt_auth_enabled() ) {
-			add_submenu_page( $main_menu, __( 'JWT Auth integration', WPA0_LANG ), __( 'JWT Auth integration', WPA0_LANG ), 'manage_options', 'wpa0-jwt-auth', array( $this->configure_jwt_auth, 'render_settings_page' ) );
+			add_submenu_page( $main_menu, __( 'JWT Auth integration', 'wp-auth0' ), __( 'JWT Auth integration', 'wp-auth0' ), 'manage_options', 'wpa0-jwt-auth', array( $this->configure_jwt_auth, 'render_settings_page' ) );
 		}
 	}
 

--- a/lib/WP_Auth0_UsersRepo.php
+++ b/lib/WP_Auth0_UsersRepo.php
@@ -117,7 +117,9 @@ class WP_Auth0_UsersRepo {
 			$auth0_id = get_user_meta( $joinUser->ID, $wpdb->prefix.'auth0_id', true);
 
 			if ($auth0_id) { // if it has an a0 id, we cant join it
-				throw new WP_Auth0_CouldNotCreateUserException('There is a user with the same email');
+				$msg = __( 'There is a user with the same email', 'wp-auth0' );
+				
+				throw new WP_Auth0_CouldNotCreateUserException( $msg );
 			}
 		}
 
@@ -142,7 +144,9 @@ class WP_Auth0_UsersRepo {
 			if ( is_wp_error( $user_id ) ) {
 				throw new WP_Auth0_CouldNotCreateUserException( $user_id->get_error_message() );
 			}elseif ( $user_id == -2 ) {
-				throw new WP_Auth0_CouldNotCreateUserException( 'Could not create user. The registration process were rejected. Please verify that your account is whitelisted for this system. Please contact your site’s administrator.' );
+				$msg = __( 'Could not create user. The registration process were rejected. Please verify that your account is whitelisted for this system. Please contact your site’s administrator.', 'wp-auth0' );
+				
+				throw new WP_Auth0_CouldNotCreateUserException( $msg );
 			}elseif ( $user_id <0 ) {
 				throw new WP_Auth0_CouldNotCreateUserException();
 			}

--- a/lib/admin/WP_Auth0_Admin.php
+++ b/lib/admin/WP_Auth0_Admin.php
@@ -89,8 +89,8 @@ class WP_Auth0_Admin {
 		wp_enqueue_style( 'media' );
 
 		wp_localize_script( 'wpa0_admin', 'wpa0', array(
-				'media_title' => __( 'Choose your icon', WPA0_LANG ),
-				'media_button' => __( 'Choose icon', WPA0_LANG ),
+				'media_title' => __( 'Choose your icon', 'wp-auth0' ),
+				'media_button' => __( 'Choose icon', 'wp-auth0' ),
 			) );
 	}
 
@@ -106,9 +106,9 @@ class WP_Auth0_Admin {
 		<div id="message" class="error">
 			<p>
 				<strong>
-					<?php echo __( 'The current user is not authorized to manage the Auth0 account. You must be both a WordPress site administrator and a user known to Auth0 to control Auth0 from this settings page. Please see the', WPA0_LANG ); ?>
-					<a href="https://auth0.com/docs/cms/wordpress/troubleshoot#the-settings-page-shows-me-this-warning-the-current-user-is-not-authorized-to-manage-the-auth0-account-"><?php echo __( 'documentation', WPA0_LANG ); ?></a>
-					<?php echo __( 'for more information.', WPA0_LANG ); ?>
+					<?php echo __( 'The current user is not authorized to manage the Auth0 account. You must be both a WordPress site administrator and a user known to Auth0 to control Auth0 from this settings page. Please see the', 'wp-auth0' ); ?>
+					<a href="https://auth0.com/docs/cms/wordpress/troubleshoot#the-settings-page-shows-me-this-warning-the-current-user-is-not-authorized-to-manage-the-auth0-account-"><?php echo __( 'documentation', 'wp-auth0' ); ?></a>
+					<?php echo __( 'for more information.', 'wp-auth0' ); ?>
 				</strong>
 			</p>
 		</div>
@@ -164,9 +164,9 @@ class WP_Auth0_Admin {
 		<div id="message" class="updated">
 			<p>
 				<strong>
-					<?php echo __( 'In order to use this plugin, you need to first', WPA0_LANG ); ?>
-					<a target="_blank" href="https://manage.auth0.com/#/applications"><?php echo __( 'create an application', WPA0_LANG ); ?></a>
-					<?php echo __( ' on Auth0 and copy the information here.', WPA0_LANG ); ?>
+					<?php echo __( 'In order to use this plugin, you need to first', 'wp-auth0' ); ?>
+					<a target="_blank" href="https://manage.auth0.com/#/applications"><?php echo __( 'create an application', 'wp-auth0' ); ?></a>
+					<?php echo __( ' on Auth0 and copy the information here.', 'wp-auth0' ); ?>
 				</strong>
 			</p>
 		</div>

--- a/lib/admin/WP_Auth0_Admin_Advanced.php
+++ b/lib/admin/WP_Auth0_Admin_Advanced.php
@@ -95,8 +95,8 @@ class WP_Auth0_Admin_Advanced extends WP_Auth0_Admin_Generic {
 
       <div class="subelement">
         <span class="description">
-          <?php echo __( 'For more info about the password policies check ', WPA0_LANG ); ?>
-          <a target="_blank" href="https://auth0.com/docs/password-strength"><?php echo __( 'HERE', WPA0_LANG ); ?></a>
+          <?php echo __( 'For more info about the password policies check ', 'wp-auth0' ); ?>
+          <a target="_blank" href="https://auth0.com/docs/password-strength"><?php echo __( 'HERE', 'wp-auth0' ); ?></a>
         </span>
       </div>
     <?php
@@ -108,7 +108,7 @@ class WP_Auth0_Admin_Advanced extends WP_Auth0_Admin_Generic {
     echo $this->render_a0_switch( "wpa0_jwt_auth_integration", "jwt_auth_integration", 1, 1 == $v );
 ?>
     <div class="subelement">
-      <span class="description"><?php echo __( 'This will enable the JWT Auth\'s Users Repository override.', WPA0_LANG ); ?></span>
+      <span class="description"><?php echo __( 'This will enable the JWT Auth\'s Users Repository override.', 'wp-auth0' ); ?></span>
     </div>
   <?php
   }
@@ -118,7 +118,7 @@ class WP_Auth0_Admin_Advanced extends WP_Auth0_Admin_Generic {
 ?>
       <input type="text" name="<?php echo $this->options->get_options_name(); ?>[default_login_redirection]" id="wpa0_default_login_redirection" value="<?php echo esc_attr( $v ); ?>"/>
       <div class="subelement">
-        <span class="description"><?php echo __( 'This is the URL that all users will be redirected to by default after login.', WPA0_LANG ); ?></span>
+        <span class="description"><?php echo __( 'This is the URL that all users will be redirected to by default after login.', 'wp-auth0' ); ?></span>
       </div>
     <?php
   }
@@ -130,9 +130,9 @@ class WP_Auth0_Admin_Advanced extends WP_Auth0_Admin_Generic {
     <textarea name="<?php echo $this->options->get_options_name(); ?>[extra_conf]" id="wpa0_extra_conf"><?php echo esc_attr( $v ); ?></textarea>
     <div class="subelement">
       <span class="description">
-        <?php echo __( 'This field is the Json that describes the options to call Lock with. It\'ll override any other option set here. See all the possible options ', WPA0_LANG ); ?>
-        <a target="_blank" href="https://auth0.com/docs/libraries/lock/customization"><?php echo __( 'here', WPA0_LANG ); ?></a>
-        <?php echo __( '(For example: {"disableResetAction": true }) ', WPA0_LANG ); ?>
+        <?php echo __( 'This field is the Json that describes the options to call Lock with. It\'ll override any other option set here. See all the possible options ', 'wp-auth0' ); ?>
+        <a target="_blank" href="https://auth0.com/docs/libraries/lock/customization"><?php echo __( 'here', 'wp-auth0' ); ?></a>
+        <?php echo __( '(For example: {"disableResetAction": true }) ', 'wp-auth0' ); ?>
       </span>
     </div>
     <?php
@@ -145,8 +145,8 @@ class WP_Auth0_Admin_Advanced extends WP_Auth0_Admin_Generic {
     <textarea name="<?php echo $this->options->get_options_name(); ?>[custom_signup_fields]" id="wpa0_custom_signup_fields"><?php echo esc_attr( $v ); ?></textarea>
     <div class="subelement">
       <span class="description">
-        <?php echo __( 'This field is the Json that describes the custom signup fields for lock. It should be a valida json and allows the use of functions (for validation). More info', WPA0_LANG ); ?>
-        <a target="_blank" href="https://auth0.com/docs/libraries/lock/v10/new-features#custom-sign-up-fields"><?php echo __( 'here', WPA0_LANG ); ?></a>
+        <?php echo __( 'This field is the Json that describes the custom signup fields for lock. It should be a valida json and allows the use of functions (for validation). More info', 'wp-auth0' ); ?>
+        <a target="_blank" href="https://auth0.com/docs/libraries/lock/v10/new-features#custom-sign-up-fields"><?php echo __( 'here', 'wp-auth0' ); ?></a>
 
         <code><pre>[
   {
@@ -174,7 +174,7 @@ class WP_Auth0_Admin_Advanced extends WP_Auth0_Admin_Generic {
     echo $this->render_a0_switch( "wpa0_link_auth0_users", "link_auth0_users", 1, ! empty( $v ) );
 ?>
       <div class="subelement">
-        <span class="description"><?php echo __( 'Links accounts with the same e-mail address. It will only occur if both e-mails are previously verified.', WPA0_LANG ); ?></span>
+        <span class="description"><?php echo __( 'Links accounts with the same e-mail address. It will only occur if both e-mails are previously verified.', 'wp-auth0' ); ?></span>
       </div>
     <?php
   }
@@ -186,7 +186,7 @@ class WP_Auth0_Admin_Advanced extends WP_Auth0_Admin_Generic {
 ?>
 
       <div class="subelement">
-        <span class="description"><?php echo __( 'The plugin will automatically add new users if they do not exist in the WordPress database if the signups are enabled (enabling this setting will enable this behaviour when signups are disabled).', WPA0_LANG ); ?></span>
+        <span class="description"><?php echo __( 'The plugin will automatically add new users if they do not exist in the WordPress database if the signups are enabled (enabling this setting will enable this behaviour when signups are disabled).', 'wp-auth0' ); ?></span>
         </div>
     <?php
   }
@@ -198,7 +198,7 @@ class WP_Auth0_Admin_Advanced extends WP_Auth0_Admin_Generic {
 ?>
 
       <div class="subelement">
-        <span class="description"><?php echo __( 'This option will replace the login widget with Lock Passwordless (Username and password login will not be enabled).', WPA0_LANG ); ?></span>
+        <span class="description"><?php echo __( 'This option will replace the login widget with Lock Passwordless (Username and password login will not be enabled).', 'wp-auth0' ); ?></span>
       </div>
     <?php
   }
@@ -210,7 +210,7 @@ class WP_Auth0_Admin_Advanced extends WP_Auth0_Admin_Generic {
 ?>
 
       <div class="subelement">
-        <span class="description"><?php echo __( 'This option forces the plugin to use HTTPS for the callback URL in those cases where it needs to support mixed HTTP and HTTPS pages. If disabled, it will pick the protocol from the WordPress home URL (configured under Settings > General).', WPA0_LANG ); ?></span>
+        <span class="description"><?php echo __( 'This option forces the plugin to use HTTPS for the callback URL in those cases where it needs to support mixed HTTP and HTTPS pages. If disabled, it will pick the protocol from the WordPress home URL (configured under Settings > General).', 'wp-auth0' ); ?></span>
       </div>
     <?php
   }
@@ -222,7 +222,7 @@ class WP_Auth0_Admin_Advanced extends WP_Auth0_Admin_Generic {
 ?>
 
       <div class="subelement">
-        <span class="description"><?php echo __( 'This option will use the latest version of lock. The lock API has changed on this version and can produce some incompatibilities with CSS or JS customizations you might made.', WPA0_LANG ); ?></span>
+        <span class="description"><?php echo __( 'This option will use the latest version of lock. The lock API has changed on this version and can produce some incompatibilities with CSS or JS customizations you might made.', 'wp-auth0' ); ?></span>
       </div>
     <?php
   }
@@ -234,7 +234,7 @@ class WP_Auth0_Admin_Advanced extends WP_Auth0_Admin_Generic {
 ?>
 
       <div class="subelement">
-        <span class="description"><?php echo __( 'Users session by default lives for two days. Enabling this setting will make the sessions be kept for 14 days.', WPA0_LANG ); ?></span>
+        <span class="description"><?php echo __( 'Users session by default lives for two days. Enabling this setting will make the sessions be kept for 14 days.', 'wp-auth0' ); ?></span>
       </div>
     <?php
   }
@@ -248,16 +248,16 @@ class WP_Auth0_Admin_Advanced extends WP_Auth0_Admin_Generic {
     if ( $v ) {
 ?>
       <div class="subelement">
-        <span class="description"><?php echo __( 'Users migration is enabled. If you disable this setting, it can not be automatically enabled again, it needs to be done manually in the Auth0 dashboard.', WPA0_LANG ); ?></span>
+        <span class="description"><?php echo __( 'Users migration is enabled. If you disable this setting, it can not be automatically enabled again, it needs to be done manually in the Auth0 dashboard.', 'wp-auth0' ); ?></span>
         <br>
-        <span class="description"><?php echo __( 'Security token:', WPA0_LANG ); ?></span>
+        <span class="description"><?php echo __( 'Security token:', 'wp-auth0' ); ?></span>
         <textarea class="code" disabled><?php echo $token; ?></textarea>
       </div>
     <?php
     } else {
 ?>
       <div class="subelement">
-        <span class="description"><?php echo __( 'Users migration is disabled. Enabling it will expose the migration webservices but the connection needs to be updated manually on the Auth0 dashboard. More info about the migration process ', WPA0_LANG ); ?><a target="_blank" href="https://auth0.com/docs/connections/database/migrating">HERE</a>.</span>
+        <span class="description"><?php echo __( 'Users migration is disabled. Enabling it will expose the migration webservices but the connection needs to be updated manually on the Auth0 dashboard. More info about the migration process ', 'wp-auth0' ); ?><a target="_blank" href="https://auth0.com/docs/connections/database/migrating">HERE</a>.</span>
       </div>
     <?php
     }
@@ -273,7 +273,7 @@ class WP_Auth0_Admin_Advanced extends WP_Auth0_Admin_Generic {
 ?>
       <div class="subelement">
         <textarea name="migration_ips_filter"><?php echo $list; ?></textarea>
-        <span class="description"><?php echo __( 'Only requests from this IPs will be allowed to the migration WS.', WPA0_LANG ); ?></span>
+        <span class="description"><?php echo __( 'Only requests from this IPs will be allowed to the migration WS.', 'wp-auth0' ); ?></span>
       </div>
     <?php
 
@@ -286,7 +286,7 @@ class WP_Auth0_Admin_Advanced extends WP_Auth0_Admin_Generic {
 ?>
 
     <div class="subelement">
-      <span class="description"><?php echo __( 'Activate this option to change the login workflow and allow the plugin to work when the server doesn\'t have internet access.', WPA0_LANG ); ?></span>
+      <span class="description"><?php echo __( 'Activate this option to change the login workflow and allow the plugin to work when the server doesn\'t have internet access.', 'wp-auth0' ); ?></span>
     </div>
     <?php
   }
@@ -298,7 +298,7 @@ class WP_Auth0_Admin_Advanced extends WP_Auth0_Admin_Generic {
 ?>
 
     <div class="subelement">
-      <span class="description"><?php echo __( 'Mark this to avoid the login page (you will have to select a single login provider)', WPA0_LANG ); ?></span>
+      <span class="description"><?php echo __( 'Mark this to avoid the login page (you will have to select a single login provider)', 'wp-auth0' ); ?></span>
     </div>
     <?php
   }
@@ -308,7 +308,7 @@ class WP_Auth0_Admin_Advanced extends WP_Auth0_Admin_Generic {
 ?>
     <input type="text" name="<?php echo $this->options->get_options_name(); ?>[auto_login_method]" id="wpa0_auto_login_method" value="<?php echo esc_attr( $v ); ?>"/>
     <div class="subelement">
-      <span class="description"><?php echo __( 'To find the method name, log into Auth0 Dashboard, and navigate to: Connection -> [Connection Type] (eg. Social or Enterprise). Click the "down arrow" to expand the wanted method, and use the value in the "Name"-field. Example: google-oauth2', WPA0_LANG ); ?></span>
+      <span class="description"><?php echo __( 'To find the method name, log into Auth0 Dashboard, and navigate to: Connection -> [Connection Type] (eg. Social or Enterprise). Click the "down arrow" to expand the wanted method, and use the value in the "Name"-field. Example: google-oauth2', 'wp-auth0' ); ?></span>
     </div>
     <?php
   }
@@ -324,7 +324,7 @@ class WP_Auth0_Admin_Advanced extends WP_Auth0_Admin_Generic {
 ?>
     <textarea cols="25" name="<?php echo $this->options->get_options_name(); ?>[ip_ranges]" id="wpa0_ip_ranges"><?php echo esc_textarea( $v ); ?></textarea>
     <div class="subelement">
-      <span class="description"><?php echo __( 'Only one range per line! Range format should be as follows (spaces will be trimmed):', WPA0_LANG ); ?></span>
+      <span class="description"><?php echo __( 'Only one range per line! Range format should be as follows (spaces will be trimmed):', 'wp-auth0' ); ?></span>
       <code>xx.xx.xx.xx - yy.yy.yy.yy</code>
     </div>
     <?php
@@ -361,7 +361,7 @@ class WP_Auth0_Admin_Advanced extends WP_Auth0_Admin_Generic {
 ?>
     <input type="text" name="<?php echo $this->options->get_options_name(); ?>[valid_proxy_ip]" id="wpa0_valid_proxy_ip" value="<?php echo esc_attr( $v ); ?>"/>
     <div class="subelement">
-      <span class="description"><?php echo __( ' If you are using a load balancer or a proxy, you will need to whitelist its IP in order to enable IP checks for logins or migration webservices.', WPA0_LANG ); ?></span>
+      <span class="description"><?php echo __( ' If you are using a load balancer or a proxy, you will need to whitelist its IP in order to enable IP checks for logins or migration webservices.', 'wp-auth0' ); ?></span>
     </div>
     <?php
   }
@@ -376,7 +376,7 @@ class WP_Auth0_Admin_Advanced extends WP_Auth0_Admin_Generic {
       <input type="text" name="<?php echo $this->options->get_options_name(); ?>[wpa0_passwordless_cdn_url]" id="wpa0_passwordless_cdn_url" value="<?php echo esc_attr( $passwordless_cdn_url ); ?>" style="<?php echo $passwordless_enabled ? '' : 'display:none' ?>"/>
 
       <div class="subelement">
-        <span class="description"><?php echo __( 'Point this to the latest widget available in the CDN', WPA0_LANG ); ?></span>
+        <span class="description"><?php echo __( 'Point this to the latest widget available in the CDN', 'wp-auth0' ); ?></span>
       </div>
     <?php
   }
@@ -387,7 +387,7 @@ class WP_Auth0_Admin_Advanced extends WP_Auth0_Admin_Generic {
       <input type="text" name="<?php echo $this->options->get_options_name(); ?>[auth0_server_domain]" id="wpa0_auth0_server_domain" value="<?php echo esc_attr( $v ); ?>" />
 
       <div class="subelement">
-        <span class="description"><?php echo __( 'The Auth0 domain, it is used by the setup wizard to fetch your account information.', WPA0_LANG ); ?></span>
+        <span class="description"><?php echo __( 'The Auth0 domain, it is used by the setup wizard to fetch your account information.', 'wp-auth0' ); ?></span>
       </div>
     <?php
   }
@@ -398,7 +398,7 @@ class WP_Auth0_Admin_Advanced extends WP_Auth0_Admin_Generic {
       <input type="text" name="<?php echo $this->options->get_options_name(); ?>[lock_connections]" id="wpa0_connections" value="<?php echo esc_attr( $v ); ?>" />
 
       <div class="subelement">
-        <span class="description"><?php echo __( 'This is used to select which connections should lock show. It is ignored when empty and is mandatory for passwordless with social mode.', WPA0_LANG ); ?></span>
+        <span class="description"><?php echo __( 'This is used to select which connections should lock show. It is ignored when empty and is mandatory for passwordless with social mode.', 'wp-auth0' ); ?></span>
       </div>
     <?php
   }
@@ -411,7 +411,7 @@ class WP_Auth0_Admin_Advanced extends WP_Auth0_Admin_Generic {
 
       <div class="subelement">
         <span class="description">
-          <?php echo __( 'This plugin tracks anonymous usage data. Click to disable.', WPA0_LANG ); ?>
+          <?php echo __( 'This plugin tracks anonymous usage data. Click to disable.', 'wp-auth0' ); ?>
         </span>
       </div>
     <?php
@@ -423,7 +423,7 @@ class WP_Auth0_Admin_Advanced extends WP_Auth0_Admin_Generic {
     echo $this->render_a0_switch( "wpa0_verified_email", "requires_verified_email", 1, 1 == $v );
 ?>
       <div class="subelement">
-        <span class="description"><?php echo __( 'Mark this if you require the user to have a verified email to login', WPA0_LANG ); ?></span>
+        <span class="description"><?php echo __( 'Mark this if you require the user to have a verified email to login', 'wp-auth0' ); ?></span>
       </div>
     <?php
   }
@@ -464,13 +464,13 @@ class WP_Auth0_Admin_Advanced extends WP_Auth0_Admin_Generic {
     $input['custom_signup_fields'] = trim( $input['custom_signup_fields'] );
 
     if ( $input['passwordless_enabled'] && empty( $input['lock_connections'] ) && strpos( strtolower( $input['passwordless_method'] ), 'social' ) !== false ) {
-      $error = __( "Please complete the list of connections to be used by Lock in social mode.", WPA0_LANG );
+      $error = __( "Please complete the list of connections to be used by Lock in social mode.", "wp-auth0" );
       self::add_validation_error( $error );
     }
 
     if ( trim( $input["extra_conf"] ) != '' ) {
       if ( json_decode( $input["extra_conf"] ) === null ) {
-        $error = __( "The Extra settings parameter should be a valid json object", WPA0_LANG );
+        $error = __( "The Extra settings parameter should be a valid json object", "wp-auth0" );
         self::add_validation_error( $error );
       }
     }
@@ -490,7 +490,7 @@ class WP_Auth0_Admin_Advanced extends WP_Auth0_Admin_Generic {
         $input['migration_token_id'] = $token_id;
 
         // if ($response === false) {
-        $error = __( 'There was an error enabling your custom database. Check how to do it manually ', WPA0_LANG );
+        $error = __( 'There was an error enabling your custom database. Check how to do it manually ', 'wp-auth0' );
         $error .= '<a href="https://manage.auth0.com/#/connections/database">HERE</a>.';
         $this->add_validation_error( $error );
         // }
@@ -518,7 +518,7 @@ class WP_Auth0_Admin_Advanced extends WP_Auth0_Admin_Generic {
         }
 
         if ( $response === false ) {
-          $error = __( 'There was an error disabling your custom database. Check how to do it manually ', WPA0_LANG );
+          $error = __( 'There was an error disabling your custom database. Check how to do it manually ', 'wp-auth0' );
           $error .= '<a href="https://manage.auth0.com/#/connections/database">HERE</a>.';
           $this->add_validation_error( $error );
         }
@@ -588,7 +588,7 @@ class WP_Auth0_Admin_Advanced extends WP_Auth0_Admin_Generic {
       $matching = array_intersect($enabled_connections, $check_if_enabled);
 
       if (array_diff($matching, $check_if_enabled) !== array_diff($check_if_enabled, $matching)) {
-        $error = __( 'The passwordless connection is not enabled. Please go to the Auth0 Dashboard and configure it.', WPA0_LANG );
+        $error = __( 'The passwordless connection is not enabled. Please go to the Auth0 Dashboard and configure it.', 'wp-auth0' );
         $this->add_validation_error( $error );
       }
 
@@ -606,7 +606,7 @@ class WP_Auth0_Admin_Advanced extends WP_Auth0_Admin_Generic {
       if ( strpos( $input['default_login_redirection'], $home_url ) !== 0 ) {
         if ( strpos( $input['default_login_redirection'], 'http' ) === 0 ) {
           $input['default_login_redirection'] = $home_url;
-          $error = __( "The 'Login redirect URL' cannot point to a foreign page.", WPA0_LANG );
+          $error = __( "The 'Login redirect URL' cannot point to a foreign page.", "wp-auth0" );
           $this->add_validation_error( $error );
         }
       }
@@ -614,7 +614,7 @@ class WP_Auth0_Admin_Advanced extends WP_Auth0_Admin_Generic {
       if ( strpos( $input['default_login_redirection'], 'action=logout' ) !== false ) {
         $input['default_login_redirection'] = $home_url;
 
-        $error = __( "The 'Login redirect URL' cannot point to the logout page. ", WPA0_LANG );
+        $error = __( "The 'Login redirect URL' cannot point to the logout page. ", "wp-auth0" );
         $this->add_validation_error( $error );
       }
     }

--- a/lib/admin/WP_Auth0_Admin_Appearance.php
+++ b/lib/admin/WP_Auth0_Admin_Appearance.php
@@ -34,8 +34,8 @@ class WP_Auth0_Admin_Appearance extends WP_Auth0_Admin_Generic {
 ?>
     <div class="subelement">
       <span class="description">
-        <?php echo __( 'Request for SSO data and enable "Last time you signed in with[...]" message.', WPA0_LANG ); ?>
-        <a target="_blank" href="https://auth0.com/docs/libraries/lock/customization#rememberlastlogin-boolean-"><?php echo __( 'More info', WPA0_LANG ); ?></a>
+        <?php echo __( 'Request for SSO data and enable "Last time you signed in with[...]" message.', 'wp-auth0' ); ?>
+        <a target="_blank" href="https://auth0.com/docs/libraries/lock/customization#rememberlastlogin-boolean-"><?php echo __( 'More info', 'wp-auth0' ); ?></a>
       </span>
     </div>
   <?php
@@ -46,7 +46,7 @@ class WP_Auth0_Admin_Appearance extends WP_Auth0_Admin_Generic {
 ?>
       <input type="text" name="<?php echo $this->options->get_options_name(); ?>[form_title]" id="wpa0_form_title" value="<?php echo esc_attr( $v ); ?>"/>
       <div class="subelement">
-        <span class="description"><?php echo __( 'This is the title for the login widget', WPA0_LANG ); ?></span>
+        <span class="description"><?php echo __( 'This is the title for the login widget', 'wp-auth0' ); ?></span>
       </div>
     <?php
 	}
@@ -56,7 +56,7 @@ class WP_Auth0_Admin_Appearance extends WP_Auth0_Admin_Generic {
 ?>
       <input type="text" name="<?php echo $this->options->get_options_name(); ?>[language]" id="wpa0_language" value="<?php echo esc_attr( $v ); ?>" />
       <div class="subelement">
-        <span class="description"><?php echo __( 'This is the widget\'s language param.', WPA0_LANG ); ?><a target="_blank" href="https://github.com/auth0/lock#ui-options"><?php echo __( 'More info', WPA0_LANG ); ?></a></span>
+        <span class="description"><?php echo __( 'This is the widget\'s language param.', 'wp-auth0' ); ?><a target="_blank" href="https://github.com/auth0/lock#ui-options"><?php echo __( 'More info', 'wp-auth0' ); ?></a></span>
       </div>
     <?php
   }
@@ -66,7 +66,7 @@ class WP_Auth0_Admin_Appearance extends WP_Auth0_Admin_Generic {
 ?>
       <input type="text" name="<?php echo $this->options->get_options_name(); ?>[primary_color]" id="wpa0_primary_color" value="<?php echo esc_attr( $v ); ?>" />
       <div class="subelement">
-        <span class="description"><?php echo __( 'The primary color for Lock', WPA0_LANG ); ?></span>
+        <span class="description"><?php echo __( 'The primary color for Lock', 'wp-auth0' ); ?></span>
       </div>
     <?php
   }
@@ -76,7 +76,7 @@ class WP_Auth0_Admin_Appearance extends WP_Auth0_Admin_Generic {
 ?>
       <textarea name="<?php echo $this->options->get_options_name(); ?>[language_dictionary]" id="wpa0_language_dictionary"><?php echo esc_attr( $v ); ?></textarea>
       <div class="subelement">
-        <span class="description"><?php echo __( 'This is the widget\'s languageDictionary param.', WPA0_LANG ); ?><a target="_blank" href="https://github.com/auth0/lock#ui-options"><?php echo __( 'More info', WPA0_LANG ); ?></a></span>
+        <span class="description"><?php echo __( 'This is the widget\'s languageDictionary param.', 'wp-auth0' ); ?><a target="_blank" href="https://github.com/auth0/lock#ui-options"><?php echo __( 'More info', 'wp-auth0' ); ?></a></span>
       </div>
     <?php
   }
@@ -86,7 +86,7 @@ class WP_Auth0_Admin_Appearance extends WP_Auth0_Admin_Generic {
 ?>
       <textarea name="<?php echo $this->options->get_options_name(); ?>[custom_css]" id="wpa0_custom_css"><?php echo esc_attr( $v ); ?></textarea>
       <div class="subelement">
-        <span class="description"><?php echo __( 'This should be a valid CSS to customize the Auth0 login widget. ', WPA0_LANG ); ?><a target="_blank" href="https://github.com/auth0/wp-auth0#can-i-customize-the-login-widget"><?php echo __( 'More info', WPA0_LANG ); ?></a></span>
+        <span class="description"><?php echo __( 'This should be a valid CSS to customize the Auth0 login widget. ', 'wp-auth0' ); ?><a target="_blank" href="https://github.com/auth0/wp-auth0#can-i-customize-the-login-widget"><?php echo __( 'More info', 'wp-auth0' ); ?></a></span>
       </div>
     <?php
 	}
@@ -96,7 +96,7 @@ class WP_Auth0_Admin_Appearance extends WP_Auth0_Admin_Generic {
 ?>
       <textarea name="<?php echo $this->options->get_options_name(); ?>[custom_js]" id="wpa0_custom_js"><?php echo esc_attr( $v ); ?></textarea>
       <div class="subelement">
-        <span class="description"><?php echo __( 'This should be a valid JS to customize the Auth0 login widget to, for example, add custom buttons. ', WPA0_LANG ); ?><a target="_blank" href="https://auth0.com/docs/hrd#option-3-adding-custom-buttons-to-lock"><?php echo __( 'More info', WPA0_LANG ); ?></a></span>
+        <span class="description"><?php echo __( 'This should be a valid JS to customize the Auth0 login widget to, for example, add custom buttons. ', 'wp-auth0' ); ?><a target="_blank" href="https://auth0.com/docs/hrd#option-3-adding-custom-buttons-to-lock"><?php echo __( 'More info', 'wp-auth0' ); ?></a></span>
       </div>
     <?php
 	}
@@ -105,18 +105,18 @@ class WP_Auth0_Admin_Appearance extends WP_Auth0_Admin_Generic {
 		$v = $this->options->get( 'username_style' );
 ?>
       <input type="radio" name="<?php echo $this->options->get_options_name(); ?>[username_style]" id="wpa0_username_style_auto" value="" <?php echo esc_attr( $v ) == '' ? 'checked="true"' : ''; ?> />
-      <label for="wpa0_username_style_auto"><?php echo __( 'Auto', WPA0_LANG ); ?></label>
+      <label for="wpa0_username_style_auto"><?php echo __( 'Auto', 'wp-auth0' ); ?></label>
 
       <input type="radio" name="<?php echo $this->options->get_options_name(); ?>[username_style]" id="wpa0_username_style_email" value="email" <?php echo esc_attr( $v ) == 'email' ? 'checked="true"' : ''; ?> />
-      <label for="wpa0_username_style_email"><?php echo __( 'Email', WPA0_LANG ); ?></label>
+      <label for="wpa0_username_style_email"><?php echo __( 'Email', 'wp-auth0' ); ?></label>
 
       <input type="radio" name="<?php echo $this->options->get_options_name(); ?>[username_style]" id="wpa0_username_style_username" value="username" <?php echo esc_attr( $v ) == 'username' ? 'checked="true"' : ''; ?> />
-      <label for="wpa0_username_style_username"><?php echo __( 'Username', WPA0_LANG ); ?></label>
+      <label for="wpa0_username_style_username"><?php echo __( 'Username', 'wp-auth0' ); ?></label>
 
       <div class="subelement">
         <span class="description">
-          <?php echo __( 'If you want to allow the user to use either email or password, set it to Auto.', WPA0_LANG ); ?>
-          <a target="_blank" href="https://auth0.com/docs/libraries/lock/customization#usernamestyle-string-"><?php echo __( 'More info', WPA0_LANG ); ?></a>
+          <?php echo __( 'If you want to allow the user to use either email or password, set it to Auto.', 'wp-auth0' ); ?>
+          <a target="_blank" href="https://auth0.com/docs/libraries/lock/customization#usernamestyle-string-"><?php echo __( 'More info', 'wp-auth0' ); ?></a>
         </span>
       </div>
     <?php
@@ -136,8 +136,8 @@ class WP_Auth0_Admin_Appearance extends WP_Auth0_Admin_Generic {
 
       <div class="subelement">
         <span class="description">
-          <?php echo __( 'Read more about the gravatar integration ', WPA0_LANG ); ?>
-          <a target="_blank" href="https://auth0.com/docs/libraries/lock/customization#gravatar-boolean-"><?php echo __( 'HERE', WPA0_LANG ); ?></a></span>
+          <?php echo __( 'Read more about the gravatar integration ', 'wp-auth0' ); ?>
+          <a target="_blank" href="https://auth0.com/docs/libraries/lock/customization#gravatar-boolean-"><?php echo __( 'HERE', 'wp-auth0' ); ?></a></span>
       </div>
     <?php
 	}
@@ -146,9 +146,9 @@ class WP_Auth0_Admin_Appearance extends WP_Auth0_Admin_Generic {
 		$v = $this->options->get( 'icon_url' );
 ?>
       <input type="text" name="<?php echo $this->options->get_options_name(); ?>[icon_url]" id="wpa0_icon_url" value="<?php echo esc_attr( $v ); ?>"/>
-      <a target="_blank" href="javascript:void(0);" id="wpa0_choose_icon" class="button-secondary"><?php echo __( 'Choose Icon', WPA0_LANG ); ?></a>
+      <a target="_blank" href="javascript:void(0);" id="wpa0_choose_icon" class="button-secondary"><?php echo __( 'Choose Icon', 'wp-auth0' ); ?></a>
       <div class="subelement">
-        <span class="description"><?php echo __( 'The icon should be 32x32 pixels!', WPA0_LANG ); ?></span>
+        <span class="description"><?php echo __( 'The icon should be 32x32 pixels!', 'wp-auth0' ); ?></span>
       </div>
     <?php
 	}
@@ -173,7 +173,7 @@ class WP_Auth0_Admin_Appearance extends WP_Auth0_Admin_Generic {
 
     if ( trim( $input['language_dictionary'] ) !== '' ) {
       if ( json_decode( $input['language_dictionary'] ) === null ) {
-        $error = __( 'The language dictionary parameter should be a valid json object.', WPA0_LANG );
+        $error = __( 'The language dictionary parameter should be a valid json object.', 'wp-auth0' );
         $this->add_validation_error( $error );
         $input['language'] = $old_options['language'];
       }
@@ -181,7 +181,7 @@ class WP_Auth0_Admin_Appearance extends WP_Auth0_Admin_Generic {
 
 		// if ( trim( $input['extra_conf'] ) !== '' ) {
 		//  if ( json_decode( $input['extra_conf'] ) === null ) {
-		//    $error = __( 'The Extra settings parameter should be a valid json object.', WPA0_LANG );
+		//    $error = __( 'The Extra settings parameter should be a valid json object.', 'wp-auth0' );
 		//    $this->add_validation_error( $error );
 		//  }
 		// }

--- a/lib/admin/WP_Auth0_Admin_Basic.php
+++ b/lib/admin/WP_Auth0_Admin_Basic.php
@@ -31,7 +31,7 @@ class WP_Auth0_Admin_Basic extends WP_Auth0_Admin_Generic {
 ?>
       <input type="text" name="<?php echo $this->options->get_options_name(); ?>[client_id]" id="wpa0_client_id" value="<?php echo esc_attr( $v ); ?>"/>
       <div class="subelement">
-        <span class="description"><?php echo __( 'Application ID, copy from your application\'s settings in the', WPA0_LANG ); ?> <a href="https://manage.auth0.com/#/applications" target="_blank">Auth0 dashboard</a>.</span>
+        <span class="description"><?php echo __( 'Application ID, copy from your application\'s settings in the', 'wp-auth0' ); ?> <a href="https://manage.auth0.com/#/applications" target="_blank">Auth0 dashboard</a>.</span>
       </div>
     <?php
 	}
@@ -45,9 +45,9 @@ class WP_Auth0_Admin_Basic extends WP_Auth0_Admin_Generic {
       <input type="text" name="<?php echo $this->options->get_options_name(); ?>[auth0_app_token]" id="wpa0_auth0_app_token" autocomplete="off" <?php if ( !empty( $v ) ) {?>placeholder="Not visible"<?php } ?> />
       <div class="subelement">
         <span class="description">
-          <?php echo __( 'The token should be generated via the ', WPA0_LANG ); ?>
-          <a href="https://auth0.com/docs/api/v2" target="_blank"><?php echo __( 'token generator', WPA0_LANG ); ?></a>
-          <?php echo __( ' with the following scopes:', WPA0_LANG ); ?>
+          <?php echo __( 'The token should be generated via the ', 'wp-auth0' ); ?>
+          <a href="https://auth0.com/docs/api/v2" target="_blank"><?php echo __( 'token generator', 'wp-auth0' ); ?></a>
+          <?php echo __( ' with the following scopes:', 'wp-auth0' ); ?>
           <i>
           <?php $a = 0; foreach ( $scopes as $resource => $actions ) { $a++;?>
             <b><?php echo $resource ?></b> (<?php echo $actions ?>)<?php
@@ -69,7 +69,7 @@ class WP_Auth0_Admin_Basic extends WP_Auth0_Admin_Generic {
 ?>
       <input type="text" autocomplete="off" name="<?php echo $this->options->get_options_name(); ?>[client_secret]" id="wpa0_client_secret"  <?php if ( !empty( $v ) ) {?>placeholder="Not visible"<?php } ?> />
       <div class="subelement">
-        <span class="description"><?php echo __( 'Application secret, copy from your application\'s settings in the', WPA0_LANG ); ?> <a href="https://manage.auth0.com/#/applications" target="_blank">Auth0 dashboard</a>.</span>
+        <span class="description"><?php echo __( 'Application secret, copy from your application\'s settings in the', 'wp-auth0' ); ?> <a href="https://manage.auth0.com/#/applications" target="_blank">Auth0 dashboard</a>.</span>
       </div>
     <?php
 	}
@@ -81,7 +81,7 @@ class WP_Auth0_Admin_Basic extends WP_Auth0_Admin_Generic {
 	?>
 				<div class="subelement">
 					<span class="description"><?php echo __( 'Enable if your client secret is base64 enabled.  If you are not sure, check your clients page in Auth0.  Displayed below the client secret on that page is the text "The Client Secret is not base64 encoded.
-	" when this is not encoded.', WPA0_LANG ); ?></span>
+	" when this is not encoded.', 'wp-auth0' ); ?></span>
 				</div>
 			<?php
 	}
@@ -91,7 +91,7 @@ class WP_Auth0_Admin_Basic extends WP_Auth0_Admin_Generic {
 ?>
       <input type="text" name="<?php echo $this->options->get_options_name(); ?>[domain]" id="wpa0_domain" value="<?php echo esc_attr( $v ); ?>" />
       <div class="subelement">
-        <span class="description"><?php echo __( 'Your Auth0 domain, you can see it in the', WPA0_LANG ); ?> <a href="https://manage.auth0.com/#/applications" target="_blank">Auth0 dashboard</a><?php echo __( '. Example: foo.auth0.com', WPA0_LANG ); ?></span>
+        <span class="description"><?php echo __( 'Your Auth0 domain, you can see it in the', 'wp-auth0' ); ?> <a href="https://manage.auth0.com/#/applications" target="_blank">Auth0 dashboard</a><?php echo __( '. Example: foo.auth0.com', 'wp-auth0' ); ?></span>
       </div>
     <?php
 	}
@@ -109,17 +109,17 @@ class WP_Auth0_Admin_Basic extends WP_Auth0_Admin_Generic {
 		$allow_signup = $this->options->is_wp_registration_enabled();
 ?>
       <span class="description">
-        <?php echo __( 'Signup will be', WPA0_LANG ); ?>
+        <?php echo __( 'Signup will be', 'wp-auth0' ); ?>
 
         <?php if ( ! $allow_signup ) { ?>
-          <b><?php echo __( 'disabled', WPA0_LANG ); ?></b>
-          <?php echo __( ' because it is enabled by the setting "Allow new registrations" in the Network Admin.', WPA0_LANG ); ?>
+          <b><?php echo __( 'disabled', 'wp-auth0' ); ?></b>
+          <?php echo __( ' because it is enabled by the setting "Allow new registrations" in the Network Admin.', 'wp-auth0' ); ?>
         <?php } else { ?>
-          <b><?php echo __( 'enabled', WPA0_LANG ); ?></b>
-          <?php echo __( ' because it is enabled by the setting "Allow new registrations" in the Network Admin.', WPA0_LANG ); ?>
+          <b><?php echo __( 'enabled', 'wp-auth0' ); ?></b>
+          <?php echo __( ' because it is enabled by the setting "Allow new registrations" in the Network Admin.', 'wp-auth0' ); ?>
         <?php } ?>
 
-        <?php echo __( 'You can manage this setting on <code>Network Admin > Settings > Network Settings > Allow new registrations</code> (you need to set it up to <b>User accounts may be registered</b> or <b>Both sites and user accounts can be registered</b> depending on your preferences).', WPA0_LANG ); ?>
+        <?php echo __( 'You can manage this setting on <code>Network Admin > Settings > Network Settings > Allow new registrations</code> (you need to set it up to <b>User accounts may be registered</b> or <b>Both sites and user accounts can be registered</b> depending on your preferences).', 'wp-auth0' ); ?>
       </span>
 
     <?php
@@ -129,17 +129,17 @@ class WP_Auth0_Admin_Basic extends WP_Auth0_Admin_Generic {
 		$allow_signup = $this->options->is_wp_registration_enabled();
 ?>
       <span class="description">
-        <?php echo __( 'Signup will be', WPA0_LANG ); ?>
+        <?php echo __( 'Signup will be', 'wp-auth0' ); ?>
 
         <?php if ( ! $allow_signup ) { ?>
-          <b><?php echo __( 'disabled', WPA0_LANG ); ?></b>
-          <?php echo __( ' because it is enabled by the setting "Anyone can register" in the WordPress General Settings.', WPA0_LANG ); ?>
+          <b><?php echo __( 'disabled', 'wp-auth0' ); ?></b>
+          <?php echo __( ' because it is enabled by the setting "Anyone can register" in the WordPress General Settings.', 'wp-auth0' ); ?>
         <?php } else { ?>
-          <b><?php echo __( 'enabled', WPA0_LANG ); ?></b>
-          <?php echo __( ' because it is enabled by the setting "Anyone can register" in the WordPress General Settings.', WPA0_LANG ); ?>
+          <b><?php echo __( 'enabled', 'wp-auth0' ); ?></b>
+          <?php echo __( ' because it is enabled by the setting "Anyone can register" in the WordPress General Settings.', 'wp-auth0' ); ?>
         <?php } ?>
 
-        <?php echo __( 'You can manage this setting on <code>Settings > General > Membership</code>, Anyone can register', WPA0_LANG ); ?>
+        <?php echo __( 'You can manage this setting on <code>Settings > General > Membership</code>, Anyone can register', 'wp-auth0' ); ?>
       </span>
 
     <?php
@@ -151,7 +151,7 @@ class WP_Auth0_Admin_Basic extends WP_Auth0_Admin_Generic {
 		echo $this->render_a0_switch( "wpa0_wp_login_enabled", "wordpress_login_enabled", 1, 1 == $v );
 ?>
       <div class="subelement">
-        <span class="description"><?php echo __( 'Enable to allow existing and new WordPress logins to work. If this site already had users before you installed Auth0, and you want them to still be able to use those logins, enable this.', WPA0_LANG ); ?></span>
+        <span class="description"><?php echo __( 'Enable to allow existing and new WordPress logins to work. If this site already had users before you installed Auth0, and you want them to still be able to use those logins, enable this.', 'wp-auth0' ); ?></span>
       </div>
     <?php
 	}
@@ -180,18 +180,18 @@ class WP_Auth0_Admin_Basic extends WP_Auth0_Admin_Generic {
 		$error = '';
 		$completeBasicData = true;
 		if ( empty( $input['domain'] ) ) {
-			$error = __( 'You need to specify domain', WPA0_LANG );
+			$error = __( 'You need to specify domain', 'wp-auth0' );
 			$this->add_validation_error( $error );
 			$completeBasicData = false;
 		}
 
 		if ( empty( $input['client_id'] ) ) {
-			$error = __( 'You need to specify a client id', WPA0_LANG );
+			$error = __( 'You need to specify a client id', 'wp-auth0' );
 			$this->add_validation_error( $error );
 			$completeBasicData = false;
 		}
 		if ( empty( $input['client_secret'] ) && empty( $old_options['client_secret'] ) ) {
-			$error = __( 'You need to specify a client secret', WPA0_LANG );
+			$error = __( 'You need to specify a client secret', 'wp-auth0' );
 			$this->add_validation_error( $error );
 			$completeBasicData = false;
 		}

--- a/lib/admin/WP_Auth0_Admin_Dashboard.php
+++ b/lib/admin/WP_Auth0_Admin_Dashboard.php
@@ -65,13 +65,13 @@ class WP_Auth0_Admin_Dashboard extends WP_Auth0_Admin_Generic {
 ?>
 
     <input type="radio" name="<?php echo $this->options->get_options_name() ?>[chart_age_type]" id="wpa0_auth0_age_chart_type_donut" value="donut" <?php echo checked( $v, 'donut', false ); ?>/>
-    <label for="wpa0_auth0_age_chart_type_donut"><?php echo __( 'Donut', WPA0_LANG ); ?></label>
+    <label for="wpa0_auth0_age_chart_type_donut"><?php echo __( 'Donut', 'wp-auth0' ); ?></label>
 
     <input type="radio" name="<?php echo $this->options->get_options_name() ?>[chart_age_type]" id="wpa0_auth0_age_chart_type_pie" value="pie" <?php echo checked( $v, 'pie', false ); ?>/>
-    <label for="wpa0_auth0_age_chart_type_pie"><?php echo __( 'Pie', WPA0_LANG ); ?></label>
+    <label for="wpa0_auth0_age_chart_type_pie"><?php echo __( 'Pie', 'wp-auth0' ); ?></label>
     &nbsp;
     <input type="radio" name="<?php echo $this->options->get_options_name() ?>[chart_age_type]" id="wpa0_auth0_age_chart_type_bar" value="bar" <?php echo checked( $v, 'bar', false ); ?>/>
-    <label for="wpa0_auth0_age_chart_type_bars"><?php echo __( 'Bars', WPA0_LANG ); ?></label>
+    <label for="wpa0_auth0_age_chart_type_bars"><?php echo __( 'Bars', 'wp-auth0' ); ?></label>
 
     <?php
 	}
@@ -82,13 +82,13 @@ class WP_Auth0_Admin_Dashboard extends WP_Auth0_Admin_Generic {
 ?>
 
     <input type="radio" name="<?php echo $this->options->get_options_name() ?>[chart_idp_type]" id="wpa0_auth0_idp_chart_type_donut" value="donut" <?php echo checked( $v, 'donut', false ); ?>/>
-    <label for="wpa0_auth0_idp_chart_type_donut"><?php echo __( 'Donut', WPA0_LANG ); ?></label>
+    <label for="wpa0_auth0_idp_chart_type_donut"><?php echo __( 'Donut', 'wp-auth0' ); ?></label>
 
     <input type="radio" name="<?php echo $this->options->get_options_name() ?>[chart_idp_type]" id="wpa0_auth0_idp_chart_type_pie" value="pie" <?php echo checked( $v, 'pie', false ); ?>/>
-    <label for="wpa0_auth0_idp_chart_type_pie"><?php echo __( 'Pie', WPA0_LANG ); ?></label>
+    <label for="wpa0_auth0_idp_chart_type_pie"><?php echo __( 'Pie', 'wp-auth0' ); ?></label>
     &nbsp;
     <input type="radio" name="<?php echo $this->options->get_options_name() ?>[chart_idp_type]" id="wpa0_auth0_idp_chart_type_bar" value="bar" <?php echo checked( $v, 'bar', false ); ?>/>
-    <label for="wpa0_auth0_idp_chart_type_bars"><?php echo __( 'Bars', WPA0_LANG ); ?></label>
+    <label for="wpa0_auth0_idp_chart_type_bars"><?php echo __( 'Bars', 'wp-auth0' ); ?></label>
 
     <?php
 	}
@@ -99,13 +99,13 @@ class WP_Auth0_Admin_Dashboard extends WP_Auth0_Admin_Generic {
 ?>
 
     <input type="radio" name="<?php echo $this->options->get_options_name() ?>[chart_gender_type]" id="wpa0_auth0_gender_chart_type_donut" value="donut" <?php echo checked( $v, 'donut', false ); ?>/>
-    <label for="wpa0_auth0_gender_chart_type_donut"><?php echo __( 'Donut', WPA0_LANG ); ?></label>
+    <label for="wpa0_auth0_gender_chart_type_donut"><?php echo __( 'Donut', 'wp-auth0' ); ?></label>
 
     <input type="radio" name="<?php echo $this->options->get_options_name() ?>[chart_gender_type]" id="wpa0_auth0_gender_chart_type_pie" value="pie" <?php echo checked( $v, 'pie', false ); ?>/>
-    <label for="wpa0_auth0_gender_chart_type_pie"><?php echo __( 'Pie', WPA0_LANG ); ?></label>
+    <label for="wpa0_auth0_gender_chart_type_pie"><?php echo __( 'Pie', 'wp-auth0' ); ?></label>
     &nbsp;
     <input type="radio" name="<?php echo $this->options->get_options_name() ?>[chart_gender_type]" id="wpa0_auth0_gender_chart_type_bar" value="bar" <?php echo checked( $v, 'bar', false ); ?>/>
-    <label for="wpa0_auth0_gender_chart_type_bars"><?php echo __( 'Bars', WPA0_LANG ); ?></label>
+    <label for="wpa0_auth0_gender_chart_type_bars"><?php echo __( 'Bars', 'wp-auth0' ); ?></label>
 
     <?php
 	}

--- a/lib/admin/WP_Auth0_Admin_Features.php
+++ b/lib/admin/WP_Auth0_Admin_Features.php
@@ -40,7 +40,7 @@ class WP_Auth0_Admin_Features extends WP_Auth0_Admin_Generic {
       <input type="radio" name="<?php echo $this->options->get_options_name(); ?>[password_policy]" id="wpa0_password_policy_excellent" value="excellent" <?php echo checked( $v, 'excellent', false ); ?>/><label for="wpa0_password_policy_excellent">Excellent</label>
       <div class="subelement">
         <span class="description">
-          <?php echo __( 'The difficulty of the user password where \'none\' requires a single character, \'low\' requires six characters and so on. For more details see our', WPA0_LANG ); ?> <a target="_blank" href="https://auth0.com/docs/password-strength"><?php echo __( 'help page', WPA0_LANG ); ?></a> <?php echo __( 'on password difficulty.', WPA0_LANG ); ?>
+          <?php echo __( 'The difficulty of the user password where \'none\' requires a single character, \'low\' requires six characters and so on. For more details see our', 'wp-auth0' ); ?> <a target="_blank" href="https://auth0.com/docs/password-strength"><?php echo __( 'help page', 'wp-auth0' ); ?></a> <?php echo __( 'on password difficulty.', 'wp-auth0' ); ?>
         </span>
       </div>
     <?php
@@ -54,8 +54,8 @@ class WP_Auth0_Admin_Features extends WP_Auth0_Admin_Generic {
 
       <div class="subelement">
         <span class="description">
-          <?php echo __( 'Single Sign On (SSO) allows users to sign in once to multiple services. For more details, see our ', WPA0_LANG ); ?>
-          <a target="_blank" href="https://auth0.com/docs/sso/single-sign-on"><?php echo __( 'help page on SSO', WPA0_LANG ); ?></a>.
+          <?php echo __( 'Single Sign On (SSO) allows users to sign in once to multiple services. For more details, see our ', 'wp-auth0' ); ?>
+          <a target="_blank" href="https://auth0.com/docs/sso/single-sign-on"><?php echo __( 'help page on SSO', 'wp-auth0' ); ?></a>.
         </span>
       </div>
     <?php
@@ -69,8 +69,8 @@ class WP_Auth0_Admin_Features extends WP_Auth0_Admin_Generic {
 
       <div class="subelement">
         <span class="description">
-          <?php echo __( 'Single Logout is the opposite of the above SSO, it logs users out of everything at once. For more details, see our', WPA0_LANG ); ?>
-          <a target="_blank" href="https://auth0.com/docs/sso/single-sign-on"><?php echo __( 'help page on SSO', WPA0_LANG ); ?></a>.
+          <?php echo __( 'Single Logout is the opposite of the above SSO, it logs users out of everything at once. For more details, see our', 'wp-auth0' ); ?>
+          <a target="_blank" href="https://auth0.com/docs/sso/single-sign-on"><?php echo __( 'help page on SSO', 'wp-auth0' ); ?></a>.
         </span>
       </div>
     <?php
@@ -84,11 +84,11 @@ class WP_Auth0_Admin_Features extends WP_Auth0_Admin_Generic {
 
       <div class="subelement">
         <span class="description">
-          <?php echo __( 'Mark this if you want to enable multifactor authentication with Auth0 Guardian. For more information, see ', WPA0_LANG ); ?>
-          <a target="_blank" href="https://auth0.com/docs/mfa"><?php echo __( 'our help page on MFA', WPA0_LANG ); ?></a>.
-          <?php echo __( 'You can enable other MFA providers from the ', WPA0_LANG ); ?>
-          <a target="_blank" href="https://manage.auth0.com/#/multifactor"><?php echo __( 'Auth0 dashboard', WPA0_LANG ); ?></a>.
-          <?php echo __( 'You can reset your users MFA provider data, by going to the user and clicking on "Delete MFA Provider" button.', WPA0_LANG ); ?>
+          <?php echo __( 'Mark this if you want to enable multifactor authentication with Auth0 Guardian. For more information, see ', 'wp-auth0' ); ?>
+          <a target="_blank" href="https://auth0.com/docs/mfa"><?php echo __( 'our help page on MFA', 'wp-auth0' ); ?></a>.
+          <?php echo __( 'You can enable other MFA providers from the ', 'wp-auth0' ); ?>
+          <a target="_blank" href="https://manage.auth0.com/#/multifactor"><?php echo __( 'Auth0 dashboard', 'wp-auth0' ); ?></a>.
+          <?php echo __( 'You can reset your users MFA provider data, by going to the user and clicking on "Delete MFA Provider" button.', 'wp-auth0' ); ?>
         </span>
       </div>
     <?php
@@ -102,7 +102,7 @@ class WP_Auth0_Admin_Features extends WP_Auth0_Admin_Generic {
 
       <div class="subelement">
         <span class="description">
-          <?php echo __( 'Mark this if you want to store geo location information based on your users IP in the user_metadata', WPA0_LANG );?>
+          <?php echo __( 'Mark this if you want to store geo location information based on your users IP in the user_metadata', 'wp-auth0' );?>
         </span>
       </div>
     <?php
@@ -114,10 +114,10 @@ class WP_Auth0_Admin_Features extends WP_Auth0_Admin_Generic {
     echo $this->render_a0_switch( "wpa0_income_rule", "income_rule", 1, !empty( $v ) );
 ?>
       <div class="subelement">
-        <span class="description"><?php echo __( 'Mark this if you want to store income data based on the zipcode (calculated using the users IP).', WPA0_LANG ); ?></span>
+        <span class="description"><?php echo __( 'Mark this if you want to store income data based on the zipcode (calculated using the users IP).', 'wp-auth0' ); ?></span>
       </div>
       <div class="subelement">
-        <span class="description"><?php echo __( 'Represents the median income of the users zipcode, based on last US census data.', WPA0_LANG ); ?></span>
+        <span class="description"><?php echo __( 'Represents the median income of the users zipcode, based on last US census data.', 'wp-auth0' ); ?></span>
       </div>
     <?php
   }
@@ -128,7 +128,7 @@ class WP_Auth0_Admin_Features extends WP_Auth0_Admin_Generic {
     echo $this->render_a0_switch( "wpa0_override_wp_avatars", "override_wp_avatars", 1, !empty( $v ) );
 ?>
       <div class="subelement">
-        <span class="description"><?php echo __( 'Mark this if you want to override the WordPress avatar with the user\'s Auth0 profile avatar.', WPA0_LANG ); ?></span>
+        <span class="description"><?php echo __( 'Mark this if you want to override the WordPress avatar with the user\'s Auth0 profile avatar.', 'wp-auth0' ); ?></span>
       </div>
     <?php
   }
@@ -148,9 +148,9 @@ class WP_Auth0_Admin_Features extends WP_Auth0_Admin_Generic {
 
       <div class="subelement">
         <span class="description">
-          <?php echo __( 'Mark this if you want to enrich your users\' profiles with the data provided by FullContact. A valid api key is required. ', WPA0_LANG ); ?>
-          <?php echo __( 'For more information, see our ', WPA0_LANG ); ?>
-          <a target="_blank" href="https://auth0.com/docs/scenarios/mixpanel-fullcontact-salesforce#2-augment-user-profile-with-fullcontact-"><?php echo __( 'help page on FullContact integration with Auth0', WPA0_LANG );?></a>
+          <?php echo __( 'Mark this if you want to enrich your users\' profiles with the data provided by FullContact. A valid api key is required. ', 'wp-auth0' ); ?>
+          <?php echo __( 'For more information, see our ', 'wp-auth0' ); ?>
+          <a target="_blank" href="https://auth0.com/docs/scenarios/mixpanel-fullcontact-salesforce#2-augment-user-profile-with-fullcontact-"><?php echo __( 'help page on FullContact integration with Auth0', 'wp-auth0' );?></a>
         </span>
       </div>
     <?php
@@ -177,7 +177,7 @@ class WP_Auth0_Admin_Features extends WP_Auth0_Admin_Generic {
     if ( $old_options['sso'] != $input['sso'] && 1 == $input['sso'] ) {
       if ( false === WP_Auth0_Api_Client::update_client( $input['domain'], $input['auth0_app_token'], $input['client_id'], $input['sso'] == 1 ) ) {
 
-        $error = __( 'There was an error updating your Auth0 App to enable SSO. To do it manually, turn it ', WPA0_LANG );
+        $error = __( 'There was an error updating your Auth0 App to enable SSO. To do it manually, turn it ', 'wp-auth0' );
         $error .= '<a href="https://auth0.com/docs/sso/single-sign-on#1">HERE</a>.';
         $this->add_validation_error( $error );
 
@@ -207,7 +207,7 @@ class WP_Auth0_Admin_Features extends WP_Auth0_Admin_Generic {
  
           if ( false === WP_Auth0_Api_Client::update_connection($input['domain'], $input['auth0_app_token'], $connection_id, $connection ) ) {
 
-            $error = __( 'There was an error updating your Auth0 DB Connection. To do it manually, change it ', WPA0_LANG );
+            $error = __( 'There was an error updating your Auth0 DB Connection. To do it manually, change it ', 'wp-auth0' );
             $error .= '<a href="https://manage.auth0.com/#/connections/database">HERE</a>.';
             $this->add_validation_error( $error );
 

--- a/lib/admin/WP_Auth0_Admin_Generic.php
+++ b/lib/admin/WP_Auth0_Admin_Generic.php
@@ -15,7 +15,7 @@ class WP_Auth0_Admin_Generic {
 
 		add_settings_section(
 			"wp_auth0_{$id}_settings_section",
-			__( $sectionName, WPA0_LANG ),
+			__( $sectionName, 'wp-auth0' ),
 			array( $this, "render_{$id}_description" ),
 			$options_name
 		);
@@ -23,7 +23,7 @@ class WP_Auth0_Admin_Generic {
 		foreach ( $settings as $setting ) {
 			add_settings_field(
 				$setting['id'],
-				__( $setting['name'], WPA0_LANG ),
+				__( $setting['name'], 'wp-auth0' ),
 				array( $this, $setting['function'] ),
 				$options_name,
 				"wp_auth0_{$id}_settings_section",

--- a/lib/dashboard-widgets/WP_Auth0_Dashboard_Widgets.php
+++ b/lib/dashboard-widgets/WP_Auth0_Dashboard_Widgets.php
@@ -31,7 +31,7 @@ class WP_Auth0_Dashboard_Widgets {
 
 		if ( ! get_user_meta( $user_id, 'a0_ignore_widgets_explanation' ) ) {
 			echo '<div class="updated"><p>';
-			printf( __( 'Auth0 tip: You can filter the data by clicking on the charts. Click again to clear the selection.  | <a href="%1$s">Hide</a>' ), '?a0_ignore_widgets_explanation=0' );
+			printf( __( 'Auth0 tip: You can filter the data by clicking on the charts. Click again to clear the selection.  | <a href="%1$s">Hide</a>', 'wp-auth0' ), '?a0_ignore_widgets_explanation=0' );
 			echo "</p></div>";
 		}
 	}

--- a/lib/initial-setup/WP_Auth0_InitialSetup.php
+++ b/lib/initial-setup/WP_Auth0_InitialSetup.php
@@ -150,11 +150,11 @@ class WP_Auth0_InitialSetup {
   		<div id="message" class="error">
   			<p>
   				<strong>
-  					<?php echo __( 'There was an error creating the Auth0 App. Check the ', WPA0_LANG ); ?>
-  					<a target="_blank" href="<?php echo admin_url( 'admin.php?page=wpa0-errors' ); ?>"><?php echo __( 'Error log', WPA0_LANG ); ?></a>
-  					<?php echo __( ' for more information. If the problem persists, please create it manually in the ', WPA0_LANG ); ?>
-  					<a target="_blank" href="https://manage.auth0.com/#/applications"><?php echo __( 'Auth0 Dashboard', WPA0_LANG ); ?></a>
-  					<?php echo __( ' and copy the client_id and secret.', WPA0_LANG ); ?>
+  					<?php echo __( 'There was an error creating the Auth0 App. Check the ', 'wp-auth0' ); ?>
+  					<a target="_blank" href="<?php echo admin_url( 'admin.php?page=wpa0-errors' ); ?>"><?php echo __( 'Error log', 'wp-auth0' ); ?></a>
+  					<?php echo __( ' for more information. If the problem persists, please create it manually in the ', 'wp-auth0' ); ?>
+  					<a target="_blank" href="https://manage.auth0.com/#/applications"><?php echo __( 'Auth0 Dashboard', 'wp-auth0' ); ?></a>
+  					<?php echo __( ' and copy the client_id and secret.', 'wp-auth0' ); ?>
   				</strong>
   			</p>
   		</div>
@@ -167,9 +167,9 @@ class WP_Auth0_InitialSetup {
   		<div id="message" class="error">
   			<p>
   				<strong>
-  					<?php echo __( 'There was an error retieving your auth0 credentials. Check the ', WPA0_LANG ); ?>
-  					<a target="_blank" href="<?php echo admin_url( 'admin.php?page=wpa0-errors' ); ?>"><?php echo __( 'Error log', WPA0_LANG ); ?></a>
-  					<?php echo __( ' for more information. Please check that your sever has internet access and can reach "https://'.$domain.'/" ', WPA0_LANG ); ?>
+  					<?php echo __( 'There was an error retieving your auth0 credentials. Check the ', 'wp-auth0' ); ?>
+  					<a target="_blank" href="<?php echo admin_url( 'admin.php?page=wpa0-errors' ); ?>"><?php echo __( 'Error log', 'wp-auth0' ); ?></a>
+  					<?php echo __( ' for more information. Please check that your sever has internet access and can reach "https://'.$domain.'/" ', 'wp-auth0' ); ?>
   				</strong>
   			</p>
   		</div>
@@ -182,7 +182,7 @@ class WP_Auth0_InitialSetup {
       <div id="message" class="error">
         <p>
           <strong>
-            <?php echo __( 'The required scoped were rejected.', WPA0_LANG ); ?>
+            <?php echo __( 'The required scoped were rejected.', 'wp-auth0' ); ?>
           </strong>
         </p>
       </div>
@@ -194,7 +194,7 @@ class WP_Auth0_InitialSetup {
   		<div id="message" class="error">
   			<p>
   				<strong>
-  					<?php echo __( 'Please create your Auth0 account first at ', WPA0_LANG ); ?>
+  					<?php echo __( 'Please create your Auth0 account first at ', 'wp-auth0' ); ?>
             <a href="https://manage.auth0.com">https://manage.auth0.com</a>
   				</strong>
   			</p>

--- a/templates/a0-error-log.php
+++ b/templates/a0-error-log.php
@@ -2,7 +2,7 @@
 
     <?php require WPA0_PLUGIN_DIR . 'templates/initial-setup/partials/header.php'; ?>
 
-    <div class="a0-table"><h1><?php _e( 'Auth0 Error Log', WPA0_LANG ); ?></h1></div>
+    <div class="a0-table"><h1><?php _e( 'Auth0 Error Log', 'wp-auth0' ); ?></h1></div>
 
     <table class="a0-table widefat">
         <thead>

--- a/templates/a0-widget-setup-form.php
+++ b/templates/a0-widget-setup-form.php
@@ -115,12 +115,12 @@ $redirect_to = isset( $instance[ 'redirect_to' ] ) ? $instance[ 'redirect_to' ] 
         <?php echo esc_attr( $dict ); ?>
     </textarea>
     <br/><span class="description">
-            <?php echo __( 'This is the widget\'s dict param.', WPA0_LANG ); ?>
-        <a target="_blank" href="https://github.com/auth0/lock/wiki/Auth0Lock-customization#dict-stringobject"><?php echo __( 'More info', WPA0_LANG ); ?></a>
+            <?php echo __( 'This is the widget\'s dict param.', 'wp-auth0' ); ?>
+        <a target="_blank" href="https://github.com/auth0/lock/wiki/Auth0Lock-customization#dict-stringobject"><?php echo __( 'More info', 'wp-auth0' ); ?></a>
         </span><br>
         <span class="description">
-            <i><b><?php echo __( 'Note', WPA0_LANG ); ?>:</b>
-                <?php echo __( 'This will override the "Form title" setting', WPA0_LANG ); ?>
+            <i><b><?php echo __( 'Note', 'wp-auth0' ); ?>:</b>
+                <?php echo __( 'This will override the "Form title" setting', 'wp-auth0' ); ?>
             </i>
         </span>
     </span>
@@ -132,12 +132,12 @@ $redirect_to = isset( $instance[ 'redirect_to' ] ) ? $instance[ 'redirect_to' ] 
         <?php echo esc_attr( $extra_conf ); ?>
     </textarea>
     <br/><span class="description">
-            <?php echo __( 'This field allows you to set all the widget settings.', WPA0_LANG ); ?>
-        <a target="_blank" href="https://github.com/auth0/lock/wiki/Auth0Lock-customization"><?php echo __( 'More info', WPA0_LANG ); ?></a>
+            <?php echo __( 'This field allows you to set all the widget settings.', 'wp-auth0' ); ?>
+        <a target="_blank" href="https://github.com/auth0/lock/wiki/Auth0Lock-customization"><?php echo __( 'More info', 'wp-auth0' ); ?></a>
         </span><br>
         <span class="description">
-            <i><b><?php echo __( 'Note', WPA0_LANG ); ?>:</b>
-                <?php echo __( 'The other settings will override this configuration', WPA0_LANG ); ?>
+            <i><b><?php echo __( 'Note', 'wp-auth0' ); ?>:</b>
+                <?php echo __( 'The other settings will override this configuration', 'wp-auth0' ); ?>
             </i>
         </span>
     </span>
@@ -149,8 +149,8 @@ $redirect_to = isset( $instance[ 'redirect_to' ] ) ? $instance[ 'redirect_to' ] 
         <?php echo esc_attr( $custom_css ); ?>
     </textarea>
     <br/><span class="description">
-            <?php echo __( 'This should be a valid CSS to customize the Auth0 login widget.', WPA0_LANG ); ?>
-        <a target="_blank" href="https://github.com/auth0/wp-auth0#can-i-customize-the-login-widget"><?php echo __( 'More info', WPA0_LANG ); ?></a>
+            <?php echo __( 'This should be a valid CSS to customize the Auth0 login widget.', 'wp-auth0' ); ?>
+        <a target="_blank" href="https://github.com/auth0/wp-auth0#can-i-customize-the-login-widget"><?php echo __( 'More info', 'wp-auth0' ); ?></a>
         </span>
     </span>
 </p>
@@ -161,5 +161,5 @@ $redirect_to = isset( $instance[ 'redirect_to' ] ) ? $instance[ 'redirect_to' ] 
         <?php echo esc_attr( $custom_js ); ?>
     </textarea>
     <br/>
-    <span class="description"><?php echo __( 'This should be a valid JS to customize the Auth0 login widget to, for example, add custom buttons. ', WPA0_LANG ); ?><a target="_blank" href="https://auth0.com/docs/hrd#3"><?php echo __( 'More info', WPA0_LANG ); ?></a></span>
+    <span class="description"><?php echo __( 'This should be a valid JS to customize the Auth0 login widget to, for example, add custom buttons. ', 'wp-auth0' ); ?><a target="_blank" href="https://auth0.com/docs/hrd#3"><?php echo __( 'More info', 'wp-auth0' ); ?></a></span>
 </p>

--- a/templates/auth0-login-form-lock10.php
+++ b/templates/auth0-login-form-lock10.php
@@ -4,7 +4,7 @@ $lock_options = new WP_Auth0_Lock10_Options( $specialSettings );
 
 if ( ! $lock_options->can_show() ) {
 ?>
-    <p><?php _e( 'Auth0 Integration has not yet been set up! Please visit your Wordpress Auth0 settings and fill in the required settings.', WPA0_LANG ); ?></p>
+    <p><?php _e( 'Auth0 Integration has not yet been set up! Please visit your Wordpress Auth0 settings and fill in the required settings.', 'wp-auth0' ); ?></p>
 <?php
   return;
 }

--- a/templates/auth0-login-form.php
+++ b/templates/auth0-login-form.php
@@ -4,7 +4,7 @@ $lock_options = new WP_Auth0_Lock_Options( $specialSettings );
 
 if ( ! $lock_options->can_show() ) {
 ?>
-    <p><?php _e( 'Auth0 Integration has not yet been set up! Please visit your Wordpress Auth0 settings and fill in the required settings.', WPA0_LANG ); ?></p>
+    <p><?php _e( 'Auth0 Integration has not yet been set up! Please visit your Wordpress Auth0 settings and fill in the required settings.', 'wp-auth0' ); ?></p>
 <?php
 	return;
 }

--- a/templates/configure-jwt-auth.php
+++ b/templates/configure-jwt-auth.php
@@ -4,7 +4,7 @@
 
 	<div class="container-fluid">
 
-		<h1><?php _e( 'JWT Auth authentication', WPA0_LANG ); ?></h1>
+		<h1><?php _e( 'JWT Auth authentication', 'wp-auth0' ); ?></h1>
 
 		<?php if ( !$ready ) { ?>
 			<form action="options.php" method="post">

--- a/templates/export-users.php
+++ b/templates/export-users.php
@@ -4,7 +4,7 @@
 
 	<div class="container-fluid">
 
-		<h1><?php _e( 'Export Auth0 Users', WPA0_LANG ); ?></h1>
+		<h1><?php _e( 'Export Auth0 Users', 'wp-auth0' ); ?></h1>
 
    	<form action="options.php" method="post" onsubmit="return presubmit();">
 			<input type="hidden" name="action" value="wpauth0_export_users" />

--- a/templates/import_settings.php
+++ b/templates/import_settings.php
@@ -5,7 +5,7 @@
   <div class="container-fluid">
 
     <div class="row">
-      <h1><?php _e( 'Import and Export Settings', WPA0_LANG ); ?></h1>
+      <h1><?php _e( 'Import and Export Settings', 'wp-auth0' ); ?></h1>
       <p class="a0-step-text top-margin no-bottom-margin">You can import and export your Auth0 WordPress plugin settings here. This allows you to either backup the data, or to move your settings to a new WordPress instance.</p>
     </div>
     <div class="row">

--- a/templates/initial-setup/admin-creation.php
+++ b/templates/initial-setup/admin-creation.php
@@ -6,17 +6,17 @@
   <div class="container-fluid">
     <div class="row">
 
-      <h1><?php _e( "Choose your password", WPA0_LANG ); ?></h1>
+      <h1><?php _e( "Choose your password", "wp-auth0" ); ?></h1>
 
-      <p class="a0-step-text"><?php _e( "Last step: Auth0 will migrate your own account from the WordPress user database to Auth0. You can choose to use the same password as you currently use, or pick a new one. Either way, Auth0 will link your existing account and its administrative role with the new account in Auth0. Type the password you wish to use for this account below.", WPA0_LANG ); ?></p>
+      <p class="a0-step-text"><?php _e( "Last step: Auth0 will migrate your own account from the WordPress user database to Auth0. You can choose to use the same password as you currently use, or pick a new one. Either way, Auth0 will link your existing account and its administrative role with the new account in Auth0. Type the password you wish to use for this account below.", "wp-auth0" ); ?></p>
 
       <?php if ( $error ) { ?>
 
       <p class="bg-danger">
 
-        <?php _e( "An error occurred creating the user. Check that the migration webservices are accesible or check the ", WPA0_LANG ); ?>
-        <a href="<?php echo admin_url( "admin.php?page=wpa0-errors" ); ?>" target="_blank"><?php _e( "Error Log", WPA0_LANG ); ?></a>
-        <?php _e( "for more info.", WPA0_LANG ); ?>
+        <?php _e( "An error occurred creating the user. Check that the migration webservices are accesible or check the ", "wp-auth0" ); ?>
+        <a href="<?php echo admin_url( "admin.php?page=wpa0-errors" ); ?>" target="_blank"><?php _e( "Error Log", "wp-auth0" ); ?></a>
+        <?php _e( "for more info.", "wp-auth0" ); ?>
       </p>
 
       <?php } ?>
@@ -34,7 +34,7 @@
         <div class="a0-buttons">
           <input type="hidden" name="action" value="wpauth0_callback_step3_social" />
           <input type="submit" class="a0-button primary" value="Submit" />
-          <a onclick="onSkip()" href="<?php echo admin_url( 'admin.php?page=wpa0-setup&step=4&profile=social' ); ?>"class="a0-button link"><?php _e( "Skip this step", WPA0_LANG ); ?></a>
+          <a onclick="onSkip()" href="<?php echo admin_url( 'admin.php?page=wpa0-setup&step=4&profile=social' ); ?>"class="a0-button link"><?php _e( "Skip this step", "wp-auth0" ); ?></a>
         </div>
 
       </form>

--- a/templates/initial-setup/connection_profile.php
+++ b/templates/initial-setup/connection_profile.php
@@ -4,14 +4,14 @@
 
   <div class="container-fluid">
     <div class="row">
-      <h1><?php _e( "Step 1: Choose your account type", WPA0_LANG ); ?></h1>
-      <p class="a0-step-text"><?php _e( "Users can log in within their own credentials - social like Google or Facebook, or name/password -  or use their employee credentials through an enterprise connection. Use either or both, and you'll increase your WordPress site's security and gather data about your visitors. For more information and help on the Auth0 WordPress plugin please visit", WPA0_LANG ); ?> <a href="https://auth0.com/docs/cms" target="_blank">our help documentation</a> </p>
+      <h1><?php _e( "Step 1: Choose your account type", "wp-auth0" ); ?></h1>
+      <p class="a0-step-text"><?php _e( "Users can log in within their own credentials - social like Google or Facebook, or name/password -  or use their employee credentials through an enterprise connection. Use either or both, and you'll increase your WordPress site's security and gather data about your visitors. For more information and help on the Auth0 WordPress plugin please visit", "wp-auth0" ); ?> <a href="https://auth0.com/docs/cms" target="_blank">our help documentation</a> </p>
     </div>
     <div class="row">
       <div class="a0-step-text a0-message a0-warning">
 
         <b>Important:</b>
-        <?php _e( 'To continue you need an Auth0 account, don\'t have one yet?', WPA0_LANG ); ?>
+        <?php _e( 'To continue you need an Auth0 account, don\'t have one yet?', 'wp-auth0' ); ?>
 
         <a class="a0-button default pull-right" target="_blank" href="https://auth0.com/signup" >Sign up for free</a>
 
@@ -26,9 +26,9 @@
           <div class="profile">
             <img src="<?php echo WPA0_PLUGIN_URL; ?>/assets/img/initial-setup/simple-end-users-login.svg">
 
-            <h2><?php _e( "Social Login", WPA0_LANG ); ?></h2>
+            <h2><?php _e( "Social Login", "wp-auth0" ); ?></h2>
 
-            <p><?php _e( "Let your users login with their social accounts. For example; Google, Facebook, Twitter and many more along with traditional username and password. Don't worry - if you have existing users they will still be able to login.", WPA0_LANG ); ?></p>
+            <p><?php _e( "Let your users login with their social accounts. For example; Google, Facebook, Twitter and many more along with traditional username and password. Don't worry - if you have existing users they will still be able to login.", "wp-auth0" ); ?></p>
 
             <div class="a0-buttons">
               <input type="submit" value="Social" name="type" class="a0-button primary"/>
@@ -40,9 +40,9 @@
           <div class="profile">
             <img src="<?php echo WPA0_PLUGIN_URL; ?>/assets/img/initial-setup/effortless-employee-access.svg">
 
-            <h2><?php _e( "Enterprise Login", WPA0_LANG ); ?></h2>
+            <h2><?php _e( "Enterprise Login", "wp-auth0" ); ?></h2>
 
-            <p><?php _e( "Secure this WordPress instance with your organizations login system so that users can login with their work account information. For example, you can connect to your existing ActiveDirectory infrastructure.", WPA0_LANG ); ?></p>
+            <p><?php _e( "Secure this WordPress instance with your organizations login system so that users can login with their work account information. For example, you can connect to your existing ActiveDirectory infrastructure.", "wp-auth0" ); ?></p>
 
             <div class="a0-buttons">
               <input type="submit" value="Enterprise" name="type" class="a0-button primary"/>
@@ -60,13 +60,13 @@
                 <h4 class="modal-title" id="connectionSelectedModalLabel">Important</h4>
               </div>
               <div class="modal-body no-padding-bottom">
-                <p><?php _e( 'This wizard gets you started with the Auth0 for WordPress plug-in. You\'ll be transferred to Auth0 and can login or sign-up. Then you\'ll authorize the plug-in and configure identity providers, whether social or enterprise connections.', WPA0_LANG ); ?></p>
-                <p><b><?php _e( 'This plug-in replaces the standard WordPress login screen, but don\'t worry, you can still use your existing WordPress login. Auth0 adds many features to make login easier and better for your users but the old system will still be there too.', WPA0_LANG ); ?></b></p>
+                <p><?php _e( 'This wizard gets you started with the Auth0 for WordPress plug-in. You\'ll be transferred to Auth0 and can login or sign-up. Then you\'ll authorize the plug-in and configure identity providers, whether social or enterprise connections.', 'wp-auth0' ); ?></p>
+                <p><b><?php _e( 'This plug-in replaces the standard WordPress login screen, but don\'t worry, you can still use your existing WordPress login. Auth0 adds many features to make login easier and better for your users but the old system will still be there too.', 'wp-auth0' ); ?></b></p>
 
                 <div class="a0-message a0-warning multiline">
 
                   <b>Note:</b>
-                  <?php _e( 'For this plugin to work, your server/host needs an inbound connection from auth0.com, as Auth0 needs to fetch some information to complete the process. If this website is not accesible from the internet, it will require manual intervention to configure the api token.', WPA0_LANG ); ?>
+                  <?php _e( 'For this plugin to work, your server/host needs an inbound connection from auth0.com, as Auth0 needs to fetch some information to complete the process. If this website is not accesible from the internet, it will require manual intervention to configure the api token.', 'wp-auth0' ); ?>
 
                 </div>
 
@@ -88,14 +88,14 @@
               </div>
               <div class="modal-body">
                 <p>
-                  <?php _e( 'To complete the plugin\'s initial setup, you will need to enter your account subdomain:', WPA0_LANG ); ?>
+                  <?php _e( 'To complete the plugin\'s initial setup, you will need to enter your account subdomain:', 'wp-auth0' ); ?>
                 </p>
                 <input type="text" name="domain" placeholder="youraccount.auth0.com" />
                 <br><br>
                 <p>
-                  <?php _e( 'And manually create an api token on the', WPA0_LANG ); ?>
-                  <a href="https://auth0.com/docs/api/v2" target="_blank"><?php echo __( 'token generator', WPA0_LANG ); ?></a>
-                  <?php _e( ' and paste it here:', WPA0_LANG ); ?>
+                  <?php _e( 'And manually create an api token on the', 'wp-auth0' ); ?>
+                  <a href="https://auth0.com/docs/api/v2" target="_blank"><?php echo __( 'token generator', 'wp-auth0' ); ?></a>
+                  <?php _e( ' and paste it here:', 'wp-auth0' ); ?>
                 </p>
                 <input type="text" name="apitoken" autocomplete="off" />
                 <p>

--- a/templates/initial-setup/connections.php
+++ b/templates/initial-setup/connections.php
@@ -11,24 +11,24 @@ if ( !$migration_ws_enabled ) {
 	<div class="container-fluid">
 		<div class="row">
 
-			<h1><?php _e( "Configure your social connections", WPA0_LANG ); ?></h1>
+			<h1><?php _e( "Configure your social connections", "wp-auth0" ); ?></h1>
 
-			<p class="a0-step-text"><?php _e( "If your WordPress site's visitors already have social network accounts, they can access your site with their existing credentials, or they can set up a username/password combination safeguarded by Auth0's password complexity policies and brute force protection.", WPA0_LANG ); ?></p>
+			<p class="a0-step-text"><?php _e( "If your WordPress site's visitors already have social network accounts, they can access your site with their existing credentials, or they can set up a username/password combination safeguarded by Auth0's password complexity policies and brute force protection.", "wp-auth0" ); ?></p>
 
 			<div class="a0-separator"></div>
 
 			<div class="a0-db-connection">
-				<h3><?php _e( "Database Connections", WPA0_LANG ); ?></h3>
+				<h3><?php _e( "Database Connections", "wp-auth0" ); ?></h3>
 				<div class="a0-switch">
 					<input type="checkbox" name="dbconnection" id="db-connection-check" value="auth0" <?php echo checked( $db_connection_enabled, 1, false ); ?> />
 					<label for="db-connection-check"></label>
 				</div>
-				<p class="a0-step-text"><?php _e( "Select this option to let users choose their own name/password. If a user already has an account on your site, Auth0 will log them in with their existing credentials and then migrate them to a new account behind the scenes - no need to change passwords.", WPA0_LANG ); ?></p>
+				<p class="a0-step-text"><?php _e( "Select this option to let users choose their own name/password. If a user already has an account on your site, Auth0 will log them in with their existing credentials and then migrate them to a new account behind the scenes - no need to change passwords.", "wp-auth0" ); ?></p>
 			</div>
 
 			<div class="a0-separator"></div>
 
-			<h3><?php _e( "Social Connections", WPA0_LANG ); ?></h3>
+			<h3><?php _e( "Social Connections", "wp-auth0" ); ?></h3>
 
 		</div>
 		<div class="row">

--- a/templates/initial-setup/consent-disclaimer.php
+++ b/templates/initial-setup/consent-disclaimer.php
@@ -2,9 +2,9 @@
 	<div class="container-fluid">
 		<img class="logo" src="http://cdn.auth0.com/styleguide/latest/img/badge.png" />
 
-		<h1><?php _e( 'Get started with Auth0 for WordPress', WPA0_LANG ); ?></h1>
+		<h1><?php _e( 'Get started with Auth0 for WordPress', 'wp-auth0' ); ?></h1>
 
-		<p><?php _e( 'This wizard gets you started with the Auth0 for WordPress plug-in. You\'ll be transferred to Auth0 and can login or sign-up. Then you\'ll authorize the plug-in and configure identity providers, whether social or enterprise connections. Finally, you\'ll migrate your own WordPress administrator account to Auth0, ready to configure the plug-in through the WordPress dashboard.', WPA0_LANG ); ?></p>
+		<p><?php _e( 'This wizard gets you started with the Auth0 for WordPress plug-in. You\'ll be transferred to Auth0 and can login or sign-up. Then you\'ll authorize the plug-in and configure identity providers, whether social or enterprise connections. Finally, you\'ll migrate your own WordPress administrator account to Auth0, ready to configure the plug-in through the WordPress dashboard.', 'wp-auth0' ); ?></p>
 
 		<div class="a0-buttons">
 			<a href="<?php echo $consent_url; ?>" class="a0-button primary"><?php echo _e( 'Start' ); ?></a>

--- a/templates/initial-setup/data-migration.php
+++ b/templates/initial-setup/data-migration.php
@@ -1,7 +1,7 @@
 <div class="wrap">
 
 	<?php screen_icon(); ?>
-	<h2><?php _e( "Auth0 for WordPress - Setup Wizard (step $step)", WPA0_LANG ); ?></h2>
+	<h2><?php _e( "Auth0 for WordPress - Setup Wizard (step $step)", "wp-auth0" ); ?></h2>
 
 	<p>This will create a new database connections, expose 2 endpoints and will pupulate the custom scripts to call this endpoints to migrate the users to auth0. the users will not be changed in wordpress.</p>
 
@@ -9,8 +9,8 @@
 
 		<input type="checkbox" name="migration_ws" id="wpa0_auth0_migration_ws" value="1" <?php echo checked( $migration_ws, 1, false ); ?>/>
 		<div class="subelement">
-			<span class="description"><?php echo __( 'Mark this to expose a WS in order to easy the users migration process.', WPA0_LANG ); ?></span>
-			<span class="description"><?php echo __( 'Security token:', WPA0_LANG ); ?><code><?php echo $token; ?></code></span>
+			<span class="description"><?php echo __( 'Mark this to expose a WS in order to easy the users migration process.', 'wp-auth0' ); ?></span>
+			<span class="description"><?php echo __( 'Security token:', 'wp-auth0' ); ?><code><?php echo $token; ?></code></span>
 			<p>
 				This action will create a new Database connection with the custom scrits required to import your Wordpress Users.
 			</p>

--- a/templates/initial-setup/end.php
+++ b/templates/initial-setup/end.php
@@ -6,9 +6,9 @@
 
     <svg width="90" height="90" viewBox="0 0 52 52" xmlns="http://www.w3.org/2000/svg" class="checkmark"><circle cx="26" cy="26" r="25" fill="none" class="checkmark__circle"/><path fill="none" d="M14.1 27.2l7.1 7.2 16.7-16.8" class="checkmark__check"/></svg>
 
-    <h1><?php _e( "Done! You finished this Setup Wizard", WPA0_LANG ); ?></h1>
+    <h1><?php _e( "Done! You finished this Setup Wizard", "wp-auth0" ); ?></h1>
 
-    <p class="a0-step-text"><?php _e( "Adjust the plug-in's settings from the WordPress dashboard, and visit Auth0's dashboard to change how users log in, add connections, enable multi-factor authentication, and more.", WPA0_LANG ); ?></h1>
+    <p class="a0-step-text"><?php _e( "Adjust the plug-in's settings from the WordPress dashboard, and visit Auth0's dashboard to change how users log in, add connections, enable multi-factor authentication, and more.", "wp-auth0" ); ?></h1>
 
     <div class="a0-buttons extra-space">
       <a onclick="onNext()" href="<?php echo admin_url( 'admin.php?page=wpa0' ); ?>" class="a0-button primary">GO TO PLUG-IN SETTINGS</a>

--- a/templates/initial-setup/enterprise_connections.php
+++ b/templates/initial-setup/enterprise_connections.php
@@ -4,13 +4,13 @@
 
   <div class="container-fluid">
     <div class="row">
-      <h1><?php _e( "Configure your enterprise connections", WPA0_LANG ); ?></h1>
+      <h1><?php _e( "Configure your enterprise connections", "wp-auth0" ); ?></h1>
 
-      <p class="a0-step-text"><?php _e( "Make it convenient and secure for your employees to access your WordPress site. Connect your enterprise directory to Auth0 and your users won't need to log in at all, if they're already logged in on the enterprise directory. If they aren't logged in, they'll use their employee credentials - no additional passwords to remember. To configure enterprise connections, you'll use the Auth0 Dashboard.", WPA0_LANG ); ?></p>
+      <p class="a0-step-text"><?php _e( "Make it convenient and secure for your employees to access your WordPress site. Connect your enterprise directory to Auth0 and your users won't need to log in at all, if they're already logged in on the enterprise directory. If they aren't logged in, they'll use their employee credentials - no additional passwords to remember. To configure enterprise connections, you'll use the Auth0 Dashboard.", "wp-auth0" ); ?></p>
 
       <div class="a0-separator"></div>
 
-      <h3><?php _e( "Auth0 supports the following identity providers", WPA0_LANG ); ?></h3>
+      <h3><?php _e( "Auth0 supports the following identity providers", "wp-auth0" ); ?></h3>
 
     </div>
     <div class="row enterprise-connections">
@@ -20,7 +20,7 @@
           <div class="logo" style="background:#fff url('<?php echo WPA0_PLUGIN_URL; ?>/assets/img/initial-setup/enterprise-connections/<?php echo $provider['icon']; ?>.png') no-repeat center center;"></div>
           <h4 class="title-wrapper"><?php echo $provider['name']; ?></h4>
           <?php if ( $provider['url'] !== null ) { ?>
-          <a onclick="onClick('<?php echo $provider['name']; ?>')" href="<?php echo $provider['url']; ?>" target="_blank"><?php _e( "READ MORE", WPA0_LANG ); ?></a>
+          <a onclick="onClick('<?php echo $provider['name']; ?>')" href="<?php echo $provider['url']; ?>" target="_blank"><?php _e( "READ MORE", "wp-auth0" ); ?></a>
           <?php } else { ?>
           <span>&nbsp;</span>
           <?php } ?>
@@ -30,8 +30,8 @@
     </div>
 
     <div class="a0-buttons">
-      <a onclick="gotodashboard()" href="https://manage.auth0.com" class="a0-button primary" target="_blank"><?php _e( "GO TO DASHBOARD", WPA0_LANG ); ?></a>
-      <a onclick="next()" href="<?php echo admin_url( 'admin.php?page=wpa0-setup&step=4' ); ?>"class="a0-button link"><?php _e( "Skip this step", WPA0_LANG ); ?></a>
+      <a onclick="gotodashboard()" href="https://manage.auth0.com" class="a0-button primary" target="_blank"><?php _e( "GO TO DASHBOARD", "wp-auth0" ); ?></a>
+      <a onclick="next()" href="<?php echo admin_url( 'admin.php?page=wpa0-setup&step=4' ); ?>"class="a0-button link"><?php _e( "Skip this step", "wp-auth0" ); ?></a>
     </div>
   </div>
 </div>

--- a/templates/initial-setup/rules.php
+++ b/templates/initial-setup/rules.php
@@ -1,7 +1,7 @@
 <div class="wrap">
 
 	<?php screen_icon(); ?>
-	<h2><?php _e( "Auth0 for WordPress - Setup Wizard (step $step)", WPA0_LANG ); ?></h2>
+	<h2><?php _e( "Auth0 for WordPress - Setup Wizard (step $step)", "wp-auth0" ); ?></h2>
 
 	<p>This will create a new database connections, expose 2 endpoints and will pupulate the custom scripts to call this endpoints to migrate the users to auth0. the users will not be changed in wordpress.</p>
 
@@ -12,10 +12,10 @@
 			MFA: <input type="checkbox" name="mfa" id="wpa0_mfa" value="1" <?php echo empty( $mfa ) ? '' : 'checked'; ?>/>
 			<div class="subelement">
 				<span class="description">
-					<?php echo __( 'Mark this if you want to enable multifactor authentication with Google Authenticator. More info ', WPA0_LANG ); ?>
-					<a target="_blank" href="https://auth0.com/docs/mfa"><?php echo __( 'HERE', WPA0_LANG ); ?></a>.
-					<?php echo __( 'You can enable other MFA providers from the ', WPA0_LANG ); ?>
-					<a target="_blank" href="https://manage.auth0.com/#/multifactor"><?php echo __( 'Auth0 dashboard', WPA0_LANG ); ?></a>.
+					<?php echo __( 'Mark this if you want to enable multifactor authentication with Google Authenticator. More info ', 'wp-auth0' ); ?>
+					<a target="_blank" href="https://auth0.com/docs/mfa"><?php echo __( 'HERE', 'wp-auth0' ); ?></a>.
+					<?php echo __( 'You can enable other MFA providers from the ', 'wp-auth0' ); ?>
+					<a target="_blank" href="https://manage.auth0.com/#/multifactor"><?php echo __( 'Auth0 dashboard', 'wp-auth0' ); ?></a>.
 				</span>
 			</div>
 		</div>
@@ -24,7 +24,7 @@
 			GEO: <input type="checkbox" name="geo_rule" id="wpa0_geo_rule" value="1" <?php echo is_null( $geo ) ? '' : 'checked'; ?>/>
 			<div class="subelement">
 				<span class="description">
-					<?php echo __( 'Mark this if you want to store geo location information based on your users IP in the user_metadata', WPA0_LANG );?>
+					<?php echo __( 'Mark this if you want to store geo location information based on your users IP in the user_metadata', 'wp-auth0' );?>
 				</span>
 			</div>
 		</div>
@@ -33,10 +33,10 @@
 		<div>
 			Income: <input type="checkbox" name="income_rule" id="wpa0_income_rule" value="1" <?php echo is_null( $income ) ? '' : 'checked'; ?>/>
 			<div class="subelement">
-				<span class="description"><?php echo __( 'Mark this if you want to store income data based on the zipcode (calculated using the users IP).', WPA0_LANG ); ?></span>
+				<span class="description"><?php echo __( 'Mark this if you want to store income data based on the zipcode (calculated using the users IP).', 'wp-auth0' ); ?></span>
 			</div>
 			<div class="subelement">
-				<span class="description"><?php echo __( 'Represents the median income of the users zipcode, based on last US census data.', WPA0_LANG ); ?></span>
+				<span class="description"><?php echo __( 'Represents the median income of the users zipcode, based on last US census data.', 'wp-auth0' ); ?></span>
 			</div>
 		</div>
 
@@ -50,9 +50,9 @@
 
 			<div class="subelement">
 				<span class="description">
-					<?php echo __( 'Mark this if you want to hydrate your users profile with the data provided by FullContact. A valid api key is requiere.', WPA0_LANG ); ?>
-					<?php echo __( 'More info ', WPA0_LANG ); ?>
-					<a href="https://auth0.com/docs/scenarios/fullcontact"><?php echo __( 'HERE', WPA0_LANG );?></a>
+					<?php echo __( 'Mark this if you want to hydrate your users profile with the data provided by FullContact. A valid api key is requiere.', 'wp-auth0' ); ?>
+					<?php echo __( 'More info ', 'wp-auth0' ); ?>
+					<a href="https://auth0.com/docs/scenarios/fullcontact"><?php echo __( 'HERE', 'wp-auth0' );?></a>
 				</span>
 			</div>
 		</div>

--- a/templates/initial-setup/signup.php
+++ b/templates/initial-setup/signup.php
@@ -4,8 +4,8 @@
 
   <div class="container-fluid">
     <div class="row">
-      <h1><?php _e( "Sign Up with Auth0", WPA0_LANG ); ?></h1>
-      <p class="a0-step-text"><?php _e( "To get started with the plugin we need you to sign up with Auth0 below. It should only take a second:", WPA0_LANG ); ?></p>
+      <h1><?php _e( "Sign Up with Auth0", "wp-auth0" ); ?></h1>
+      <p class="a0-step-text"><?php _e( "To get started with the plugin we need you to sign up with Auth0 below. It should only take a second:", "wp-auth0" ); ?></p>
     </div>
   </div>
 </div>

--- a/templates/settings.php
+++ b/templates/settings.php
@@ -5,7 +5,7 @@
 	<div class="container-fluid">
 
 		<div class="row">
-			<h1><?php _e( 'Auth0 WordPress Plugin Settings', WPA0_LANG ); ?></h1>
+			<h1><?php _e( 'Auth0 WordPress Plugin Settings', 'wp-auth0' ); ?></h1>
 
 			<div class="row a0-message a0-warning manage">
 				For your Auth0 dashboard with more settings click <a target="_blank" href="https://manage.auth0.com">here</a>.

--- a/templates/verify-email.php
+++ b/templates/verify-email.php
@@ -1,8 +1,8 @@
-<?php echo __( 'Please verify your email and log in again.', WPA0_LANG );?>
+<?php echo __( 'Please verify your email and log in again.', 'wp-auth0' );?>
 <br/>
-<strong><a id="resend" href="#"><?php echo __( 'Resend verification email.', WPA0_LANG );?> </a></strong>
+<strong><a id="resend" href="#"><?php echo __( 'Resend verification email.', 'wp-auth0' );?> </a></strong>
 <br/><br/>
-<a href="<?php echo wp_login_url()?>"> <?php echo __( '← Login', WPA0_LANG ) ?> </a>
+<a href="<?php echo wp_login_url()?>"> <?php echo __( '← Login', 'wp-auth0' ) ?> </a>
 <script src="//code.jquery.com/jquery-1.12.0.min.js"></script>
 <script type="text/javascript">
     function resendEmail() {


### PR DESCRIPTION
**Added**
- Added translation support for a few user-facing exception messages [\#312](https://github.com/auth0/wp-auth0/pull/312) ([idpaterson](https://github.com/idpaterson))

**Changed**
- Use literal 'wp-auth0' rather than WPA0_LANG constant [\#311](https://github.com/auth0/wp-auth0/pull/311) ([idpaterson](https://github.com/idpaterson))