### PR TITLE
Switching wizard admin user creation to use /dbconnections/signup 

### DIFF
--- a/lib/WP_Auth0_Api_Client.php
+++ b/lib/WP_Auth0_Api_Client.php
@@ -191,6 +191,34 @@ class WP_Auth0_Api_Client {
 		return json_decode( $response['body'] );
 	}
 
+	public static function signup_user( $domain, $data ) {
+
+		$endpoint = "https://$domain/dbconnections/signup";
+
+		$headers = self::get_info_headers();
+
+		$headers['content-type'] = "application/json";
+
+		$response = wp_remote_post( $endpoint  , array(
+			'headers' => $headers,
+			'body' => json_encode( $data )
+		) );
+
+		if ( $response instanceof WP_Error ) {
+			WP_Auth0_ErrorManager::insert_auth0_error( 'WP_Auth0_Api_Client::signup_user', $response );
+			error_log( $response->get_error_message() );
+			return false;
+		}
+
+		if ( $response['response']['code'] != 201 ) {
+			WP_Auth0_ErrorManager::insert_auth0_error( 'WP_Auth0_Api_Client::signup_user', $response['body'] );
+			error_log( $response['body'] );
+			return false;
+		}
+
+		return json_decode( $response['body'] );
+	}
+
 	public static function get_required_scopes() {
 		return array(
 			'update:clients',

--- a/lib/WP_Auth0_Api_Client.php
+++ b/lib/WP_Auth0_Api_Client.php
@@ -168,10 +168,9 @@ class WP_Auth0_Api_Client {
 		$headers = self::get_info_headers();
 
 		$headers['Authorization'] = "Bearer $jwt";
-		$headers['content-type'] = "application/json";
+		$headers['content-type'] = 'application/json';
 
 		$response = wp_remote_post( $endpoint  , array(
-				'method' => 'POST',
 				'headers' => $headers,
 				'body' => json_encode( $data )
 			) );
@@ -197,7 +196,7 @@ class WP_Auth0_Api_Client {
 
 		$headers = self::get_info_headers();
 
-		$headers['content-type'] = "application/json";
+		$headers['content-type'] = 'application/json';
 
 		$response = wp_remote_post( $endpoint  , array(
 			'headers' => $headers,

--- a/lib/WP_Auth0_Api_Client.php
+++ b/lib/WP_Auth0_Api_Client.php
@@ -210,7 +210,7 @@ class WP_Auth0_Api_Client {
 			return false;
 		}
 
-		if ( $response['response']['code'] != 201 ) {
+		if ( $response['response']['code'] !== 200 ) {
 			WP_Auth0_ErrorManager::insert_auth0_error( 'WP_Auth0_Api_Client::signup_user', $response['body'] );
 			error_log( $response['body'] );
 			return false;

--- a/lib/initial-setup/WP_Auth0_InitialSetup_AdminUser.php
+++ b/lib/initial-setup/WP_Auth0_InitialSetup_AdminUser.php
@@ -20,23 +20,18 @@ class WP_Auth0_InitialSetup_AdminUser {
 
 		$current_user = wp_get_current_user();
 
-		$db_connection_name = $this->a0_options->get( "db_connection_name" );
-		$domain = $this->a0_options->get( 'domain' );
-		$jwt = $this->a0_options->get( 'auth0_app_token' );
-
 		$data = array(
+			'client_id' => $this->a0_options->get( 'client_id' ),
 			'email' => $current_user->user_email,
 			'password' => $_POST['admin-password'],
-			'connection' => $db_connection_name,
-			'email_verified' => true
+			'connection' => $this->a0_options->get( "db_connection_name" )
 		);
 
-		$admin_user = WP_Auth0_Api_Client::create_user( $domain, $jwt, $data );
+		$admin_user = WP_Auth0_Api_Client::signup_user( $this->a0_options->get( 'domain' ), $data );
 
 		if ( $admin_user === false ) {
 			wp_redirect( admin_url( "admin.php?page=wpa0-setup&step=3&profile=social&result=error" ) );
-		}
-		else {
+		} else {
 			wp_redirect( admin_url( "admin.php?page=wpa0-setup&step=4&profile=social" ) );
 		}
 		exit;


### PR DESCRIPTION
In testing dev, @cocojoe and I found that the /api/v2/users endpoint used in `WP_Auth0_Api_Client::create_user` would not authenticate because the API Client being used was not being activated by default for the Database Connection that was being made. We created a new method, `WP_Auth0_Api_Client::signup_user` to use the Authentication signup endpoint. 
  