### PR TITLE
Improved setup wizard client create process

### DIFF
--- a/WP_Auth0.php
+++ b/WP_Auth0.php
@@ -490,6 +490,15 @@ if ( ! function_exists( 'get_auth0_curatedBlogName' ) ) {
 
     $name = get_bloginfo( 'name' );
 
+    // WordPress can have a blank site title, which will cause initial client creation to fail
+    if ( empty( $name ) ) {
+	    $name = parse_url( home_url(), PHP_URL_HOST );
+
+	    if ( $port = parse_url( home_url(), PHP_URL_PORT ) ) {
+		    $name .= ':' . $port;
+	    }
+    }
+
     $name = preg_replace("/[^A-Za-z0-9 ]/", '', $name);
     $name = preg_replace("/\s+/", ' ', $name);
 		$name = str_replace(" ", "-", $name);

--- a/lib/WP_Auth0_Api_Client.php
+++ b/lib/WP_Auth0_Api_Client.php
@@ -480,7 +480,7 @@ class WP_Auth0_Api_Client {
 		) );
 
 		if ( $response instanceof WP_Error ) {
-			WP_Auth0_ErrorManager::insert_auth0_error( __METHOD__, $response );
+			WP_Auth0_ErrorManager::insert_auth0_error( __METHOD__, $response->get_error_message() );
 			error_log( $response->get_error_message() );
 			return false;
 		}
@@ -665,11 +665,6 @@ class WP_Auth0_Api_Client {
 			error_log( $response['body'] );
 			return false;
 		}
-
-		WP_Auth0_ErrorManager::insert_auth0_error(
-			__METHOD__,
-			'Client Grant has been successfully created!'
-		);
 
 		return json_decode( $response['body'] );
 	}

--- a/lib/WP_Auth0_DBManager.php
+++ b/lib/WP_Auth0_DBManager.php
@@ -145,9 +145,9 @@ class WP_Auth0_DBManager {
 			// Update Client
 			if (!empty($client_id) && !empty($domain)) {
 				$payload = array(
-					"cross_origin_auth" => true,
-					"cross_origin_loc" => site_url('index.php?auth0fallback=1','https'),
-					"web_origins" => ( home_url() === site_url() ? array( home_url() ) : array( home_url(), site_url() ) )
+					'cross_origin_auth' => true,
+					'cross_origin_loc' => $options->get_cross_origin_loc(),
+					'web_origins' => $options->get_web_origins(),
 				);
 				WP_Auth0_Api_Client::update_client($domain, $app_token, $client_id, $sso, $payload);
 				$options->set('client_signing_algorithm', 'HS256');
@@ -199,14 +199,14 @@ class WP_Auth0_DBManager {
 				$payload = array(
 					'app_type' => 'regular_web',
 					'callbacks' => array(
-						site_url( 'index.php?auth0=1' ),
+						$options->get_wp_auth0_url(),
 						wp_login_url()
 					),
 
 					// Duplicate of DB version 15 upgrade to account for site_url() changes
 					'cross_origin_auth' => true,
-					'cross_origin_loc' => site_url('index.php?auth0fallback=1','https'),
-					'web_origins' => ( home_url() === site_url() ? array( home_url() ) : array( home_url(), site_url() ) ),
+					'cross_origin_loc' => $options->get_cross_origin_loc(),
+					'web_origins' => $options->get_web_origins(),
 				);
 
 				// Update the WP-created client

--- a/lib/WP_Auth0_DBManager.php
+++ b/lib/WP_Auth0_DBManager.php
@@ -221,6 +221,14 @@ class WP_Auth0_DBManager {
 			if ( $client_grant_created ) {
 				delete_option( 'wp_auth0_client_grant_failed' );
 				update_option( 'wp_auth0_client_grant_success', 1 );
+
+				if ( 409 !== $client_grant_created[ 'statusCode' ] ) {
+					WP_Auth0_ErrorManager::insert_auth0_error(
+						__METHOD__,
+						'Client Grant has been successfully created!'
+					);
+				}
+
 			} else {
 				WP_Auth0_ErrorManager::insert_auth0_error( __METHOD__, sprintf(
 					__( 'Unable to automatically create Client Grant. Please go to your Auth0 Dashboard '

--- a/lib/WP_Auth0_Lock10_Options.php
+++ b/lib/WP_Auth0_Lock10_Options.php
@@ -33,7 +33,7 @@ class WP_Auth0_Lock10_Options {
   }
 
   public function get_code_callback_url() {
-    $protocol = $this->_get_boolean( $this->wp_options->get( 'force_https_callback' ) ) ? 'https' : '';
+    $protocol = $this->_get_boolean( $this->wp_options->get( 'force_https_callback' ) ) ? 'https' : null;
     return $this->wp_options->get_wp_auth0_url( $protocol );
   }
 

--- a/lib/WP_Auth0_Lock10_Options.php
+++ b/lib/WP_Auth0_Lock10_Options.php
@@ -33,9 +33,8 @@ class WP_Auth0_Lock10_Options {
   }
 
   public function get_code_callback_url() {
-    $protocol = $this->_get_boolean( $this->wp_options->get( 'force_https_callback' ) ) ? 'https' : null;
-
-    return site_url( 'index.php?auth0=1', $protocol );
+    $protocol = $this->_get_boolean( $this->wp_options->get( 'force_https_callback' ) ) ? 'https' : '';
+    return $this->wp_options->get_wp_auth0_url( $protocol );
   }
 
   public function get_implicit_callback_url() {

--- a/lib/WP_Auth0_Lock_Options.php
+++ b/lib/WP_Auth0_Lock_Options.php
@@ -33,9 +33,8 @@ class WP_Auth0_Lock_Options {
 	}
 
 	public function get_code_callback_url() {
-    $protocol = $this->_get_boolean( $this->wp_options->get( 'force_https_callback' ) ) ? 'https' : null;
-
-    return site_url( 'index.php?auth0=1', $protocol );
+		$protocol = $this->_get_boolean( $this->wp_options->get( 'force_https_callback' ) ) ? 'https' : '';
+		return $this->wp_options->get_wp_auth0_url( $protocol );
   }
 
 	public function get_implicit_callback_url() {

--- a/lib/WP_Auth0_Lock_Options.php
+++ b/lib/WP_Auth0_Lock_Options.php
@@ -33,7 +33,7 @@ class WP_Auth0_Lock_Options {
 	}
 
 	public function get_code_callback_url() {
-		$protocol = $this->_get_boolean( $this->wp_options->get( 'force_https_callback' ) ) ? 'https' : '';
+		$protocol = $this->_get_boolean( $this->wp_options->get( 'force_https_callback' ) ) ? 'https' : null;
 		return $this->wp_options->get_wp_auth0_url( $protocol );
   }
 

--- a/lib/WP_Auth0_Options.php
+++ b/lib/WP_Auth0_Options.php
@@ -102,12 +102,12 @@ class WP_Auth0_Options extends WP_Auth0_Options_Generic {
 	/**
 	 * Get the main site URL for Auth0 processing
 	 *
-	 * @param string $protocol - forced URL protocol, use default if empty
+	 * @param string|null $protocol - forced URL protocol, use default if empty
 	 *
 	 * @return string
 	 */
-	public function get_wp_auth0_url( $protocol = '' ) {
-		$site_url = empty( $protocol ) ? site_url( 'index.php' ) : site_url( 'index.php', $protocol );
+	public function get_wp_auth0_url( $protocol = null ) {
+		$site_url = site_url( 'index.php', $protocol );
 		return add_query_arg( 'auth0', '1', $site_url );
 	}
 

--- a/lib/WP_Auth0_Routes.php
+++ b/lib/WP_Auth0_Routes.php
@@ -58,7 +58,7 @@ class WP_Auth0_Routes {
 		$cdn = $this->a0_options->get( 'auth0js-cdn' );
 		$client_id = $this->a0_options->get( 'client_id' );
 		$domain = $this->a0_options->get( 'domain' );
-		$protocol = $this->a0_options->get( 'force_https_callback', FALSE ) ? 'https' : '';
+		$protocol = $this->a0_options->get( 'force_https_callback', FALSE ) ? 'https' : null;
 		$redirect_uri = $this->a0_options->get_wp_auth0_url( $protocol );
 		echo <<<EOT
 		<!DOCTYPE html>

--- a/lib/WP_Auth0_Routes.php
+++ b/lib/WP_Auth0_Routes.php
@@ -58,7 +58,8 @@ class WP_Auth0_Routes {
 		$cdn = $this->a0_options->get( 'auth0js-cdn' );
 		$client_id = $this->a0_options->get( 'client_id' );
 		$domain = $this->a0_options->get( 'domain' );
-		$redirect_uri = site_url( 'index.php?auth0=1', $this->a0_options->get( 'force_https_callback' ) );
+		$protocol = $this->a0_options->get( 'force_https_callback', FALSE ) ? 'https' : '';
+		$redirect_uri = $this->a0_options->get_wp_auth0_url( $protocol );
 		echo <<<EOT
 		<!DOCTYPE html>
 		<html>


### PR DESCRIPTION
* Refactored `WP_Auth0_Api_Client::create_client()` to improve the URLs being saved by default and combine create with update (`web_origins` can now be pushed during create)
* Fix for blank site title causing client create to fail [reported here](https://wordpress.org/support/topic/auth0-setup-wizard-fails/)
* Helper functions on `WP_Auth0_DBManager` to grab correct links in the correct format