### PR TITLE
Changing Client to Application in readme files

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,16 +5,12 @@ Login by Auth0
 
 Single Sign On for Enterprises + Social Login + User/Passwords. For all your WordPress instances. Powered by Auth0.
 
-Download and install <https://wordpress.org/plugins/auth0/>
-Documentation: <https://auth0.com/docs/cms/wordpress>
-
-## Important note on 3.5
-
-This is a major update that requires changes to your Auth0 Dashboard to be completed. You can save a new [API token](https://auth0.com/docs/api/management/v2/tokens#get-a-token-manually) in your Basic settings in wp-admin before upgrading and the changes will be made automatically during the update. Otherwise, please review your [Client Advanced Settings](https://auth0.com/docs/cms/wordpress/configuration#client-setup), specifically your Grant Types, and [authorize your Client for the Management API](https://auth0.com/docs/cms/wordpress/configuration#authorize-the-client-for-the-management-api). 
+* [WordPress.org plugin page](https://wordpress.org/plugins/auth0/)
+* [Documentation (installation, configuration, more)](https://auth0.com/docs/cms/wordpress)
 
 ## Installation
 
-[Please see the Installation page on auth0.com/docs](https://auth0.com/docs/cms/wordpress/installation)
+Please see the [Installation docs](https://auth0.com/docs/cms/wordpress/installation) for detailed instructions.
 
 ## Extending the plugin
 
@@ -25,25 +21,7 @@ We're happy to review and approve new filters and actions that help you integrat
 
 ## API authentication
 
-This plugin provides the ability integrate with **wp-jwt-auth** plugin to authenticate api calls via a HTTP Authorization Header.
-
-This plugin will detect if you have wp-jwt-auth installed and active and will offer to configure it. Accepting this, will set up the client id, secret and the custom user repository.
-
-After the user logs in via Auth0 in your Api client (ie: using Lock in a mobile app) you will get a JWT (JSON Web Token). Then you need to send this token in a HTTP header in the following way:
-
-```
-Authorization: Bearer ##jwt##
-```
-
-For example:
-
-```
-Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJjb250ZW50IjoiVGhpcyBpcyB5b3VyIHVzZXIgSldUIHByb3ZpZGVkIGJ5IHRoZSBBdXRoMCBzZXJ2ZXIifQ.b47GoWoY_5n4jIyG0hPTLFEQtSegnVydcvl6gpWNeUE
-```
-
-This JWT should match with a registered user in your WP installation.
-
-You can use this feature with API's provided by plugins like **WP REST API (WP API)**.
+Please see the [JWT Authentication docs](https://auth0.com/docs/cms/wordpress/jwt-authentication) for more information.
 
 ## Contributing
 

--- a/readme.txt
+++ b/readme.txt
@@ -31,13 +31,7 @@ This plugin gives WordPress a new Login Widget (powered by [Auth0](https://auth0
 
 == Installation ==
 
-Before you start, **make sure the admin user has a valid email that you own**, read the Technical Notes for more information.
-
-1. Install from the WordPress Store or upload the entire `wp-auth0` folder to the `/wp-content/plugins/` directory.
-1. Activate the plugin through the 'Plugins' menu in WordPress.
-1. Create an account in Auth0 (https://auth0.com) and add a new PHP Application. Copy the Client ID, Client Secret and Domain from the Settings of the Application.
-1. On the Settings of the Auth0 application change the Callback URL to be: `http://your-domain/index.php?auth0=1`. Using **TLS/SSL** is **recommended for production**.
-1. Go back to WordPress `Settings` - `Auth0 Settings` edit the *Domain*, *Client ID* and *Client Secret* with the ones you copied from Auth0 Dashboard.
+Please see the Auth0 Docs site for [complete installation and configuration instructions](https://auth0.com/docs/cms/wordpress/installation).
 
 == Screenshots ==
 


### PR DESCRIPTION
Changes made below have already been made in the `dev` branch. Anything that mentioned "Client" was slated to move to the docs site. 