### PR TITLE
Migration tokens only use HS256

### DIFF
--- a/lib/WP_Auth0_Routes.php
+++ b/lib/WP_Auth0_Routes.php
@@ -124,7 +124,7 @@ EOT;
 				throw new Exception( 'Unauthorized: missing authorization header' );
 			}
 
-			$token = JWT::decode( $authorization, $secret, array(  $this->a0_options->get_client_signing_algorithm() ) );
+			$token = JWT::decode( $authorization, $secret, array( 'HS256' ) );
 
 			if ( $token->jti != $token_id ) {
 				throw new Exception( 'Invalid token id' );


### PR DESCRIPTION
Changing allowed algorithm for migration token to always be HS256