### PR TITLE
Make state work after SSO login

### DIFF
--- a/WP_Auth0.php
+++ b/WP_Auth0.php
@@ -202,6 +202,7 @@ class WP_Auth0 {
 		$qvars[] = 'a0_action';
 		$qvars[] = 'auth0';
 		$qvars[] = 'code';
+		$qvars[] = 'state';
 		return $qvars;
 	}
 

--- a/lib/WP_Auth0_LoginManager.php
+++ b/lib/WP_Auth0_LoginManager.php
@@ -271,6 +271,8 @@ class WP_Auth0_LoginManager {
         } else {
           if ( null !== $stateFromGet && isset( $stateFromGet->redirect_to ) ) {
             $redirectURL = $stateFromGet->redirect_to;
+          } elseif ( !empty($state) ) {
+            $redirectURL = $state;
           } else {
             $redirectURL = $this->a0_options->get( 'default_login_redirection' );
           }


### PR DESCRIPTION
This pull request rebases and replaces https://github.com/auth0/wp-auth0/pull/303.

I'm using this to redirect to a specific page after logging in via an Auth0 SSO link:
```
https://uuid.auth0.com/authorize/?connection_id=google-oauth2&client_id=xxx&redirect_uri=https://mywordpresssite.com/index.php?auth0=1&response_type=code&state=https%3A%2F%2Fmywordpresssite.com%2Fwp-admin%2Fedit.php%3Fpost_type%3Dpost
```