### PR TITLE
Fix improper state handling

### DIFF
--- a/WP_Auth0.php
+++ b/WP_Auth0.php
@@ -13,6 +13,7 @@ define( 'WPA0_LANG', 'wp-auth0' ); // deprecated; do not use for translations
 define( 'AUTH0_DB_VERSION', 17 );
 define( 'WPA0_VERSION', '3.5.2' );
 define( 'WPA0_CACHE_GROUP', 'wp_auth0' );
+define( 'WPA0_STATE_COOKIE_NAME', 'auth0_state' );
 
 /**
  * Main plugin class
@@ -119,9 +120,6 @@ class WP_Auth0 {
 		$edit_profile->init();
 
 		$this->check_signup_status();
-
-		// Store nonce value before headers are sent
-		WP_Auth0_State_Handler::getInstance()->setCookie();
 
 		WP_Auth0_Email_Verification::init();
 	}

--- a/WP_Auth0.php
+++ b/WP_Auth0.php
@@ -120,6 +120,9 @@ class WP_Auth0 {
 
 		$this->check_signup_status();
 
+		// Store nonce value before headers are sent
+		WP_Auth0_State_Handler::getInstance()->setCookie();
+
 		WP_Auth0_Email_Verification::init();
 	}
 

--- a/lib/WP_Auth0_Lock10_Options.php
+++ b/lib/WP_Auth0_Lock10_Options.php
@@ -101,7 +101,7 @@ class WP_Auth0_Lock10_Options {
 
     $stateObj = array(
       'interim' => ( isset( $_GET['interim-login'] ) && $_GET['interim-login'] == 1 ),
-      'nonce' => WP_Auth0_State_Handler::getInstance()->get()
+      'nonce' => WP_Auth0_Nonce_Handler::getInstance()->get()
     );
 
     if ( !empty( $redirect_to ) ) {
@@ -110,8 +110,6 @@ class WP_Auth0_Lock10_Options {
     elseif ( isset( $_GET['redirect_to'] ) ) {
       $stateObj["redirect_to"] = addslashes( $_GET['redirect_to'] );
     }
-
-    $stateObj["state"] = 'nonce';
 
     return base64_encode( json_encode( $stateObj ) );
   }
@@ -214,7 +212,7 @@ class WP_Auth0_Lock10_Options {
 
     unset( $options["authParams"] );
     $options["state"] = $this->get_state_obj( $redirect_to );
-    $options["nonce"] = 'nonce';
+    $options["nonce"] = WP_Auth0_Nonce_Handler::getInstance()->get();
 
     return $options;
   }

--- a/lib/WP_Auth0_Lock10_Options.php
+++ b/lib/WP_Auth0_Lock10_Options.php
@@ -99,10 +99,9 @@ class WP_Auth0_Lock10_Options {
 
   public function get_state_obj( $redirect_to = null ) {
 
-    $stateHandler = new WP_Auth0_State_Handler();
     $stateObj = array(
       'interim' => ( isset( $_GET['interim-login'] ) && $_GET['interim-login'] == 1 ),
-      'nonce' => $stateHandler->issue()
+      'nonce' => WP_Auth0_State_Handler::getInstance()->get()
     );
 
     if ( !empty( $redirect_to ) ) {

--- a/lib/WP_Auth0_Lock_Options.php
+++ b/lib/WP_Auth0_Lock_Options.php
@@ -100,7 +100,7 @@ class WP_Auth0_Lock_Options {
 	public function get_state_obj( $redirect_to = null ) {
 		$stateObj = array(
 			'interim' => ( isset( $_GET['interim-login'] ) && $_GET['interim-login'] == 1 ),
-			'nonce' => WP_Auth0_State_Handler::getInstance()->get()
+			'nonce' => WP_Auth0_Nonce_Handler::getInstance()->get()
 		);
 		if ( !empty( $redirect_to ) ) {
 			$stateObj["redirect_to"] = addslashes( $redirect_to );

--- a/lib/WP_Auth0_Lock_Options.php
+++ b/lib/WP_Auth0_Lock_Options.php
@@ -98,10 +98,9 @@ class WP_Auth0_Lock_Options {
 	}
 
 	public function get_state_obj( $redirect_to = null ) {
-		$stateHandler = new WP_Auth0_State_Handler();
 		$stateObj = array(
 			'interim' => ( isset( $_GET['interim-login'] ) && $_GET['interim-login'] == 1 ),
-			'nonce' => $stateHandler->issue()
+			'nonce' => WP_Auth0_State_Handler::getInstance()->get()
 		);
 		if ( !empty( $redirect_to ) ) {
 			$stateObj["redirect_to"] = addslashes( $redirect_to );

--- a/lib/WP_Auth0_LoginManager.php
+++ b/lib/WP_Auth0_LoginManager.php
@@ -160,7 +160,8 @@ class WP_Auth0_LoginManager {
     // Check for valid state nonce
     // See https://auth0.com/docs/protocols/oauth2/oauth-state
     $state_decoded = $this->get_state();
-    if ( empty( $state_decoded->nonce ) || ! WP_Auth0_State_Handler::validate( $state_decoded->nonce ) ) {
+    $state_nonce = isset( $state_decoded->nonce ) ? $state_decoded->nonce : '';
+    if ( ! WP_Auth0_State_Handler::getInstance()->validate( $state_nonce ) ) {
       $this->die_on_login( __( 'Invalid state', 'wp-auth0' ) );
     }
 

--- a/templates/auth0-login-form-lock10.php
+++ b/templates/auth0-login-form-lock10.php
@@ -28,7 +28,7 @@ if ( empty( $title ) ) {
   $title = "Sign In";
 }
 
-$options = json_encode( $lock_options->get_lock_options() );
+$options = $lock_options->get_lock_options();
 
 ?>
 
@@ -59,11 +59,18 @@ $options = json_encode( $lock_options->get_lock_options() );
 
 <script type="text/javascript">
 var ignore_sso = false;
+
+document.cookie = '<?php
+  echo WPA0_STATE_COOKIE_NAME ?>=<?php
+  echo $options['auth']['params']['state'] ?>;max-age=<?php
+  echo WP_Auth0_Nonce_Handler::COOKIE_EXPIRES ?>;path=/';
+
+
 document.addEventListener("DOMContentLoaded", function() {
 
     var callback = null;
 
-    var options = <?php echo $options; ?>;
+    var options = <?php echo json_encode( $options ); ?>;
 
     options.additionalSignUpFields = <?php echo $lock_options->get_custom_signup_fields(); ?>;
     <?php if ( $lock_options->get_auth0_implicit_workflow() ) { ?>


### PR DESCRIPTION
State generation, specifically cookie storage, needs to happen before
any output. The previous arch was ok for login page generation but
failed with a "headers already set" error if used in the shortcode.
This addresses the issue by storing state earlier and getting the
value later.