### PR TITLE
Fixed Client Grant Types during update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## [3.5.0](https://github.com/auth0/wp-auth0/tree/3.5.0) (2018-01-25)
 [Full Changelog](https://github.com/auth0/wp-auth0/compare/3.4.0...3.5.0)
 
+**Please note:** This is a major update that requires changes to your Auth0 Dashboard to be completed. You can save a new [API token](https://auth0.com/docs/api/management/v2/tokens#get-a-token-manually) in your Basic settings in wp-admin before upgrading and the changes will be made automatically during the update. Otherwise, after upgrading, please review your [Client Advanced Settings](https://auth0.com/docs/cms/wordpress/configuration#client-setup), specifically your Grant Types, and [authorize your Client for the Management API](https://auth0.com/docs/cms/wordpress/configuration#authorize-the-client-for-the-management-api). 
+
 **Changed**
 - updating CDN URLs for Lock and Auth.js [\#365](https://github.com/auth0/wp-auth0/pull/365) ([joshcanhelp](https://github.com/joshcanhelp))
 - Changing home_url() to site_url(), wp_login_url(), and wp_logout_url()  [\#360](https://github.com/auth0/wp-auth0/pull/360) ([joshcanhelp](https://github.com/joshcanhelp))

--- a/README.md
+++ b/README.md
@@ -9,6 +9,10 @@ Demo: <http://auth0wp.azurewebsites.net>
 
 Documentation: <https://auth0.com/docs/cms>
 
+## Important note on 3.5.0 and 3.5.1
+
+This is a major update that requires changes to your Auth0 Dashboard to be completed. You can save a new [API token](https://auth0.com/docs/api/management/v2/tokens#get-a-token-manually) in your Basic settings in wp-admin before upgrading and the changes will be made automatically during the update. Otherwise, please review your [Client Advanced Settings](https://auth0.com/docs/cms/wordpress/configuration#client-setup), specifically your Grant Types, and [authorize your Client for the Management API](https://auth0.com/docs/cms/wordpress/configuration#authorize-the-client-for-the-management-api). 
+
 ## Contributions
 
 All PR should be done towards the `dev` branch.

--- a/WP_Auth0.php
+++ b/WP_Auth0.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: PLUGIN_NAME
  * Description: PLUGIN_DESCRIPTION
- * Version: 3.5.0
+ * Version: 3.5.1
  * Author: Auth0
  * Author URI: https://auth0.com
  */
@@ -10,8 +10,8 @@ define( 'WPA0_PLUGIN_FILE', __FILE__ );
 define( 'WPA0_PLUGIN_DIR', trailingslashit( plugin_dir_path( __FILE__ ) ) );
 define( 'WPA0_PLUGIN_URL', trailingslashit( plugin_dir_url( __FILE__ ) ) );
 define( 'WPA0_LANG', 'wp-auth0' ); // deprecated; do not use for translations
-define( 'AUTH0_DB_VERSION', 16 );
-define( 'WPA0_VERSION', '3.5.0' );
+define( 'AUTH0_DB_VERSION', 17 );
+define( 'WPA0_VERSION', '3.5.1' );
 define( 'WPA0_CACHE_GROUP', 'wp_auth0' );
 
 /**

--- a/lib/admin/WP_Auth0_Admin_Basic.php
+++ b/lib/admin/WP_Auth0_Admin_Basic.php
@@ -271,9 +271,16 @@ class WP_Auth0_Admin_Basic extends WP_Auth0_Admin_Generic {
 		}
 
 		// If we have an app token, get and store the audience
-		if ( ! empty( $input['auth0_app_token'] ) && get_option( 'wp_auth0_client_grant_failed' ) ) {
+		if ( ! empty( $input['auth0_app_token'] ) ) {
 			$db_manager = new WP_Auth0_DBManager( WP_Auth0_Options::Instance() );
-			$db_manager->install_db( 16, $input['auth0_app_token'] );
+
+			if ( get_option( 'wp_auth0_client_grant_failed' ) ) {
+				$db_manager->install_db( 16, $input['auth0_app_token'] );
+			}
+
+			if ( get_option( 'wp_auth0_grant_types_failed' ) ) {
+				$db_manager->install_db( 17, $input['auth0_app_token'] );
+			}
 		}
 
 		if ( empty( $input['domain'] ) ) {


### PR DESCRIPTION
Older legacy clients may not have the `client_credentials` Grant Type activated in their Client Advanced settings. This will prevent them from getting a Management API token, breaking functionality in a number of places. This can be remedied manually in **[Client Advanced Settings](https://auth0.com/docs/cms/wordpress/configuration#client-setup) > Grant Types** tab, activating the **Client Credentials** type. 

This PR adds a DB version and attempts to update this automatically if there is a valid API token saved in wp-admin. It also enforces the correct `grant_types` during client creation and adds a note to the README and CHANGELOG regarding the 3.5.0 update.