### PR TITLE
State handling during login process for both types

### DIFF
--- a/WP_Auth0.php
+++ b/WP_Auth0.php
@@ -244,6 +244,7 @@ class WP_Auth0 {
 		$qvars[] = 'a0_action';
 		$qvars[] = 'auth0';
 		$qvars[] = 'code';
+		$qvars[] = 'state';
 		return $qvars;
 	}
 

--- a/lib/WP_Auth0_Lock10_Options.php
+++ b/lib/WP_Auth0_Lock10_Options.php
@@ -99,13 +99,12 @@ class WP_Auth0_Lock10_Options {
 
   public function get_state_obj( $redirect_to = null ) {
 
-    if ( isset( $_GET['interim-login'] ) && $_GET['interim-login'] == 1 ) {
-      $interim_login = true;
-    } else {
-      $interim_login = false;
-    }
+    $stateHandler = new WP_Auth0_State_Handler();
+    $stateObj = array(
+      'interim' => ( isset( $_GET['interim-login'] ) && $_GET['interim-login'] == 1 ),
+      'nonce' => $stateHandler->issue()
+    );
 
-    $stateObj = array( "interim" => $interim_login, "uuid" =>uniqid() );
     if ( !empty( $redirect_to ) ) {
       $stateObj["redirect_to"] = addslashes( $redirect_to );
     }

--- a/lib/WP_Auth0_Lock_Options.php
+++ b/lib/WP_Auth0_Lock_Options.php
@@ -98,12 +98,11 @@ class WP_Auth0_Lock_Options {
 	}
 
 	public function get_state_obj( $redirect_to = null ) {
-		if ( isset( $_GET['interim-login'] ) && $_GET['interim-login'] == 1 ) {
-			$interim_login = true;
-		} else {
-			$interim_login = false;
-		}
-		$stateObj = array( "interim" => $interim_login, "uuid" =>uniqid() );
+		$stateHandler = new WP_Auth0_State_Handler();
+		$stateObj = array(
+			'interim' => ( isset( $_GET['interim-login'] ) && $_GET['interim-login'] == 1 ),
+			'nonce' => $stateHandler->issue()
+		);
 		if ( !empty( $redirect_to ) ) {
 			$stateObj["redirect_to"] = addslashes( $redirect_to );
 		}

--- a/lib/WP_Auth0_LoginManager.php
+++ b/lib/WP_Auth0_LoginManager.php
@@ -66,19 +66,6 @@ class WP_Auth0_LoginManager {
       return;
     }
 
-    $current_user = get_currentauth0user();
-    $user_profile = $current_user->auth0_obj;
-
-    if ( empty( $user_profile ) ) {
-      return;
-    }
-
-    $lock_options = new WP_Auth0_Lock10_Options();
-    $cdn = $this->a0_options->get('auth0js-cdn');
-    $client_id = $this->a0_options->get( 'client_id' );
-    $domain = $this->a0_options->get( 'domain' );
-    $logout_url = wp_logout_url( get_permalink() ) . '&SLO=1';
-
     include WPA0_PLUGIN_DIR . 'templates/auth0-singlelogout-handler.php';
   }
 

--- a/lib/WP_Auth0_State_Handler.php
+++ b/lib/WP_Auth0_State_Handler.php
@@ -1,0 +1,78 @@
+<?php
+
+class WP_Auth0_State_Handler {
+
+  /**
+   * @var string
+   */
+  protected $uniqid = '';
+
+  /**
+   * @var string
+   */
+  const COOKIE_NAME = 'auth0_uniqid';
+
+  /**
+   * @var int
+   */
+  protected $cookieExpiresIn = MINUTE_IN_SECONDS;
+
+  /**
+   * WP_Auth0_State_Handler constructor.
+   */
+  public function __construct() {
+    $this->uniqid = self::generateNonce();
+  }
+
+  /**
+   * Set the unique ID for state and return
+   *
+   * @return string
+   */
+  public function issue() {
+    $this->store();
+    return $this->uniqid;
+  }
+
+  /**
+   * Set the state cookie value
+   *
+   * @return bool
+   */
+  protected function store() {
+    return setcookie( self::COOKIE_NAME, $this->uniqid, time() + $this->cookieExpiresIn );
+  }
+
+  /**
+   * Check if the stored state matches a specific value
+   *
+   * @param $state
+   *
+   * @return bool
+   */
+  public static function validate( $state ) {
+    $valid = isset( $_COOKIE[ self::COOKIE_NAME ] ) ? $_COOKIE[ self::COOKIE_NAME ] === $state : FALSE;
+    self::reset();
+    return $valid;
+  }
+
+  /**
+   * Reset the state cookie value
+   *
+   * @return bool
+   */
+  public static function reset() {
+    return setcookie( self::COOKIE_NAME, '', 0 );
+  }
+
+  /**
+   * Generate a pseudo-random ID (not cryptographically secure)
+   *
+   * @see https://stackoverflow.com/a/1846229/728480
+   *
+   * @return string
+   */
+  public static function generateNonce() {
+    return md5( uniqid( rand(), true ) );
+  }
+}

--- a/lib/WP_Auth0_State_Handler.php
+++ b/lib/WP_Auth0_State_Handler.php
@@ -5,7 +5,7 @@ class WP_Auth0_State_Handler {
   /**
    * @var string
    */
-  protected $uniqid = '';
+  protected $uniqid;
 
   /**
    * @var string

--- a/templates/auth0-singlelogout-handler.php
+++ b/templates/auth0-singlelogout-handler.php
@@ -1,28 +1,29 @@
-<script id="auth0" src="<?php echo $cdn ?>"></script>
+<?php
+$current_user = get_currentauth0user();
+if ( empty( $current_user->auth0_obj ) ) {
+  return;
+}
+?>
+<script id="auth0" src="<?php echo esc_url( $this->a0_options->get('auth0js-cdn') ) ?>"></script>
 <script type="text/javascript">
 (function(){
 
-  var uuids = '<?php echo $user_profile->user_id; ?>';
   document.addEventListener("DOMContentLoaded", function() {
     if (typeof(auth0) === 'undefined') {
       return;
     }
 
     var webAuth = new auth0.WebAuth({
-      clientID:'<?php echo $client_id; ?>',
-      domain:'<?php echo $domain; ?>'
+      clientID:'<?php echo sanitize_text_field( $this->a0_options->get( 'client_id' ) ); ?>',
+      domain:'<?php echo sanitize_text_field( $this->a0_options->get( 'domain' ) ); ?>'
     });
 
-    var options = <?php echo json_encode( $lock_options->get_sso_options() ); ?>;
-    options.responseType = 'token id_token';
-    webAuth.checkSession(options, function (err, authResult) {
-      if (err !== null) {
-        if(err.error ==='login_required') {
-          window.location = '<?php echo html_entity_decode( $logout_url ); ?>';
+    webAuth.checkSession( { 'responseType' : 'token', 'redirectUri' : window.location.href }, function ( err ) {
+            if ( err && err.error ==='login_required' ) {
+                window.location = '<?php echo esc_url( wp_logout_url( get_permalink() ) . '&SLO=1' ); ?>';
+            }
         }
-      }
-    });
-
+    );
   });
 })();
 </script>


### PR DESCRIPTION
The WordPress plugin doesn't not currently handle state checking at all. A value is set in Lock and sent back but not stored and checked. This PR:

- Adds a `WP_Auth0_State_Handler` class used to generate, store, and validate a state nonce using cookies
- Adjusts Lock to use the new nonce value and stores it as a cookie
- Checks for this value during login for both flows, redirect and implicit
- Adds a `WP_Auth0_LoginManager->die_on_login()` method to handling error message display for login errors
- Adjusts the `auth0-singlelogout-handler.php` to not pull Lock options and skip anything related to state