### PR TITLE
Remove api_audience settings field

### DIFF
--- a/lib/WP_Auth0_Api_Client.php
+++ b/lib/WP_Auth0_Api_Client.php
@@ -51,12 +51,8 @@ class WP_Auth0_Api_Client {
 				'client_secret_encoded' => $a0_options->get( 'client_secret_b64_encoded' ),
 				'connection' => $a0_options->get( 'db_connection_name' ),
 				'app_token' => $a0_options->get( 'auth0_app_token' ),
-				'audience' => $a0_options->get( 'api_audience' ),
+				'audience' => self::get_endpoint( 'api/v2/' ),
 			);
-
-			if ( empty( self::$connect_info[ 'audience' ] ) ) {
-				self::$connect_info[ 'audience' ] = self::get_endpoint( 'api/v2/' );
-			}
 		}
 
 		if ( empty( $opt ) ) {

--- a/lib/WP_Auth0_DBManager.php
+++ b/lib/WP_Auth0_DBManager.php
@@ -187,10 +187,6 @@ class WP_Auth0_DBManager {
 				$options->set( 'auth0js-cdn', '//cdn.auth0.com/js/auth0/9.1/auth0.min.js' );
 			}
 
-			// Add API audience
-
-			$options->set( 'api_audience', 'https://' . $options->get( 'domain' ) . '/api/v2/' );
-
 			// Update app type and client grant
 
 			$client_grant_created = FALSE;

--- a/lib/admin/WP_Auth0_Admin_Basic.php
+++ b/lib/admin/WP_Auth0_Admin_Basic.php
@@ -35,7 +35,6 @@ class WP_Auth0_Admin_Basic extends WP_Auth0_Admin_Generic {
 				array( 'id' => 'wpa0_client_signing_algorithm', 'name' => 'Client Signing Algorithm', 'function' => 'render_client_signing_algorithm' ),
 				array( 'id' => 'wpa0_cache_expiration', 'name' => 'Cache Time (minutes)', 'function' => 'render_cache_expiration' ),
 				array( 'id' => 'wpa0_auth0_app_token', 'name' => 'API token', 'function' => 'render_auth0_app_token' ),
-				array( 'id' => 'wpa0_api_audience', 'name' => 'API Identifier (audience)', 'function' => 'render_api_audience' ),
 				array( 'id' => 'wpa0_login_enabled', 'name' => 'WordPress login enabled', 'function' => 'render_allow_wordpress_login' ),
 				array( 'id' => 'wpa0_allow_signup', 'name' => 'Allow signup', 'function' => 'render_allow_signup' ),
 
@@ -79,18 +78,6 @@ class WP_Auth0_Admin_Basic extends WP_Auth0_Admin_Generic {
         </span>
       </div>
     <?php
-	}
-
-	public function render_api_audience() {
-		$v = $this->options->get( 'api_audience' );
-		?>
-		<input type="text" name="<?php
-			echo $this->options->get_options_name(); ?>[api_audience]" id="wpa0_api_audience" value="<?php
-			echo esc_attr( $v ); ?>"/>
-		<div class="subelement">
-			<span class="description"><?php _e( 'API Identifier for the management API. ', 'wp-auth0' ); ?></span>
-		</div>
-		<?php
 	}
 
 	public function render_client_secret() {
@@ -276,13 +263,6 @@ class WP_Auth0_Admin_Basic extends WP_Auth0_Admin_Generic {
 		$input['auth0_app_token'] = ( ! empty( $input['auth0_app_token'] )
 			? $input['auth0_app_token']
 			: $old_options['auth0_app_token'] );
-
-		if ( ! empty( $input['domain'] ) ) {
-
-			$input['api_audience'] = ( ! empty( $input['api_audience'] )
-				? $input['api_audience']
-				: 'https://' . $input['domain'] . '/api/v2/' );
-		}
 
 		// If we have an app token, get and store the audience
 		if ( ! empty( $input['auth0_app_token'] ) ) {


### PR DESCRIPTION
This field was for an audience value used with the Management API. This
value should never change and should not be user-configurable.

The render function is `public` but has only been around for a short 
period of time so I don't think it's necessary to deprecate officially.