### PR TITLE
Fixed automatic setup process for public sites

### DIFF
--- a/lib/WP_Auth0_Api_Client.php
+++ b/lib/WP_Auth0_Api_Client.php
@@ -46,8 +46,10 @@ class WP_Auth0_Api_Client {
 				'domain' => $a0_options->get( 'domain' ),
 				'client_id' => $a0_options->get( 'client_id' ),
 				'client_secret' => $a0_options->get( 'client_secret' ),
+				'client_secret_encoded' => $a0_options->get( 'client_secret_b64_encoded' ),
 				'connection' => $a0_options->get( 'db_connection_name' ),
-				'audience' => $a0_options->get( 'auth0_app_token_audience' ),
+				'app_token' => $a0_options->get( 'auth0_app_token' ),
+				'audience' => $a0_options->get( 'api_audience' ),
 			);
 
 			if ( empty( self::$connect_info[ 'audience' ] ) ) {
@@ -214,13 +216,13 @@ class WP_Auth0_Api_Client {
 	public static function get_client_token() {
 
 		$response = wp_remote_post( self::get_endpoint( 'oauth/token' ), array(
-				'headers' => self::get_headers( '', 'application/x-www-form-urlencoded' ),
-				'body' => array(
+				'headers' => self::get_headers(),
+				'body' => json_encode( array(
 					'client_id' => self::get_connect_info( 'client_id' ),
 					'client_secret' => self::get_connect_info( 'client_secret' ),
 					'audience' => self::get_connect_info( 'audience' ),
 					'grant_type' => 'client_credentials',
-				),
+				) ),
 			) );
 
 		if ( $response instanceof WP_Error ) {
@@ -912,6 +914,9 @@ class WP_Auth0_Api_Client {
 		return array(
 			'create:clients',
 			'update:clients',
+
+			'create:client_grants',
+			'update:client_grants',
 
 			'update:connections',
 			'create:connections',

--- a/lib/WP_Auth0_Options.php
+++ b/lib/WP_Auth0_Options.php
@@ -81,31 +81,6 @@ class WP_Auth0_Options extends WP_Auth0_Options_Generic {
 			return $is_encoded ? JWT::urlsafeB64Decode( $secret ) : $secret;
 		}
 	}
-
-	/**
-	 * Update the app token audience with one from a decoded JWT
-	 *
-	 * @param string $jwt - a valid JWT
-	 *
-	 * @return bool
-	 */
-	public function set_audience_with_token( $jwt ) {
-		$audience = '';
-		try {
-			$decoded_token = JWT::decode(
-				$jwt,
-				$this->get_client_secret_as_key(),
-				array( $this->get_client_signing_algorithm() )
-			);
-			if ( ! empty( $decoded_token->aud ) ) {
-				$audience = $decoded_token->aud;
-			}
-		} catch ( Exception $e ) {
-			WP_Auth0_ErrorManager::insert_auth0_error( __METHOD__, $e->getMessage() );
-		}
-		$this->set( 'auth0_app_token_audience', $audience );
-		return ! empty( $audience );
-	}
 	
 	protected function defaults() {
 		return array(
@@ -151,7 +126,7 @@ class WP_Auth0_Options extends WP_Auth0_Options_Generic {
 			'gravatar' => true,
 			'jwt_auth_integration' => false,
 			'auth0_app_token' => null,
-			'auth0_app_token_audience' => null,
+			'api_audience' => null,
 			'mfa' => null,
 			'fullcontact' => null,
 			'fullcontact_rule' => null,

--- a/lib/admin/WP_Auth0_Admin_Basic.php
+++ b/lib/admin/WP_Auth0_Admin_Basic.php
@@ -22,7 +22,7 @@ class WP_Auth0_Admin_Basic extends WP_Auth0_Admin_Generic {
 				array( 'id' => 'wpa0_client_signing_algorithm', 'name' => 'Client Signing Algorithm', 'function' => 'render_client_signing_algorithm' ),
 				array( 'id' => 'wpa0_cache_expiration', 'name' => 'Cache Time (minutes)', 'function' => 'render_cache_expiration' ),
 				array( 'id' => 'wpa0_auth0_app_token', 'name' => 'API token', 'function' => 'render_auth0_app_token' ),
-				array( 'id' => 'wpa0_auth0_app_token_audience', 'name' => 'API token audience', 'function' => 'render_auth0_app_token_audience' ),
+				array( 'id' => 'wpa0_api_audience', 'name' => 'API Identifier (audience)', 'function' => 'render_api_audience' ),
 				array( 'id' => 'wpa0_login_enabled', 'name' => 'WordPress login enabled', 'function' => 'render_allow_wordpress_login' ),
 				array( 'id' => 'wpa0_allow_signup', 'name' => 'Allow signup', 'function' => 'render_allow_signup' ),
 
@@ -68,17 +68,14 @@ class WP_Auth0_Admin_Basic extends WP_Auth0_Admin_Generic {
     <?php
 	}
 
-	public function render_auth0_app_token_audience() {
-		$v = $this->options->get( 'auth0_app_token_audience' );
+	public function render_api_audience() {
+		$v = $this->options->get( 'api_audience' );
 		?>
-		<input type="text"
-		       disabled="disabled"
-		       name="<?php echo $this->options->get_options_name(); ?>[auth0_app_token_audience]"
-		       id="wpa0_auth0_app_token_audience"
-		       value="<?php echo esc_attr( $v ); ?>"
-		       class="form-control"/>
+		<input type="text" name="<?php
+			echo $this->options->get_options_name(); ?>[api_audience]" id="wpa0_api_audience" value="<?php
+			echo esc_attr( $v ); ?>"/>
 		<div class="subelement">
-			<span class="description"><?php _e( 'Identifier value for the token above.', 'wp-auth0' ); ?></span>
+			<span class="description"><?php _e( 'API Identifier for the management API. ', 'wp-auth0' ); ?></span>
 		</div>
 		<?php
 	}
@@ -266,39 +263,17 @@ class WP_Auth0_Admin_Basic extends WP_Auth0_Admin_Generic {
 			? $input['auth0_app_token']
 			: $old_options['auth0_app_token'] );
 
+		if ( ! empty( $input['domain'] ) ) {
+
+			$input['api_audience'] = ( ! empty( $input['api_audience'] )
+				? $input['api_audience']
+				: 'https://' . $input['domain'] . '/api/v2/' );
+		}
+
 		// If we have an app token, get and store the audience
-		if ( ! empty( $input['auth0_app_token'] ) && ! empty( $input['client_secret'] ) ) {
-
-			$a0_options = WP_Auth0_Options::Instance();
-
-			try {
-				$token_parts = explode( '.', $input['auth0_app_token'] );
-				$header = json_decode( JWT::urlsafeB64Decode( $token_parts[0] ) );
-
-				$decoded_token = JWT::decode(
-					$input['auth0_app_token'],
-					$a0_options->convert_client_secret_to_key(
-						$input['client_secret'],
-						$input['client_secret_b64_encoded'],
-						'RS256' === $header->alg,
-						$input['domain']
-					),
-					array( $header->alg )
-				);
-
-				if ( ! empty( $decoded_token->aud ) ) {
-					$input['auth0_app_token_audience'] = $decoded_token->aud;
-				}
-
-			} catch ( Exception $e ) {
-				WP_Auth0_ErrorManager::insert_auth0_error( __METHOD__, $e->getMessage() );
-				$this->add_validation_error( $e->getMessage() );
-			}
-
-			if ( get_option( 'wp_auth0_client_grant_failed' ) ) {
-				$db_manager = new WP_Auth0_DBManager( WP_Auth0_Options::Instance() );
-				$db_manager->install_db( 16, $input['auth0_app_token'] );
-			}
+		if ( ! empty( $input['auth0_app_token'] ) && get_option( 'wp_auth0_client_grant_failed' ) ) {
+			$db_manager = new WP_Auth0_DBManager( WP_Auth0_Options::Instance() );
+			$db_manager->install_db( 16, $input['auth0_app_token'] );
 		}
 
 		if ( empty( $input['domain'] ) ) {
@@ -311,10 +286,6 @@ class WP_Auth0_Admin_Basic extends WP_Auth0_Admin_Generic {
 
 		if ( empty( $input['client_secret'] ) && empty( $old_options['client_secret'] ) ) {
 			$this->add_validation_error( __( 'You need to specify a client secret', 'wp-auth0' ) );
-		}
-
-		if ( empty( $input['cache_expiration'] ) && empty( $old_options['cache_expiration'] ) ) {
-			$this->add_validation_error( __( 'You need to specify a number for cache expiration', 'wp-auth0' ) );
 		}
 
 		return $input;

--- a/lib/initial-setup/WP_Auth0_InitialSetup_Consent.php
+++ b/lib/initial-setup/WP_Auth0_InitialSetup_Consent.php
@@ -20,7 +20,6 @@ class WP_Auth0_InitialSetup_Consent {
 
 		$this->a0_options->set( 'auth0_app_token', $access_token );
 		$this->a0_options->set( 'domain', $domain );
-		$this->a0_options->set_audience_with_token( $access_token );
 
 		$this->hasInternetConnection = $hasInternetConnection;
 

--- a/templates/initial-setup/connection_profile.php
+++ b/templates/initial-setup/connection_profile.php
@@ -88,13 +88,14 @@
               </div>
               <div class="modal-body">
                 <p>
-                  <?php _e( 'To complete the plugin\'s initial setup, you will need to enter your account subdomain:', 'wp-auth0' ); ?>
+                  <?php _e( 'To complete the plugin\'s initial setup, you will need to enter your tenant Domain:', 'wp-auth0' ); ?>
                 </p>
                 <input type="text" name="domain" placeholder="youraccount.auth0.com" />
                 <br><br>
                 <p>
-                  <?php _e( 'And manually create an api token on the', 'wp-auth0' ); ?>
-                  <a href="https://auth0.com/docs/api/v2" target="_blank"><?php echo __( 'token generator', 'wp-auth0' ); ?></a>
+                  <?php _e( 'And manually create an api token with the', 'wp-auth0' ); ?>
+                  <a href="https://auth0.com/docs/api/management/v2/tokens#get-a-token-manually" target="_blank">
+	                  <?php echo __( 'token generator', 'wp-auth0' ); ?></a>
                   <?php _e( ' and paste it here:', 'wp-auth0' ); ?>
                 </p>
                 <input type="text" name="apitoken" autocomplete="off" />


### PR DESCRIPTION
Main goal here is moving from storing the API audience from the API token to creating a settings field to hold one with the system Management API audience (most likely to be used in the vast majority of installs) as a default. 

Also:

* Fixed up `WP_Auth0_Api_Client::get_client_token()` do use recommended Content-Type header
* Updated 2 docs links, relevant to the updates in this release
* Removed empty cache_expiration setting check (can be 0 for no caching)
* Added client update procedure from DB v15 to DB v16 to catch `site_url()` update