### PR TITLE
Fix state handling for Implicit flow

### DIFF
--- a/lib/WP_Auth0_LoginManager.php
+++ b/lib/WP_Auth0_LoginManager.php
@@ -530,7 +530,9 @@ class WP_Auth0_LoginManager {
   protected function get_state() {
 
     if ( empty( $this->state ) ) {
-      $this->state = json_decode( base64_decode( $this->query_vars( 'state' ) ) );
+      $state_val = urldecode( $this->query_vars( 'state' ) );
+      $state_val = base64_decode( $state_val );
+      $this->state = json_decode( $state_val );
     }
     return is_object( $this->state ) ? $this->state : null;
   }

--- a/lib/WP_Auth0_State_Handler.php
+++ b/lib/WP_Auth0_State_Handler.php
@@ -21,7 +21,7 @@ class WP_Auth0_State_Handler {
    * WP_Auth0_State_Handler constructor.
    */
   public function __construct() {
-    $this->uniqid = self::generateNonce();
+    $this->uniqid = isset( $_COOKIE[ self::COOKIE_NAME ] ) ? $_COOKIE[ self::COOKIE_NAME ] : self::generateNonce();
   }
 
   /**


### PR DESCRIPTION
The implicit login flow redirects to the login page to handle the
response from Auth0. This caused the cookie to be set to a new value
before the state being returned is checked. The state was also not
urldecoded so "=" chars were being received as "%3D" and were not being
base64 decoded properly.