### PR TITLE
Remove and migrate Passwordless setting

### DIFF
--- a/WP_Auth0.php
+++ b/WP_Auth0.php
@@ -6,6 +6,9 @@
  * Author: Auth0
  * Author URI: https://auth0.com
  */
+define( 'WPA0_VERSION', '3.5.2' );
+define( 'AUTH0_DB_VERSION', 18 );
+
 define( 'WPA0_PLUGIN_FILE', __FILE__ );
 define( 'WPA0_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'WPA0_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
@@ -14,11 +17,14 @@ define( 'WPA0_PLUGIN_CSS_URL', WPA0_PLUGIN_URL . 'assets/css/' );
 define( 'WPA0_PLUGIN_IMG_URL', WPA0_PLUGIN_URL . 'assets/img/' );
 define( 'WPA0_PLUGIN_LIB_URL', WPA0_PLUGIN_URL . 'assets/lib/' );
 define( 'WPA0_PLUGIN_BS_URL', WPA0_PLUGIN_URL . 'assets/bootstrap/' );
-define( 'WPA0_LANG', 'wp-auth0' ); // deprecated; do not use for translations
-define( 'AUTH0_DB_VERSION', 17 );
-define( 'WPA0_VERSION', '3.5.2' );
+
+define( 'WPA0_LOCK_CDN_URL', 'https://cdn.auth0.com/js/lock/11.5/lock.min.js' );
+define( 'WPA0_AUTH0_JS_CDN_URL', 'https://cdn.auth0.com/js/auth0/9.4/auth0.min.js' );
+
 define( 'WPA0_CACHE_GROUP', 'wp_auth0' );
 define( 'WPA0_STATE_COOKIE_NAME', 'auth0_state' );
+
+define( 'WPA0_LANG', 'wp-auth0' ); // deprecated; do not use for translations
 
 /**
  * Main plugin class

--- a/lib/WP_Auth0_DBManager.php
+++ b/lib/WP_Auth0_DBManager.php
@@ -323,12 +323,10 @@ class WP_Auth0_DBManager {
 				}
 
 				// Need to set a special passwordlessMethod flag if using email code
-				if ( in_array( $pwl_method, array( 'emailcode', 'socialOrEmailcode' ) ) ) {
-					$lock_json = trim( $options->get( 'extra_conf' ) );
-					$lock_json_decoded = ! empty( $lock_json ) ? json_decode( $lock_json, TRUE ) : array();
-					$lock_json_decoded[ 'passwordlessMethod' ] = 'code';
-					$options->set( 'extra_conf', json_encode( $lock_json_decoded ) );
-				}
+				$lock_json = trim( $options->get( 'extra_conf' ) );
+				$lock_json_decoded = ! empty( $lock_json ) ? json_decode( $lock_json, TRUE ) : array();
+				$lock_json_decoded[ 'passwordlessMethod' ] = strpos( $pwl_method, 'code' ) ? 'code' : 'link';
+				$options->set( 'extra_conf', json_encode( $lock_json_decoded ) );
 			}
 
 			// Set passwordless_cdn_url to latest Lock

--- a/lib/WP_Auth0_Lock10_Options.php
+++ b/lib/WP_Auth0_Lock10_Options.php
@@ -25,11 +25,7 @@ class WP_Auth0_Lock10_Options {
   }
 
   public function get_lock_show_method() {
-    if ( $this->_get_boolean( $this->wp_options->get( 'passwordless_enabled' ) ) ) {
-      return $this->wp_options->get( 'passwordless_method' );
-    } else {
-      return 'show';
-    }
+    return 'show';
   }
 
   public function get_code_callback_url() {

--- a/lib/WP_Auth0_Lock_Options.php
+++ b/lib/WP_Auth0_Lock_Options.php
@@ -25,11 +25,7 @@ class WP_Auth0_Lock_Options {
 	}
 
 	public function get_lock_show_method() {
-		if ( $this->_get_boolean( $this->wp_options->get( 'passwordless_enabled' ) ) ) {
-			return $this->wp_options->get( 'passwordless_method' );
-		} else {
-			return 'show';
-		}
+		return 'show';
 	}
 
 	public function get_code_callback_url() {

--- a/lib/WP_Auth0_Options.php
+++ b/lib/WP_Auth0_Options.php
@@ -178,7 +178,7 @@ class WP_Auth0_Options extends WP_Auth0_Options_Generic {
 			'amplificator_title' => '',
 			'amplificator_subtitle' => '',
 			'connections' => array(),
-			'auth0js-cdn' => 'https://cdn.auth0.com/js/auth0/9.1/auth0.min.js',
+			'auth0js-cdn' => WPA0_AUTH0_JS_CDN_URL,
 
 			// Basic
 			'domain' => '',
@@ -218,11 +218,10 @@ class WP_Auth0_Options extends WP_Auth0_Options_Generic {
 			'remember_users_session' => false,
 			'default_login_redirection' => home_url(),
 			'passwordless_enabled' => false,
-			'passwordless_method' => 'magiclink',
 			'force_https_callback' => false,
-			'cdn_url' => 'https://cdn.auth0.com/js/lock/11.1/lock.min.js',
+			'cdn_url' => WPA0_LOCK_CDN_URL,
 			'cdn_url_legacy' => 'https://cdn.auth0.com/js/lock-9.2.min.js',
-			'passwordless_cdn_url' => 'https://cdn.auth0.com/js/lock-passwordless-2.2.min.js',
+			'passwordless_cdn_url' => WPA0_LOCK_CDN_URL,
 			'lock_connections' => '',
 			'link_auth0_users' => null,
 			'auto_provisioning' => false,

--- a/lib/WP_Auth0_Options_Generic.php
+++ b/lib/WP_Auth0_Options_Generic.php
@@ -22,12 +22,23 @@ class WP_Auth0_Options_Generic {
 		return $this->_opt;
 	}
 
+	/**
+	 * Return a settings value
+	 *
+	 * @param string $key - settings key
+	 * @param null $default - what to return if a value is not set
+	 *
+	 * @return mixed
+	 */
 	public function get( $key, $default = null ) {
 		$options = $this->get_options();
+		$value = $default;
 
-		if ( !isset( $options[$key] ) )
-			return apply_filters( 'wp_auth0_get_option', $default, $key );
-		return apply_filters( 'wp_auth0_get_option', $options[$key], $key );
+		if ( isset( $options[$key] ) ) {
+			$value = $options[$key];
+		}
+
+		return apply_filters( 'wp_auth0_get_option', $value, $key );
 	}
 
 	public function set( $key, $value, $should_update = true ) {

--- a/lib/admin/WP_Auth0_Admin_Advanced.php
+++ b/lib/admin/WP_Auth0_Admin_Advanced.php
@@ -11,7 +11,6 @@ class WP_Auth0_Admin_Advanced extends WP_Auth0_Admin_Generic {
     'basic_validation',
     'migration_ws_validation',
     'link_accounts_validation',
-    'connections_validation',
     'loginredirection_validation',
   );
 
@@ -28,7 +27,6 @@ class WP_Auth0_Admin_Advanced extends WP_Auth0_Admin_Generic {
     $this->router = $router;
     $this->_description = __( 'Settings related to specific scenarios.', 'wp-auth0' );
   }
-
 
   /**
    * All settings in the Advanced tab
@@ -100,6 +98,7 @@ class WP_Auth0_Admin_Advanced extends WP_Auth0_Admin_Generic {
     $this->init_option_section( '', 'advanced', $options );
   }
 
+  // TODO: Deprecate
   public function render_passwordless_method() {
     $v = $this->options->get( 'passwordless_method' );
 ?>
@@ -224,6 +223,7 @@ class WP_Auth0_Admin_Advanced extends WP_Auth0_Admin_Generic {
     <?php
   }
 
+  // TODO: Better description when on - social connections, passwordless setup in the dashboard
   public function render_passwordless_enabled() {
     $v = $this->options->get( 'passwordless_enabled' );
 
@@ -392,13 +392,9 @@ class WP_Auth0_Admin_Advanced extends WP_Auth0_Admin_Generic {
   }
 
   public function render_cdn_url() {
-    $passwordless_enabled = $this->options->get( 'passwordless_enabled' );
     $cdn_url = $this->options->get( 'cdn_url' );
-    $passwordless_cdn_url = $this->options->get( 'passwordless_cdn_url' );
 ?>
-      <input type="text" name="<?php echo $this->options->get_options_name(); ?>[cdn_url]" id="wpa0_cdn_url" value="<?php echo esc_attr( $cdn_url ); ?>" style="<?php echo $passwordless_enabled ? 'display:none' : '' ?>"/>
-
-      <input type="text" name="<?php echo $this->options->get_options_name(); ?>[wpa0_passwordless_cdn_url]" id="wpa0_passwordless_cdn_url" value="<?php echo esc_attr( $passwordless_cdn_url ); ?>" style="<?php echo $passwordless_enabled ? '' : 'display:none' ?>"/>
+      <input type="text" name="<?php echo $this->options->get_options_name(); ?>[cdn_url]" id="wpa0_cdn_url" value="<?php echo esc_attr( $cdn_url ); ?>"/>
 
       <div class="subelement">
         <span class="description"><?php echo __( 'Point this to the latest widget available in the CDN', 'wp-auth0' ); ?></span>
@@ -487,11 +483,6 @@ class WP_Auth0_Admin_Advanced extends WP_Auth0_Admin_Generic {
     $input['lock_connections'] = trim( $input['lock_connections'] );
     $input['custom_signup_fields'] = trim( $input['custom_signup_fields'] );
 
-    if ( $input['passwordless_enabled'] && empty( $input['lock_connections'] ) && strpos( strtolower( $input['passwordless_method'] ), 'social' ) !== false ) {
-      $error = __( "Please complete the list of connections to be used by Lock in social mode.", "wp-auth0" );
-      self::add_validation_error( $error );
-    }
-
     if ( trim( $input["extra_conf"] ) != '' ) {
       if ( json_decode( $input["extra_conf"] ) === null ) {
         $error = __( "The Extra settings parameter should be a valid json object", "wp-auth0" );
@@ -570,6 +561,7 @@ class WP_Auth0_Admin_Advanced extends WP_Auth0_Admin_Generic {
     return $this->rule_validation($old_options, $input, 'link_auth0_users', WP_Auth0_RulesLib::$link_accounts['name'] . '-' . get_auth0_curatedBlogName(), $link_script);
   }
 
+  // TODO: Deprecate
   public function connections_validation( $old_options, $input ) {
 
     $check_if_enabled = array();

--- a/templates/settings.php
+++ b/templates/settings.php
@@ -142,12 +142,6 @@
 				metricsTrack('settings:'+matches[1], this.value);
 			}
 		});
-		jQuery('#wpa0_passwordless_cdn_url,#wpa0_cdn_url,#wpa0_connections').focusout(function(){
-			var matches = /\[([a-zA-Z0-9_-].*)\]/.exec(this.name);
-			if (matches[1]) {
-				metricsTrack('settings:'+matches[1], this.value);
-			}
-		});
 
 		jQuery('#wpa0_social_twitter_key,#wpa0_social_twitter_secret,#wpa0_social_facebook_key,#wpa0_social_facebook_secret').focusout(function(){
 			var matches = /\[([a-zA-Z0-9_-].*)\]/.exec(this.name);
@@ -197,21 +191,6 @@
 				jQuery('.subelement.fullcontact').addClass('hidden');
 			}
 		});
-		jQuery('#wpa0_passwordless_enabled').click(function() {
-			if (this.checked) {
-				jQuery('#wpa0_cdn_url').hide();
-				jQuery('#wpa0_passwordless_cdn_url').show();
-				jQuery('#wpa0_passwordless_method_social').parent().parent().show();
-			} else {
-				jQuery('#wpa0_passwordless_method_social').parent().parent().hide();
-				jQuery('#wpa0_passwordless_cdn_url').hide();
-				jQuery('#wpa0_cdn_url').show();
-			}
-		});
-		if (jQuery('#wpa0_passwordless_enabled:checked').length === 0) {
-			jQuery('#wpa0_passwordless_method_social').parent().parent().hide();
-		}
-
 	});
 
 	function confirmExit() {


### PR DESCRIPTION
Removes the passwordless method and CDN URL settings. Method is removed to simplify the wp-admin and move passwordless management to the Dashbaord. Passwordless URL is hard-coded to new combined Lock, removing the settings field to change that as well. Going forward, Lock will use the same library for both login form types. Also added a DB version bump and migration script to modify the connections setting so the login form will work as expected after a plugin update. Added a handful of TODOs that will be better suited for a future branch (same release).