### PR TITLE
Added use Management API for user data

### DIFF
--- a/lib/WP_Auth0_DBManager.php
+++ b/lib/WP_Auth0_DBManager.php
@@ -238,17 +238,7 @@ class WP_Auth0_DBManager {
 
 		if ( get_option( 'wp_auth0_client_grant_failed' ) && current_user_can( 'update_plugins' ) ) {
 
-			$token = WP_Auth0_Api_Client::get_token(
-				WP_Auth0_Api_Client::get_connect_info( 'domain' ),
-				WP_Auth0_Api_Client::get_connect_info( 'client_id' ),
-				WP_Auth0_Api_Client::get_connect_info('client_secret' ),
-				'client_credentials',
-				array(
-					'audience' => WP_Auth0_Api_Client::get_connect_info( 'audience' )
-				)
-			);
-
-			if ( 200 === $token[ 'response' ][ 'code' ] ) {
+			if ( WP_Auth0_Api_Client::get_client_token() ) {
 				delete_option( 'wp_auth0_client_grant_failed' );
 			} else {
 				?>

--- a/lib/WP_Auth0_Email_Verification.php
+++ b/lib/WP_Auth0_Email_Verification.php
@@ -34,7 +34,7 @@ class WP_Auth0_Email_Verification {
 			time(),
 			__( '← Login', 'wp-auth0' ),
 			esc_url( admin_url( 'admin-ajax.php' ) ),
-			esc_js( $userinfo->sub ),
+			esc_js( isset( $userinfo->user_id ) ? $userinfo->user_id : $userinfo->sub ),
 			esc_js( wp_create_nonce( self::RESEND_NONCE_ACTION ) ),
 			esc_js( __( 'Something went wrong; please login and try again.', 'wp-auth0' ) ),
 			esc_js( __( 'Email successfully re-sent to ' . $userinfo->email . '!', 'wp-auth0' ) ),
@@ -59,26 +59,7 @@ class WP_Auth0_Email_Verification {
 			die();
 		}
 
-		$connect_info = WP_Auth0_Api_Client::get_connect_info();
-
-		$token = WP_Auth0_Api_Client::get_token(
-			$connect_info['domain'],
-			$connect_info['client_id'],
-			$connect_info['client_secret'],
-			'client_credentials',
-			array(
-				'audience' => $connect_info['audience']
-			)
-		);
-
-		$tokenDecoded = json_decode( $token['body'] );
-
-		if ( empty( $tokenDecoded->access_token ) ) {
-			die();
-		}
-
 		echo WP_Auth0_Api_Client::resend_verification_email(
-			$tokenDecoded->access_token,
 			sanitize_text_field( $_POST['sub'] )
 		) ? 'success' : 'fail';
 

--- a/lib/WP_Auth0_Lock10_Options.php
+++ b/lib/WP_Auth0_Lock10_Options.php
@@ -242,7 +242,7 @@ class WP_Auth0_Lock10_Options {
       ),
     );
 
-    $extraOptions["auth"]["params"]["scope"] = "openid email identities ";
+    $extraOptions["auth"]["params"]["scope"] = "openid ";
 
     if ( $this->get_auth0_implicit_workflow() ) {
       $extraOptions["auth"]["params"]["scope"] .= "name email picture nickname email_verified";

--- a/lib/WP_Auth0_Lock_Options.php
+++ b/lib/WP_Auth0_Lock_Options.php
@@ -221,7 +221,7 @@ class WP_Auth0_Lock_Options {
 			"authParams"    => array( "state" => $state ),
 		);
 
-		$extraOptions["authParams"]["scope"] = "openid email identities ";
+		$extraOptions["authParams"]["scope"] = "openid ";
 
 		if ( $this->get_auth0_implicit_workflow() ) {
 			$extraOptions["authParams"]["scope"] .= "name email nickname email_verified identities";


### PR DESCRIPTION
This PR changes where user information comes from on login. Switching from the Auth API /userinfo to the Management API /users/user_id to get identities. 

* Added WP_Auth0_Api_Client::get_client_token() to quickly get a management token
* Updated WP_Auth0_Api_Client::resend_verification_email() to use this token function
* Replaced WP_Auth0_Api_Client::get_user_info() with WP_Auth0_Api_Client::get_user() to return user information during login (management API access is acquired as part of this upgrade), which fixes identities being returned
* Added read:users as a required scope
* Updated DB upgrade to use new WP_Auth0_Api_Client::get_client_token() function to confirm that a client_credentials token can be returned