### PR TITLE
Creating client_grant for management API

### DIFF
--- a/lib/WP_Auth0_LoginManager.php
+++ b/lib/WP_Auth0_LoginManager.php
@@ -529,15 +529,15 @@ class WP_Auth0_LoginManager {
     if ( isset( $_REQUEST[$key] ) ) return $_REQUEST[$key];
     return null;
   }
-  
-  /**
-   * DEPRECATED 3.4.1
-   *
-   * @param $userinfo
-   * @param $id_token
-   */
-  private function dieWithVerifyEmail( $userinfo, $id_token = '' ) {
-    trigger_error( __( 'Method dieWithVerifyEmail is deprecated.', 'wp-auth0' ), E_USER_DEPRECATED);
-    WP_Auth0_Email_Verification::render_die( $userinfo );
-  }
+
+	/**
+	 * DEPRECATED 3.4.1
+	 *
+	 * @param $userinfo
+	 * @param $id_token
+	 */
+	private function dieWithVerifyEmail( $userinfo, $id_token = '' ) {
+		trigger_error( __( 'Method dieWithVerifyEmail is deprecated.', 'wp-auth0' ), E_USER_DEPRECATED);
+		WP_Auth0_Email_Verification::render_die( $userinfo );
+	}
 }

--- a/lib/admin/WP_Auth0_Admin_Basic.php
+++ b/lib/admin/WP_Auth0_Admin_Basic.php
@@ -21,7 +21,8 @@ class WP_Auth0_Admin_Basic extends WP_Auth0_Admin_Generic {
 				array( 'id' => 'wpa0_client_secret_b64_encoded', 'name' => 'Client Secret Base64 Encoded', 'function' => 'render_client_secret_b64_encoded' ),
 				array( 'id' => 'wpa0_client_signing_algorithm', 'name' => 'Client Signing Algorithm', 'function' => 'render_client_signing_algorithm' ),
 				array( 'id' => 'wpa0_cache_expiration', 'name' => 'Cache Time (minutes)', 'function' => 'render_cache_expiration' ),
-				array( 'id' => 'wpa0_auth0_app_token', 'name' => 'API token', 'function' => 'render_auth0_app_token' ), //we are not going to show the token
+				array( 'id' => 'wpa0_auth0_app_token', 'name' => 'API token', 'function' => 'render_auth0_app_token' ),
+				array( 'id' => 'wpa0_auth0_app_token_audience', 'name' => 'API token audience', 'function' => 'render_auth0_app_token_audience' ),
 				array( 'id' => 'wpa0_login_enabled', 'name' => 'WordPress login enabled', 'function' => 'render_allow_wordpress_login' ),
 				array( 'id' => 'wpa0_allow_signup', 'name' => 'Allow signup', 'function' => 'render_allow_signup' ),
 
@@ -67,6 +68,21 @@ class WP_Auth0_Admin_Basic extends WP_Auth0_Admin_Generic {
     <?php
 	}
 
+	public function render_auth0_app_token_audience() {
+		$v = $this->options->get( 'auth0_app_token_audience' );
+		?>
+		<input type="text"
+		       disabled="disabled"
+		       name="<?php echo $this->options->get_options_name(); ?>[auth0_app_token_audience]"
+		       id="wpa0_auth0_app_token_audience"
+		       value="<?php echo esc_attr( $v ); ?>"
+		       class="form-control"/>
+		<div class="subelement">
+			<span class="description"><?php _e( 'Identifier value for the token above.', 'wp-auth0' ); ?></span>
+		</div>
+		<?php
+	}
+
 	public function render_client_secret() {
 		$v = $this->options->get( 'client_secret' );
 	?>
@@ -80,7 +96,7 @@ class WP_Auth0_Admin_Basic extends WP_Auth0_Admin_Generic {
 	public function render_client_secret_b64_encoded() {
 		$v = absint( $this->options->get( 'client_secret_b64_encoded' ) );
 
-		echo $this->render_a0_switch( "wpa_client_secret_b64_encoded", "client_secret_b64_encoded", 1, 1 == $v );
+		$this->render_a0_switch( "wpa_client_secret_b64_encoded", "client_secret_b64_encoded", 1, 1 == $v );
 	?>
 				<div class="subelement">
 					<span class="description"><?php echo __( 'Enable if your client secret is base64 enabled.  If you are not sure, check your clients page in Auth0.  Displayed below the client secret on that page is the text "The Client Secret is not base64 encoded.
@@ -98,7 +114,7 @@ class WP_Auth0_Admin_Basic extends WP_Auth0_Admin_Generic {
     	<option value="RS256" <?php echo ($v == "RS256" ? 'selected' : '') ?>>RS256</option>
     </select>
     <div class="subelement">
-			<span class="description"><?php echo __( 'If you use the default client secret to sign tokens, select HS256. See your clients page in Auth0. Advanced > OAuth > JsonWebToken Signature Algorithm', WPA0_LANG ); ?></span>
+			<span class="description"><?php echo __( 'If you use the default client secret to sign tokens, select HS256. See your clients page in Auth0. Advanced > OAuth > JsonWebToken Signature Algorithm', 'wp-auth0' ); ?></span>
 		</div>
   <?php  
  	}
@@ -189,6 +205,7 @@ class WP_Auth0_Admin_Basic extends WP_Auth0_Admin_Generic {
         <?php } ?>
 
         <?php echo __( 'You can manage this setting on <code>Settings > General > Membership</code>, Anyone can register', 'wp-auth0' ); ?>
+	       <a href="<?php echo admin_url( 'options-general.php' ) ?>" target="_blank"><?php _e( 'here', 'wp-auth0' ) ?></a>.
       </span>
 
     <?php
@@ -197,7 +214,7 @@ class WP_Auth0_Admin_Basic extends WP_Auth0_Admin_Generic {
 	public function render_allow_wordpress_login() {
 		$v = absint( $this->options->get( 'wordpress_login_enabled' ) );
 
-		echo $this->render_a0_switch( "wpa0_wp_login_enabled", "wordpress_login_enabled", 1, 1 == $v );
+		$this->render_a0_switch( "wpa0_wp_login_enabled", "wordpress_login_enabled", 1, 1 == $v );
 ?>
       <div class="subelement">
         <span class="description"><?php echo __( 'Enable to allow existing and new WordPress logins to work. If this site already had users before you installed Auth0, and you want them to still be able to use those logins, enable this.', 'wp-auth0' ); ?></span>
@@ -220,47 +237,86 @@ class WP_Auth0_Admin_Basic extends WP_Auth0_Admin_Generic {
 		delete_transient('WP_Auth0_JWKS_cache');
 
 	}
+
 	public function basic_validation( $old_options, $input ) {
 
-    // $input['registration_enabled'] = $old_options['registration_enabled'];
+		if ( wp_cache_get( 'doing_db_update', WPA0_CACHE_GROUP ) ) {
+			return $input;
+		}
 
 		$input['client_id'] = sanitize_text_field( $input['client_id'] );
 		$input['cache_expiration'] = absint( $input['cache_expiration'] );
-		$input['wordpress_login_enabled'] = ( isset( $input['wordpress_login_enabled'] ) ? $input['wordpress_login_enabled'] : 0 );
+
+		$input['wordpress_login_enabled'] = ( isset( $input['wordpress_login_enabled'] )
+			? $input['wordpress_login_enabled']
+			: 0 );
+
 		$input['allow_signup'] = ( isset( $input['allow_signup'] ) ? $input['allow_signup'] : 0 );
 
 		// Only replace the secret or token if a new value was set. If not, we will keep the last one entered.
-		$input['client_secret'] = ( !empty( $input['client_secret'] ) ? $input['client_secret'] : $old_options['client_secret'] );
-		$input['client_secret_b64_encoded'] = ( isset( $input['client_secret_b64_encoded'] ) ? $input['client_secret_b64_encoded'] == 1 : false );
-		$input['auth0_app_token'] = ( !empty( $input['auth0_app_token'] ) ? $input['auth0_app_token'] : $old_options['auth0_app_token'] );
+		$input['client_secret'] = ( ! empty( $input['client_secret'] )
+			? $input['client_secret']
+			: $old_options['client_secret'] );
 
-		$error = '';
-		$completeBasicData = true;
+		$input['client_secret_b64_encoded'] = ( isset( $input['client_secret_b64_encoded'] )
+			? $input['client_secret_b64_encoded'] == 1
+			: false );
+
+		$input['auth0_app_token'] = ( ! empty( $input['auth0_app_token'] )
+			? $input['auth0_app_token']
+			: $old_options['auth0_app_token'] );
+
+		// If we have an app token, get and store the audience
+		if ( ! empty( $input['auth0_app_token'] ) && ! empty( $input['client_secret'] ) ) {
+
+			$a0_options = WP_Auth0_Options::Instance();
+
+			try {
+				$token_parts = explode( '.', $input['auth0_app_token'] );
+				$header = json_decode( JWT::urlsafeB64Decode( $token_parts[0] ) );
+
+				$decoded_token = JWT::decode(
+					$input['auth0_app_token'],
+					$a0_options->convert_client_secret_to_key(
+						$input['client_secret'],
+						$input['client_secret_b64_encoded'],
+						'RS256' === $header->alg,
+						$input['domain']
+					),
+					array( $header->alg )
+				);
+
+				if ( ! empty( $decoded_token->aud ) ) {
+					$input['auth0_app_token_audience'] = $decoded_token->aud;
+				}
+
+			} catch ( Exception $e ) {
+				WP_Auth0_ErrorManager::insert_auth0_error( __METHOD__, $e->getMessage() );
+				$this->add_validation_error( $e->getMessage() );
+			}
+
+			if ( get_option( 'wp_auth0_client_grant_failed' ) ) {
+				$db_manager = new WP_Auth0_DBManager( WP_Auth0_Options::Instance() );
+				$db_manager->install_db( 16, $input['auth0_app_token'] );
+			}
+		}
+
 		if ( empty( $input['domain'] ) ) {
-			$error = __( 'You need to specify domain', 'wp-auth0' );
-			$this->add_validation_error( $error );
-			$completeBasicData = false;
+			$this->add_validation_error( __( 'You need to specify domain', 'wp-auth0' ) );
 		}
 
 		if ( empty( $input['client_id'] ) ) {
-			$error = __( 'You need to specify a client id', 'wp-auth0' );
-			$this->add_validation_error( $error );
-			$completeBasicData = false;
+			$this->add_validation_error( __( 'You need to specify a client id', 'wp-auth0' ) );
 		}
+
 		if ( empty( $input['client_secret'] ) && empty( $old_options['client_secret'] ) ) {
-			$error = __( 'You need to specify a client secret', 'wp-auth0' );
-			$this->add_validation_error( $error );
-			$completeBasicData = false;
+			$this->add_validation_error( __( 'You need to specify a client secret', 'wp-auth0' ) );
 		}
 
 		if ( empty( $input['cache_expiration'] ) && empty( $old_options['cache_expiration'] ) ) {
-			$error = __( 'You need to specify a number for cache expiration', WPA0_LANG );
-			$this->add_validation_error( $error );
-			$completeBasicData = false;
+			$this->add_validation_error( __( 'You need to specify a number for cache expiration', 'wp-auth0' ) );
 		}
 
 		return $input;
 	}
-
-
 }

--- a/lib/initial-setup/WP_Auth0_InitialSetup.php
+++ b/lib/initial-setup/WP_Auth0_InitialSetup.php
@@ -51,6 +51,10 @@ class WP_Auth0_InitialSetup {
 			add_action( 'admin_notices', array( $this, 'cant_create_client_message' ) );
 		}
 
+		if ( isset( $_REQUEST['error'] ) && 'cant_create_client_grant' == $_REQUEST['error'] ) {
+			add_action( 'admin_notices', array( $this, 'cant_create_client_grant_message' ) );
+		}
+
 		if ( isset( $_REQUEST['error'] ) && 'cant_exchange_token' == $_REQUEST['error'] ) {
 			add_action( 'admin_notices', array( $this, 'cant_exchange_token_message' ) );
 		}
@@ -161,13 +165,31 @@ class WP_Auth0_InitialSetup {
   		<?php
 	}
 
+	public function cant_create_client_grant_message() {
+		?>
+		<div id="message" class="error">
+			<p>
+				<strong>
+					<?php echo __( 'There was an error creating the necessary client grants. ', 'wp-auth0' ); ?>
+					<?php echo __( 'Go to your Auth0 dashboard > APIs > Auth0 Management API > Non-Interactive Clients'
+					               . ' tab and authorize the client for this site. ', 'wp-auth0' ); ?>
+					<?php echo __( 'Make sure to add the following scopes: ', 'wp-auth0' ); ?>
+					<code><?php echo implode( '</code>, <code>', WP_Auth0_Api_Client::ConsentRequiredScopes() ) ?></code>
+					<?php echo __( 'You can also check the ', 'wp-auth0' ); ?>
+					<a target="_blank" href="<?php echo admin_url( 'admin.php?page=wpa0-errors' ); ?>"><?php echo __( 'Error log', 'wp-auth0' ); ?></a> <?php echo __( ' for more information.' ); ?>
+				</strong>
+			</p>
+		</div>
+		<?php
+	}
+
 	public function cant_exchange_token_message() {
 		$domain = $this->a0_options->get( 'domain' );
 ?>
   		<div id="message" class="error">
   			<p>
   				<strong>
-  					<?php echo __( 'There was an error retieving your auth0 credentials. Check the ', 'wp-auth0' ); ?>
+  					<?php echo __( 'There was an error retrieving your auth0 credentials. Check the ', 'wp-auth0' ); ?>
   					<a target="_blank" href="<?php echo admin_url( 'admin.php?page=wpa0-errors' ); ?>"><?php echo __( 'Error log', 'wp-auth0' ); ?></a>
   					<?php echo __( ' for more information. Please check that your sever has internet access and can reach "https://'.$domain.'/" ', 'wp-auth0' ); ?>
   				</strong>

--- a/lib/initial-setup/WP_Auth0_InitialSetup_Consent.php
+++ b/lib/initial-setup/WP_Auth0_InitialSetup_Consent.php
@@ -20,6 +20,7 @@ class WP_Auth0_InitialSetup_Consent {
 
 		$this->a0_options->set( 'auth0_app_token', $access_token );
 		$this->a0_options->set( 'domain', $domain );
+		$this->a0_options->set_audience_with_token( $access_token );
 
 		$this->hasInternetConnection = $hasInternetConnection;
 
@@ -88,10 +89,13 @@ class WP_Auth0_InitialSetup_Consent {
 
 	public function consent_callback( $name ) {
 
-		$app_token = $this->a0_options->get( 'auth0_app_token' );
 		$domain = $this->a0_options->get( 'domain' );
-
+		$app_token = $this->a0_options->get( 'auth0_app_token' );
 		$client_id = trim( $this->a0_options->get( 'client_id' ) );
+
+		/*
+		 * Create Client
+		 */
 
 		$should_create_and_update_connection = false;
 
@@ -110,6 +114,10 @@ class WP_Auth0_InitialSetup_Consent {
 
 			$client_id = $client_response->client_id;
 		}
+
+		/*
+		 * Create Connection
+		 */
 
 		$db_connection_name = 'DB-' . get_auth0_curatedBlogName();
 		$connection_exists = false;
@@ -166,9 +174,18 @@ class WP_Auth0_InitialSetup_Consent {
 
 		}
 
+		/*
+		 * Create Client Grant
+		 */
+
+		$grant_response = WP_Auth0_Api_Client::create_client_grant( $app_token, $client_id );
+
+		if ( FALSE === $grant_response ) {
+			wp_redirect( admin_url( 'admin.php?page=wpa0&error=cant_create_client_grant' ) );
+			exit;
+		}
+
 		wp_redirect( admin_url( 'admin.php?page=wpa0-setup&step=2&profile=' . $this->state ) );
 		exit();
-
 	}
-
 }


### PR DESCRIPTION
Clients used with this plugin need to have a specific grant to the management API in order to handle certain actions like verification emails. The client also needs to have an app_type set, in this case "Regular Web Application."

This pull request:

- Adds the app_type and client_grant to the client creation process when the plugin is first installed
- Updates the DB version to 16 and attempts to fix the app_type and client_grant
- If this process fails, a flag is set as an option and a banner with instructions will appear until the process is complete
- Added a process to extra the audience from a manually-added app token during validation
- Added a check for the client grant when an app token is saved to re-run the client_grant process
- A few spelling and formatting errors throughout