### PR TITLE
Fixed wrong title and icon for login widget

### DIFF
--- a/lib/WP_Auth0_Lock10_Options.php
+++ b/lib/WP_Auth0_Lock10_Options.php
@@ -254,8 +254,7 @@ class WP_Auth0_Lock10_Options {
       $extraOptions["auth"]["redirectUrl"] = $this->get_code_callback_url();
     }
 
-    $options_obj = array_merge_recursive( $extraOptions, $options_obj  );
-    $options_obj = array_merge_recursive( $options_obj , $extended_settings );
+    $options_obj = array_replace_recursive( $extraOptions, $options_obj, $extended_settings );
 
     if ( ! $this->show_as_modal() ) {
       $options_obj['container'] = 'auth0-login-form';

--- a/lib/WP_Auth0_Lock_Options.php
+++ b/lib/WP_Auth0_Lock_Options.php
@@ -230,8 +230,7 @@ class WP_Auth0_Lock_Options {
 			$extraOptions["callbackURL"] = $this->get_code_callback_url();
 		}
 
-		$options_obj = array_merge( $extraOptions, $options_obj  );
-		$options_obj = array_merge( $options_obj , $extended_settings );
+		$options_obj = array_merge( $extraOptions, $options_obj, $extended_settings );
 
 		if ( ! $this->show_as_modal() ) {
 			$options_obj['container'] = 'auth0-login-form';


### PR DESCRIPTION
Swapped in `array_replace_recursive` instead of `array_merge_recursive` to avoid an array being created that the Lock widget couldn't understand. 