### PR TITLE
added configurationBaseUrl for allow Cross-Origin Authentication

### DIFF
--- a/lib/WP_Auth0_Lock10_Options.php
+++ b/lib/WP_Auth0_Lock10_Options.php
@@ -264,7 +264,7 @@ class WP_Auth0_Lock10_Options {
     if ( ! $this->is_registration_enabled() ) {
       $options_obj['disableSignupAction'] = true;
     }
-
+    $options_obj['configurationBaseUrl'] =  'https://cdn.auth0.com';
     return $options_obj;
   }
 }

--- a/lib/WP_Auth0_Lock_Options.php
+++ b/lib/WP_Auth0_Lock_Options.php
@@ -240,7 +240,7 @@ class WP_Auth0_Lock_Options {
 		if ( ! $this->is_registration_enabled() ) {
 			$options_obj['disableSignupAction'] = true;
 		}
-
+		$options_obj['configurationBaseUrl'] =  'https://cdn.auth0.com';
 		return $options_obj;
 	}
 }


### PR DESCRIPTION
## Cross-Origin Authentication 
in order to allow the cross origin authentication in SSO, I added the configuration BaseUrl with the url of CDN.

related to issue #386 where the third party cookies cause problems.