### PR TITLE
Add /userinfo fallback during login

### DIFF
--- a/lib/WP_Auth0_Api_Client.php
+++ b/lib/WP_Auth0_Api_Client.php
@@ -260,17 +260,17 @@ class WP_Auth0_Api_Client {
 		return ! empty( $response->access_token ) ? $response->access_token : '';
 	}
 
+	/**
+	 * @param string $domain - tenant domain
+	 * @param string $access_token - access token with at least `openid` scope
+	 *
+	 * @return array|WP_Error
+	 */
 	public static function get_user_info( $domain, $access_token ) {
-
-		$endpoint = "https://$domain/";
-
-		$headers = self::get_info_headers();
-		$headers['Authorization'] = "Bearer $access_token";
-
-		return wp_remote_get( $endpoint . 'userinfo/' , array(
-				'headers' => $headers,
-			) );
-
+		return wp_remote_get(
+			self::get_endpoint( 'userinfo', $domain ),
+			array( 'headers' => self::get_headers( $access_token ) )
+		);
 	}
 
 	public static function search_users( $domain, $jwt, $q = "", $page = 0, $per_page = 100, $include_totals = false, $sort = "user_id:1" ) {

--- a/lib/WP_Auth0_ErrorManager.php
+++ b/lib/WP_Auth0_ErrorManager.php
@@ -12,6 +12,8 @@ class WP_Auth0_ErrorManager {
 	 * @param string|WP_Error|Exception $error - error message string or discoverable error type
 	 */
 	public static function insert_auth0_error( $section, $error ) {
+		$code = 'unknown_code';
+		$message = __( 'Unknown error message', 'wp-auth0' );
 
 		if ( $error instanceof WP_Error ) {
 			$code = $error->get_error_code();
@@ -20,10 +22,13 @@ class WP_Auth0_ErrorManager {
 			$code = $error->getCode();
 			$message = $error->getMessage();
 		} elseif ( is_array( $error ) && ! empty( $error['response'] ) ) {
-			$code = ! empty( $error['response']['code'] ) ? $error['response']['code'] : 'N/A';
-			$message = ! empty( $error['response']['message'] ) ? $error['response']['message'] : 'N/A';
+			if ( ! empty( $error['response']['code'] ) ) {
+				$code = sanitize_text_field( $error['response']['code'] );
+			}
+			if ( ! empty( $error['response']['message'] ) ) {
+				$message = sanitize_text_field( $error['response']['message'] );
+			}
 		} else {
-			$code = 'N/A';
 			$message = is_object( $error ) || is_array( $error ) ? serialize( $error ) : $error;
 		}
 

--- a/lib/WP_Auth0_ErrorManager.php
+++ b/lib/WP_Auth0_ErrorManager.php
@@ -19,9 +19,12 @@ class WP_Auth0_ErrorManager {
 		} elseif ( $error instanceof Exception ) {
 			$code = $error->getCode();
 			$message = $error->getMessage();
+		} elseif ( is_array( $error ) && ! empty( $error['response'] ) ) {
+			$code = ! empty( $error['response']['code'] ) ? $error['response']['code'] : 'N/A';
+			$message = ! empty( $error['response']['message'] ) ? $error['response']['message'] : 'N/A';
 		} else {
 			$code = 'N/A';
-			$message = $error;
+			$message = is_object( $error ) || is_array( $error ) ? serialize( $error ) : $error;
 		}
 
 		$log = get_option( 'auth0_error_log' );

--- a/lib/WP_Auth0_Lock10_Options.php
+++ b/lib/WP_Auth0_Lock10_Options.php
@@ -4,8 +4,8 @@ class WP_Auth0_Lock10_Options {
 
   protected $wp_options;
   protected $extended_settings;
-
   protected $signup_mode = false;
+  protected $_scopes = 'openid email name nickname picture';
 
   public function __construct( $extended_settings = array() ) {
     $this->wp_options = WP_Auth0_Options::Instance();
@@ -187,12 +187,11 @@ class WP_Auth0_Lock10_Options {
   }
 
   public function get_sso_options() {
-    $options["scope"] = "openid email identities ";
+    $options["scope"] = $this->_scopes;
 
     if ( $this->get_auth0_implicit_workflow() ) {
       $options["responseType"] = 'id_token';
       $options["redirectUri"] = $this->get_implicit_callback_url();
-      $options["scope"] .= "name email picture nickname email_verified";
     } else {
       $options["responseType"] = 'code';
       $options["redirectUri"] = $this->get_code_callback_url();
@@ -233,11 +232,10 @@ class WP_Auth0_Lock10_Options {
       ),
     );
 
-    $extraOptions["auth"]["params"]["scope"] = "openid ";
+    $extraOptions["auth"]["params"]["scope"] = apply_filters( 'auth0_auth_param_scopes', $this->_scopes );
 
     if ( $this->get_auth0_implicit_workflow() ) {
-      $extraOptions["auth"]["params"]["scope"] .= "name email picture nickname email_verified";
-      $extraOptions["auth"]["responseType"] = 'token';
+      $extraOptions["auth"]["responseType"] = 'id_token';
       $extraOptions["auth"]["redirectUrl"] = $this->get_implicit_callback_url();
       $extraOptions["autoParseHash"] = false;
     } else {


### PR DESCRIPTION
Some customers are having trouble with the upgrade process in 3.5.2 while others made make changes to their account disabling management API access. This fallback allows user data to be pulled for logging-in users. Also adds requested scopes for auth code login to make this possible and updates the error manager class to handle a common error case.