### PR TITLE
Admin settings refactor - WP_Auth0_Admin_Generic

### DIFF
--- a/lib/WP_Auth0_Api_Operations.php
+++ b/lib/WP_Auth0_Api_Operations.php
@@ -3,7 +3,7 @@ class WP_Auth0_Api_Operations {
 
 	protected $a0_options;
 
-	public function __construct( WP_Auth0_Options $a0_options ) {
+	public function __construct( WP_Auth0_Options_Generic $a0_options ) {
 		$this->a0_options = $a0_options;
 	}
 

--- a/lib/admin/WP_Auth0_Admin_Advanced.php
+++ b/lib/admin/WP_Auth0_Admin_Advanced.php
@@ -2,7 +2,10 @@
 
 class WP_Auth0_Admin_Advanced extends WP_Auth0_Admin_Generic {
 
+  // TODO: Deprecate
   const ADVANCED_DESCRIPTION = 'Settings related to specific scenarios.';
+
+  protected $_description;
 
   protected $actions_middlewares = array(
     'basic_validation',
@@ -14,9 +17,16 @@ class WP_Auth0_Admin_Advanced extends WP_Auth0_Admin_Generic {
 
   protected $router;
 
+  /**
+   * WP_Auth0_Admin_Advanced constructor.
+   *
+   * @param WP_Auth0_Options_Generic $options
+   * @param WP_Auth0_Routes $router
+   */
   public function __construct( WP_Auth0_Options_Generic $options, WP_Auth0_Routes $router ) {
     parent::__construct( $options );
     $this->router = $router;
+    $this->_description = __( 'Settings related to specific scenarios.', 'wp-auth0' );
   }
 
   public function init() {
@@ -418,7 +428,7 @@ class WP_Auth0_Admin_Advanced extends WP_Auth0_Admin_Generic {
       </div>
     <?php
   }
-
+  // TODO: Deprecate
   public function render_advanced_description() {
 ?>
 

--- a/lib/admin/WP_Auth0_Admin_Appearance.php
+++ b/lib/admin/WP_Auth0_Admin_Appearance.php
@@ -2,11 +2,24 @@
 
 class WP_Auth0_Admin_Appearance extends WP_Auth0_Admin_Generic {
 
+	// TODO: Deprecate
 	const APPEARANCE_DESCRIPTION = 'Settings related to the way the login widget is shown.';
+
+	protected $_description;
 
 	protected $actions_middlewares = array(
 		'basic_validation',
 	);
+
+	/**
+	 * WP_Auth0_Admin_Appearance constructor.
+	 *
+	 * @param WP_Auth0_Options_Generic $options
+	 */
+	public function __construct( WP_Auth0_Options_Generic $options ) {
+		parent::__construct( $options );
+		$this->_description = __( 'Settings related to the way the login widget is shown.', 'wp-auth0' );
+	}
 
 	public function init() {
 
@@ -137,7 +150,7 @@ class WP_Auth0_Admin_Appearance extends WP_Auth0_Admin_Generic {
       </div>
     <?php
 	}
-
+	// TODO: Deprecate
 	public function render_appearance_description() {
 ?>
 

--- a/lib/admin/WP_Auth0_Admin_Basic.php
+++ b/lib/admin/WP_Auth0_Admin_Basic.php
@@ -2,11 +2,24 @@
 
 class WP_Auth0_Admin_Basic extends WP_Auth0_Admin_Generic {
 
+	// TODO: Deprecate
 	const BASIC_DESCRIPTION = 'Basic settings related to Auth0 credentials and basic WordPress integration.';
+
+	protected $_description;
 
 	protected $actions_middlewares = array(
 		'basic_validation',
 	);
+
+	/**
+	 * WP_Auth0_Admin_Basic constructor.
+	 *
+	 * @param WP_Auth0_Options_Generic $options
+	 */
+	public function __construct( WP_Auth0_Options_Generic $options ) {
+		parent::__construct( $options );
+		$this->_description = __( 'Basic settings related to the Auth0 integration.', 'wp-auth0' );
+	}
 
 	public function init() {
 
@@ -219,6 +232,7 @@ class WP_Auth0_Admin_Basic extends WP_Auth0_Admin_Generic {
     <?php
 	}
 
+	// TODO: Deprecate
 	public function render_basic_description() {
 ?>
 

--- a/lib/admin/WP_Auth0_Admin_Dashboard.php
+++ b/lib/admin/WP_Auth0_Admin_Dashboard.php
@@ -2,11 +2,24 @@
 
 class WP_Auth0_Admin_Dashboard extends WP_Auth0_Admin_Generic {
 
+	// TODO: Deprecate
 	const DASHBOARD_DESCRIPTION = 'Settings related to the dashboard widgets.';
+
+	protected $_description;
 
 	protected $actions_middlewares = array(
 		'basic_validation',
 	);
+
+	/**
+	 * WP_Auth0_Admin_Dashboard constructor.
+	 *
+	 * @param WP_Auth0_Options_Generic $options
+	 */
+	public function __construct( WP_Auth0_Options_Generic $options ) {
+		parent::__construct( $options );
+		$this->_description = __( 'Settings related to the dashboard widgets', 'wp-auth0' );
+	}
 
 	public function init() {
 
@@ -24,6 +37,7 @@ class WP_Auth0_Admin_Dashboard extends WP_Auth0_Admin_Generic {
 
 	}
 
+	// TODO: Deprecate
 	public function render_dashboard_description() {
 ?>
 

--- a/lib/admin/WP_Auth0_Admin_Features.php
+++ b/lib/admin/WP_Auth0_Admin_Features.php
@@ -2,7 +2,10 @@
 
 class WP_Auth0_Admin_Features extends WP_Auth0_Admin_Generic {
 
+  // TODO: Deprecate
   const FEATURES_DESCRIPTION = 'Settings related to specific features provided by the plugin.';
+
+  protected $_description;
 
   protected $actions_middlewares = array(
     'basic_validation',
@@ -13,6 +16,16 @@ class WP_Auth0_Admin_Features extends WP_Auth0_Admin_Generic {
     'fullcontact_validation',
     'mfa_validation',
   );
+
+  /**
+   * WP_Auth0_Admin_Features constructor.
+   *
+   * @param WP_Auth0_Options_Generic $options
+   */
+  public function __construct( WP_Auth0_Options_Generic $options ) {
+    parent::__construct( $options );
+    $this->_description = __( 'Settings related to specific features provided by the plugin.', 'wp-auth0' );
+  }
 
   public function init() {
 
@@ -155,7 +168,7 @@ class WP_Auth0_Admin_Features extends WP_Auth0_Admin_Generic {
       </div>
     <?php
   }
-
+  // TODO: Deprecate
   public function render_features_description() {
 ?>
 

--- a/lib/admin/WP_Auth0_Admin_Generic.php
+++ b/lib/admin/WP_Auth0_Admin_Generic.php
@@ -3,20 +3,29 @@
 class WP_Auth0_Admin_Generic {
 
 	protected $options;
+	protected $_option_name;
+	protected $_description;
+	protected $_textarea_rows = 4;
 
 	protected $actions_middlewares = array();
 
+	/**
+	 * WP_Auth0_Admin_Generic constructor.
+	 *
+	 * @param WP_Auth0_Options_Generic $options
+	 */
 	public function __construct( WP_Auth0_Options_Generic $options ) {
 		$this->options = $options;
+		$this->_option_name = $options->get_options_name();
 	}
 
 	protected function init_option_section( $sectionName, $id, $settings ) {
-		$options_name = $this->options->get_options_name() . '_' . strtolower( $id );
+		$options_name = $this->_option_name . '_' . strtolower( $id );
 
 		add_settings_section(
 			"wp_auth0_{$id}_settings_section",
-			__( $sectionName, 'wp-auth0' ),
-			array( $this, "render_{$id}_description" ),
+			$sectionName,
+			array( $this, 'render_description' ),
 			$options_name
 		);
 
@@ -32,6 +41,15 @@ class WP_Auth0_Admin_Generic {
 		}
 	}
 
+	/**
+	 * Render description at the top of the settings block
+	 */
+	public function render_description() {
+		if ( ! empty( $this->_description ) ) {
+			printf( '<p class="a0-step-text">%s</p>', $this->_description );
+		}
+	}
+
 	public function input_validator( $input, $old_options = null ) {
 		if ( empty( $old_options ) ) {
 			$old_options = $this->options->get_options();
@@ -44,10 +62,15 @@ class WP_Auth0_Admin_Generic {
 		return $input;
 	}
 
+	/**
+	 * Wrapper for add_settings_error
+	 *
+	 * @param string $error - translated error message
+	 */
 	protected function add_validation_error( $error ) {
 		add_settings_error(
-			$this->options->get_options_name(),
-			$this->options->get_options_name(),
+			$this->_option_name,
+			$this->_option_name,
 			$error,
 			'error'
 		);
@@ -73,15 +96,158 @@ class WP_Auth0_Admin_Generic {
 	}
 
 
+	// TODO: Deprecate
 	protected function render_a0_switch( $id, $name, $value, $checked ) {
 ?>
 
     <div class="a0-switch">
-      <input type="checkbox" name="<?php echo $this->options->get_options_name(); ?>[<?php echo $name; ?>]" id="<?php echo $id; ?>" value="<?php echo $value; ?>" <?php echo checked( $checked ); ?>/>
+      <input type="checkbox" name="<?php echo $this->_option_name; ?>[<?php echo $name; ?>]" id="<?php echo $id; ?>" value="<?php echo $value; ?>" <?php echo checked( $checked ); ?>/>
       <label for="<?php echo $id; ?>"></label>
     </div>
 
     <?php
+	}
+
+	/**
+	 * Output a stylized switch on the options page
+	 *
+	 * @param string $id - input id attribute
+	 * @param string $input_name - input name attribute
+	 * @param string $expand_id - id of a field that should be hidden until this switch is active
+	 */
+	protected function render_switch( $id, $input_name, $expand_id = '' ) {
+		$value = $this->options->get( $input_name );
+		printf(
+			'<div class="a0-switch"><input type="checkbox" name="%s[%s]" id="%s" data-expand="%s" value="1"%s>
+			<label for="%s"></label></div>',
+			esc_attr( $this->option_name ),
+			esc_attr( $input_name ),
+			esc_attr( $id ),
+			! empty( $expand_id ) ? esc_attr( $expand_id ) : '',
+			checked( empty( $value ), FALSE, FALSE ),
+			esc_attr( $id )
+		);
+	}
+
+	/**
+	 * Output a stylized text field on the options page
+	 *
+	 * @param string $id - input id attribute
+	 * @param string $input_name - input name attribute
+	 * @param string $type - input type attribute
+	 * @param string $placeholder - input placeholder
+	 * @param string $style - inline CSS
+	 */
+	protected function render_text_field( $id, $input_name, $type = 'text', $placeholder = '', $style = '' ) {
+		$value = $this->options->get( $input_name );
+		// Secure fields are not output by default; validation keeps last value if a new one is not entered
+		if ( 'password' === $type ) {
+			$placeholder = ! empty( $value ) ? 'Not visible' : '';
+			$value = '';
+		}
+		printf(
+			'<input type="%s" name="%s[%s]" id="%s" value="%s" placeholder="%s" style="%s">',
+			esc_attr( $type ),
+			esc_attr( $this->option_name ),
+			esc_attr( $input_name ),
+			esc_attr( $id ),
+			esc_attr( $value ),
+			$placeholder ? esc_attr( $placeholder ) : '',
+			$style ? esc_attr( $style ) : ''
+		);
+	}
+
+	/**
+	 * Output a stylized social key text field on the options page
+	 *
+	 * @param string $id - input id attribute
+	 * @param string $input_name - input name attribute
+	 */
+	protected function render_social_key_field( $id, $input_name ) {
+		printf(
+			'<input type="text" name="%s[%s]" id="wpa0_%s" value="%s">',
+			esc_attr( $this->option_name ),
+			esc_attr( $input_name ),
+			esc_attr( $id ),
+			esc_attr( $this->options->get_connection( $input_name ) )
+		);
+	}
+
+	/**
+	 * Output a stylized textarea field on the options page
+	 *
+	 * @param string $id - input id attribute
+	 * @param string $input_name - input name attribute
+	 */
+	protected function render_textarea_field( $id, $input_name ) {
+		$value = $this->options->get( $input_name );
+		printf(
+			'<textarea name="%s[%s]" id="%s" rows="%d" class="code">%s</textarea>',
+			esc_attr( $this->option_name ),
+			esc_attr( $input_name ),
+			esc_attr( $id ),
+			$this->textarea_rows,
+			esc_textarea( $value )
+		);
+	}
+
+	/**
+	 * Output a radio button
+	 *
+	 * @param string $id - input id attribute
+	 * @param string $input_name - input name attribute
+	 * @param string|integer|float $value - input value attribute
+	 * @param string $label - input label text
+	 * @param bool $selected - is it active?
+	 */
+	protected function render_radio_button( $id, $input_name, $value, $label = '', $selected = FALSE ) {
+		printf(
+			'<label for="%s"><input type="radio" name="%s[%s]" id="%s" value="%s" %s>&nbsp;%s</label>',
+			esc_attr( $id ),
+			esc_attr( $this->option_name ),
+			esc_attr( $input_name ),
+			esc_attr( $id ),
+			esc_attr( $value ),
+			checked( $selected, TRUE, FALSE ),
+			sanitize_text_field( ! empty( $label ) ? $label : ucfirst( $value ) )
+		);
+	}
+
+	/**
+	 * Output a field description
+	 *
+	 * @param string $text - description text to display
+	 */
+	protected function render_field_description( $text ) {
+		printf( '<div class="subelement"><span class="description">%s.</span></div>', $text );
+	}
+
+	/**
+	 * Output translated dashboard HTML link
+	 *
+	 * @param string $path - dashboard sub-section, if any
+	 *
+	 * @return string
+	 */
+	protected function get_dashboard_link( $path = '' ) {
+		return sprintf( '<a href="https://manage.auth0.com/#/%s" target="_blank">%s</a>',
+			$path,
+			__( 'Auth0 dashboard', 'wp-auth0' )
+		);
+	}
+
+	/**
+	 * Output a docs HTML link
+	 *
+	 * @param string $path - docs sub-page, if any
+	 * @param string $text - link text, should be translated before passing
+	 *
+	 * @return string
+	 */
+	protected function get_docs_link( $path, $text = '' ) {
+		$path = '/' === $path[0] ? substr( $path, 1 ) : $path;
+		$text = empty( $text ) ? __( 'here', 'wp-auth0' ) : sanitize_text_field( $text );
+		return sprintf( '<a href="https://auth0.com/docs/%s" target="_blank">%s</a>',	$path, $text );
 	}
 
 }


### PR DESCRIPTION
Admins settings have confusing wording, inconsistent behavior, and
broken links and translation. This first PR refactors the description
system to be more straight-forward, adds HTML generation functions for
consistent field outputs (used in future commits), adds settings page
description translation, and fixes a few other minor code issues.

First of a few smaller PRs to replace #396