### PR TITLE
Setting titles and option names

### DIFF
--- a/lib/admin/WP_Auth0_Admin.php
+++ b/lib/admin/WP_Auth0_Admin.php
@@ -108,29 +108,23 @@ class WP_Auth0_Admin {
 	}
 
 	public function init_admin() {
-
-		/* ------------------------- BASIC ------------------------- */
-
 		$this->sections['basic'] = new WP_Auth0_Admin_Basic( $this->a0_options );
 		$this->sections['basic']->init();
-
-		/* ------------------------- Features ------------------------- */
 
 		$this->sections['features'] = new WP_Auth0_Admin_Features( $this->a0_options );
 		$this->sections['features']->init();
 
-		/* ------------------------- Appearance ------------------------- */
-
 		$this->sections['appearance'] = new WP_Auth0_Admin_Appearance( $this->a0_options );
 		$this->sections['appearance']->init();
-
-		/* ------------------------- ADVANCED ------------------------- */
 
 		$this->sections['advanced'] = new WP_Auth0_Admin_Advanced( $this->a0_options, $this->router );
 		$this->sections['advanced']->init();
 
-		register_setting( $this->a0_options->get_options_name() . '_basic', $this->a0_options->get_options_name(), array( $this, 'input_validator' ) );
-
+		register_setting(
+			$this->a0_options->get_options_name() . '_basic',
+			$this->a0_options->get_options_name(),
+			array( $this, 'input_validator' )
+		);
 	}
 
 	public function input_validator( $input ) {

--- a/lib/admin/WP_Auth0_Admin_Advanced.php
+++ b/lib/admin/WP_Auth0_Admin_Advanced.php
@@ -29,52 +29,75 @@ class WP_Auth0_Admin_Advanced extends WP_Auth0_Admin_Generic {
     $this->_description = __( 'Settings related to specific scenarios.', 'wp-auth0' );
   }
 
+
+  /**
+   * All settings in the Advanced tab
+   *
+   * @see \WP_Auth0_Admin::init_admin
+   * @see \WP_Auth0_Admin_Generic::init_option_section
+   */
   public function init() {
-
-    $advancedOptions = array(
-
-      array( 'id' => 'wpa0_auto_provisioning', 'name' => 'Auto provisioning', 'function' => 'render_auto_provisioning' ),
-      array( 'id' => 'wpa0_passwordless_enabled', 'name' => 'Use passwordless login', 'function' => 'render_passwordless_enabled' ),
-      array( 'id' => 'wpa0_passwordless_method', 'name' => 'Use passwordless login', 'function' => 'render_passwordless_method' ),
-
-      array( 'id' => 'wpa0_force_https_callback', 'name' => 'Force HTTPS callback', 'function' => 'render_force_https_callback' ),
-
-      array( 'id' => 'wpa0_cdn_url', 'name' => 'Widget URL', 'function' => 'render_cdn_url' ),
-
-      array( 'id' => 'wpa0_connections', 'name' => 'Connections', 'function' => 'render_connections' ),
-
-      array( 'id' => 'wpa0_remember_users_session', 'name' => 'Remember users session', 'function' => 'render_remember_users_session' ),
-      array( 'id' => 'wpa0_link_auth0_users', 'name' => 'Link users with same email', 'function' => 'render_link_auth0_users' ),
-
-      array( 'id' => 'wpa0_social_twitter_key', 'name' => 'Twitter consumer key', 'function' => 'render_social_twitter_key' ),
-      array( 'id' => 'wpa0_social_twitter_secret', 'name' => 'Twitter consumer secret', 'function' => 'render_social_twitter_secret' ),
-
-      array( 'id' => 'wpa0_social_facebook_key', 'name' => 'Facebook app key', 'function' => 'render_social_facebook_key' ),
-      array( 'id' => 'wpa0_social_facebook_secret', 'name' => 'Facebook app secret', 'function' => 'render_social_facebook_secret' ),
-
-      array( 'id' => 'wpa0_migration_ws', 'name' => 'Users Migration', 'function' => 'render_migration_ws' ),
-      array( 'id' => 'wpa0_migration_ws_ips_filter', 'name' => 'Migration IPs Whitelist', 'function' => 'render_migration_ws_ips_filter' ),
-      array( 'id' => 'wpa0_migration_ws_ips', 'name' => '', 'function' => 'render_migration_ws_ips' ),
-      array( 'id' => 'wpa0_auth0_implicit_workflow', 'name' => 'Auth0 Implicit flow', 'function' => 'render_auth0_implicit_workflow' ),
-      array( 'id' => 'wpa0_default_login_redirection', 'name' => 'Login redirection URL', 'function' => 'render_default_login_redirection' ),
-      array( 'id' => 'wpa0_verified_email', 'name' => 'Requires verified email', 'function' => 'render_verified_email' ),
-      array( 'id' => 'wpa0_auto_login', 'name' => 'Auto Login (no widget)', 'function' => 'render_auto_login' ),
-      array( 'id' => 'wpa0_auto_login_method', 'name' => 'Auto Login Method', 'function' => 'render_auto_login_method' ),
-      array( 'id' => 'wpa0_ip_range_check', 'name' => 'Enable on IP Ranges', 'function' => 'render_ip_range_check' ),
-      array( 'id' => 'wpa0_ip_ranges', 'name' => 'IP Ranges', 'function' => 'render_ip_ranges' ),
-      array( 'id' => 'wpa0_valid_proxy_ip', 'name' => 'Valid Proxy IP', 'function' => 'render_valid_proxy_ip' ),
-      array( 'id' => 'wpa0_custom_signup_fields', 'name' => 'Custom signup fields', 'function' => 'render_custom_signup_fields' ),
-      array( 'id' => 'wpa0_extra_conf', 'name' => 'Extra settings', 'function' => 'render_extra_conf' ),
-      array( 'id' => 'wpa0_auth0_server_domain', 'name' => 'Auth0 server domain', 'function' => 'render_auth0_server_domain' ),
-      array( 'id' => 'wpa0_metrics', 'name' => 'Anonymous data', 'function' => 'render_metrics' ),
-
+    $options = array(
+      array( 'name' => __( 'Require Verified Email', 'wp-auth0' ), 'opt' => 'requires_verified_email',
+        'id' => 'wpa0_verified_email', 'function' => 'render_verified_email' ),
+      array( 'name' => __( 'Remember User Session', 'wp-auth0' ), 'opt' => 'remember_users_session',
+        'id' => 'wpa0_remember_users_session', 'function' => 'render_remember_users_session' ),
+      array( 'name' => __( 'Login Redirection URL', 'wp-auth0' ), 'opt' => 'default_login_redirection',
+        'id' => 'wpa0_default_login_redirection', 'function' => 'render_default_login_redirection' ),
+      array( 'name' => __( 'Passwordless Login', 'wp-auth0' ), 'opt' => 'passwordless_enabled',
+        'id' => 'wpa0_passwordless_enabled', 'function' => 'render_passwordless_enabled' ),
+      array( 'name' => __( 'Force HTTPS Callback', 'wp-auth0' ), 'opt' => 'force_https_callback',
+        'id' => 'wpa0_force_https_callback', 'function' => 'render_force_https_callback' ),
+      array( 'name' => __( 'Lock JS CDN URL', 'wp-auth0' ), 'opt' => 'passwordless_enabled',
+        'id' => 'wpa0_cdn_url', 'function' => 'render_cdn_url' ),
+      array( 'name' => __( 'Connections to Show', 'wp-auth0' ), 'opt' => 'lock_connections',
+        'id' => 'wpa0_connections', 'function' => 'render_connections' ),
+      array( 'name' => __( 'Link Users with Same Email', 'wp-auth0' ), 'opt' => 'link_auth0_users',
+        'id' => 'wpa0_link_auth0_users', 'function' => 'render_link_auth0_users' ),
+      array( 'name' => __( 'Auto Provisioning', 'wp-auth0' ), 'opt' => 'auto_provisioning',
+        'id' => 'wpa0_auto_provisioning', 'function' => 'render_auto_provisioning' ),
+      array( 'name' => __( 'User Migration', 'wp-auth0' ), 'opt' => 'migration_ws',
+        'id' => 'wpa0_migration_ws', 'function' => 'render_migration_ws' ),
+      array( 'name' => __( 'Migration IPs Whitelist', 'wp-auth0' ), 'opt' => 'migration_ips_filter',
+        'id' => 'wpa0_migration_ws_ips_filter', 'function' => 'render_migration_ws_ips_filter' ),
+      array( 'name' => __( 'IP Addresses', 'wp-auth0' ), 'opt' => 'migration_ips_filter',
+        'id' => 'wpa0_migration_ws_ips', 'function' => 'render_migration_ws_ips' ),
+      array( 'name' => __( 'Auto Login', 'wp-auth0' ), 'opt' => 'auto_login',
+        'id' => 'wpa0_auto_login', 'function' => 'render_auto_login' ),
+      array( 'name' => __( 'Auto Login Method', 'wp-auth0' ), 'opt' => 'auto_login_method',
+        'id' => 'wpa0_auto_login_method', 'function' => 'render_auto_login_method' ),
+      array( 'name' => __( 'Implicit Login Flow', 'wp-auth0' ), 'opt' => 'auth0_implicit_workflow',
+        'id' => 'wpa0_auth0_implicit_workflow', 'function' => 'render_auth0_implicit_workflow' ),
+      array( 'name' => __( 'Enable IP Ranges', 'wp-auth0' ), 'opt' => 'ip_range_check',
+        'id' => 'wpa0_ip_range_check', 'function' => 'render_ip_range_check' ),
+      array( 'name' => __( 'IP Ranges', 'wp-auth0' ), 'opt' => 'ip_ranges',
+        'id' => 'wpa0_ip_ranges', 'function' => 'render_ip_ranges' ),
+      array( 'name' => __( 'Valid Proxy IP', 'wp-auth0' ), 'opt' => 'valid_proxy_ip',
+        'id' => 'wpa0_valid_proxy_ip', 'function' => 'render_valid_proxy_ip' ),
+      array( 'name' => __( 'Custom Signup Fields', 'wp-auth0' ), 'opt' => 'custom_signup_fields',
+        'id' => 'wpa0_custom_signup_fields', 'function' => 'render_custom_signup_fields' ),
+      array( 'name' => __( 'Extra Settings', 'wp-auth0' ), 'opt' => 'extra_conf',
+        'id' => 'wpa0_extra_conf', 'function' => 'render_extra_conf' ),
+      array( 'name' => __( 'Twitter Consumer Key', 'wp-auth0' ), 'opt' => 'social_twitter_key',
+        'id' => 'wpa0_social_twitter_key', 'function' => 'render_social_twitter_key' ),
+      array( 'name' => __( 'Twitter Consumer Secret', 'wp-auth0' ), 'opt' => 'social_twitter_secret',
+        'id' => 'wpa0_social_twitter_secret', 'function' => 'render_social_twitter_secret' ),
+      array( 'name' => __( 'Facebook App Key', 'wp-auth0' ), 'opt' => 'social_facebook_key',
+        'id' => 'wpa0_social_facebook_key', 'function' => 'render_social_facebook_key' ),
+      array( 'name' => __( 'Facebook App Secret', 'wp-auth0' ), 'opt' => 'social_facebook_secret',
+        'id' => 'wpa0_social_facebook_secret', 'function' => 'render_social_facebook_secret' ),
+      array( 'name' => __( 'Auth0 Server Domain', 'wp-auth0' ), 'opt' => 'auth0_server_domain',
+        'id' => 'wpa0_auth0_server_domain', 'function' => 'render_auth0_server_domain' ),
+      array( 'name' => __( 'Report Anonymous Data', 'wp-auth0' ), 'opt' => 'metrics',
+        'id' => 'wpa0_metrics', 'function' => 'render_metrics' ),
     );
 
     if ( WP_Auth0_Configure_JWTAUTH::is_jwt_auth_enabled() ) {
-      $advancedOptions[] = array( 'id' => 'wpa0_jwt_auth_integration', 'name' => 'Enable JWT Auth integration', 'function' => 'render_jwt_auth_integration' );
+      $options[] = array( 'name' => 'Enable JWT Auth Integration', 'opt' => 'jwt_auth_integration',
+        'id' => 'wpa0_jwt_auth_integration', 'function' => 'render_jwt_auth_integration' );
     }
 
-    $this->init_option_section( '', 'advanced', $advancedOptions );
+    $this->init_option_section( '', 'advanced', $options );
   }
 
   public function render_passwordless_method() {

--- a/lib/admin/WP_Auth0_Admin_Appearance.php
+++ b/lib/admin/WP_Auth0_Admin_Appearance.php
@@ -21,22 +21,36 @@ class WP_Auth0_Admin_Appearance extends WP_Auth0_Admin_Generic {
 		$this->_description = __( 'Settings related to the way the login widget is shown.', 'wp-auth0' );
 	}
 
+	/**
+	 * All settings in the Appearance tab
+	 *
+	 * @see \WP_Auth0_Admin::init_admin
+	 * @see \WP_Auth0_Admin_Generic::init_option_section
+	 */
 	public function init() {
-
-		$this->init_option_section( '', 'appearance', array(
-
-				array( 'id' => 'wpa0_form_title', 'name' => 'Form Title', 'function' => 'render_form_title' ),
-				array( 'id' => 'wpa0_social_big_buttons', 'name' => 'Show big social buttons', 'function' => 'render_social_big_buttons' ),
-				array( 'id' => 'wpa0_icon_url', 'name' => 'Icon URL', 'function' => 'render_icon_url' ),
-				array( 'id' => 'wpa0_gravatar', 'name' => 'Enable Gravatar integration', 'function' => 'render_gravatar' ),
-				array( 'id' => 'wpa0_custom_css', 'name' => 'Customize the Login Widget CSS', 'function' => 'render_custom_css' ),
-				array( 'id' => 'wpa0_custom_js', 'name' => 'Customize the Login Widget with custom JS', 'function' => 'render_custom_js' ),
-				array( 'id' => 'wpa0_username_style', 'name' => 'Username style', 'function' => 'render_username_style' ),
-        array( 'id' => 'wpa0_primary_color', 'name' => 'Lock primary color', 'function' => 'render_primary_color' ),
-        array( 'id' => 'wpa0_language', 'name' => 'Lock Language', 'function' => 'render_language' ),
-				array( 'id' => 'wpa0_language_dictionary', 'name' => 'Lock Language Dictionary', 'function' => 'render_language_dictionary' ),
-
-			) );
+		$options = array(
+			array( 'name' => __( 'Icon URL', 'wp-auth0' ), 'opt' => 'icon_url',
+				'id' => 'wpa0_icon_url', 'function' => 'render_icon_url' ),
+			array( 'name' => __( 'Form Title', 'wp-auth0' ), 'opt' => 'form_title',
+				'id' => 'wpa0_form_title', 'function' => 'render_form_title' ),
+			array( 'name' => __( 'Big Social Buttons', 'wp-auth0' ), 'opt' => 'social_big_buttons',
+				'id' => 'wpa0_social_big_buttons', 'function' => 'render_social_big_buttons' ),
+			array( 'name' => __( 'Enable Gravatar Integration', 'wp-auth0' ), 'opt' => 'gravatar',
+				'id' => 'wpa0_gravatar', 'function' => 'render_gravatar' ),
+			array( 'name' => __( 'Login Form CSS', 'wp-auth0' ), 'opt' => 'custom_css',
+				'id' => 'wpa0_custom_css', 'function' => 'render_custom_css' ),
+			array( 'name' => __( 'Login Form JS', 'wp-auth0' ), 'opt' => 'custom_js',
+				'id' => 'wpa0_custom_js', 'function' => 'render_custom_js' ),
+			array( 'name' => __( 'Login Name Style', 'wp-auth0' ), 'opt' => 'username_style',
+				'id' => 'wpa0_username_style', 'function' => 'render_username_style' ),
+			array( 'name' => __( 'Primary Color', 'wp-auth0' ), 'opt' => 'primary_color',
+				'id' => 'wpa0_primary_color', 'function' => 'render_primary_color' ),
+			array( 'name' => __( 'Language', 'wp-auth0' ), 'opt' => 'language',
+				'id' => 'wpa0_language', 'function' => 'render_language' ),
+			array( 'name' => __( 'Language Dictionary', 'wp-auth0' ), 'opt' => 'language_dictionary',
+				'id' => 'wpa0_language_dictionary', 'function' => 'render_language_dictionary' ),
+		);
+		$this->init_option_section( '', 'appearance', $options );
 	}
 
 	public function render_form_title() {

--- a/lib/admin/WP_Auth0_Admin_Basic.php
+++ b/lib/admin/WP_Auth0_Admin_Basic.php
@@ -21,24 +21,36 @@ class WP_Auth0_Admin_Basic extends WP_Auth0_Admin_Generic {
 		$this->_description = __( 'Basic settings related to the Auth0 integration.', 'wp-auth0' );
 	}
 
+	/**
+	 * All settings in the Basic tab
+	 *
+	 * @see \WP_Auth0_Admin::init_admin
+	 * @see \WP_Auth0_Admin_Generic::init_option_section
+	 */
 	public function init() {
-
-		/* ------------------------- BASIC ------------------------- */
 		add_action( 'wp_ajax_auth0_delete_cache_transient', array( $this, 'auth0_delete_cache_transient' ) );
 
-		$this->init_option_section( '', 'basic', array(
-
-				array( 'id' => 'wpa0_domain', 'name' => 'Domain', 'function' => 'render_domain' ),
-				array( 'id' => 'wpa0_client_id', 'name' => 'Client ID', 'function' => 'render_client_id' ),
-				array( 'id' => 'wpa0_client_secret', 'name' => 'Client Secret', 'function' => 'render_client_secret' ),
-				array( 'id' => 'wpa0_client_secret_b64_encoded', 'name' => 'Client Secret Base64 Encoded', 'function' => 'render_client_secret_b64_encoded' ),
-				array( 'id' => 'wpa0_client_signing_algorithm', 'name' => 'Client Signing Algorithm', 'function' => 'render_client_signing_algorithm' ),
-				array( 'id' => 'wpa0_cache_expiration', 'name' => 'Cache Time (minutes)', 'function' => 'render_cache_expiration' ),
-				array( 'id' => 'wpa0_auth0_app_token', 'name' => 'API token', 'function' => 'render_auth0_app_token' ),
-				array( 'id' => 'wpa0_login_enabled', 'name' => 'WordPress login enabled', 'function' => 'render_allow_wordpress_login' ),
-				array( 'id' => 'wpa0_allow_signup', 'name' => 'Allow signup', 'function' => 'render_allow_signup' ),
-
-			) );
+		$options = array(
+			array( 'name' => __( 'Domain', 'wp-auth0' ), 'opt' => 'domain',
+                'id' => 'wpa0_domain', 'function' => 'render_domain' ),
+			array( 'name' => __( 'Application ID', 'wp-auth0' ), 'opt' => 'client_id',
+                'id' => 'wpa0_client_id', 'function' => 'render_client_id' ),
+			array( 'name' => __( 'Application Secret', 'wp-auth0' ), 'opt' => 'client_secret',
+                'id' => 'wpa0_client_secret', 'function' => 'render_client_secret' ),
+			array( 'name' => __( 'Application Secret Base64 Encoded', 'wp-auth0' ), 'opt' => 'client_secret_b64_encoded',
+                'id' => 'wpa0_client_secret_b64_encoded', 'function' => 'render_client_secret_b64_encoded' ),
+			array( 'name' => __( 'Application Signing Algorithm', 'wp-auth0' ), 'opt' => 'client_signing_algorithm',
+                'id' => 'wpa0_client_signing_algorithm', 'function' => 'render_client_signing_algorithm' ),
+			array( 'name' => __( 'Cache Time (in minutes)', 'wp-auth0' ), 'opt' => 'cache_expiration',
+                'id' => 'wpa0_cache_expiration', 'function' => 'render_cache_expiration' ),
+			array( 'name' => __( 'API Token', 'wp-auth0' ), 'opt' => 'auth0_app_token',
+                'id' => 'wpa0_auth0_app_token', 'function' => 'render_auth0_app_token' ),
+			array( 'name' => __( 'WordPress Login Enabled', 'wp-auth0' ), 'opt' => 'wordpress_login_enabled',
+                'id' => 'wpa0_login_enabled', 'function' => 'render_allow_wordpress_login' ),
+			array( 'name' => __( 'Allow Signups', 'wp-auth0' ),
+                'id' => 'wpa0_allow_signup', 'function' => 'render_allow_signup' ),
+        );
+		$this->init_option_section( '', 'basic', $options );
 	}
 
 

--- a/lib/admin/WP_Auth0_Admin_Features.php
+++ b/lib/admin/WP_Auth0_Admin_Features.php
@@ -27,20 +27,32 @@ class WP_Auth0_Admin_Features extends WP_Auth0_Admin_Generic {
     $this->_description = __( 'Settings related to specific features provided by the plugin.', 'wp-auth0' );
   }
 
+  /**
+   * All settings in the Features tab
+   *
+   * @see \WP_Auth0_Admin::init_admin
+   * @see \WP_Auth0_Admin_Generic::init_option_section
+   */
   public function init() {
-
-    $this->init_option_section( '', 'features', array(
-
-        array( 'id' => 'wpa0_password_policy', 'name' => 'Password Policy', 'function' => 'render_password_policy' ),
-        array( 'id' => 'wpa0_sso', 'name' => 'Single Sign On (SSO)', 'function' => 'render_sso' ),
-        array( 'id' => 'wpa0_singlelogout', 'name' => 'Single Logout', 'function' => 'render_singlelogout' ),
-        array( 'id' => 'wpa0_mfa', 'name' => 'Multifactor Authentication (MFA)', 'function' => 'render_mfa' ),
-        array( 'id' => 'wpa0_fullcontact', 'name' => 'FullContact integration', 'function' => 'render_fullcontact' ),
-        array( 'id' => 'wpa0_geo', 'name' => 'Store geolocation', 'function' => 'render_geo' ),
-        array( 'id' => 'wpa0_income', 'name' => 'Store zipcode income', 'function' => 'render_income' ),
-        array( 'id' => 'wpa0_override_wp_avatars', 'name' => 'Override WordPress avatars', 'function' => 'render_override_wp_avatars' ),
-
-      ) );
+    $options = array(
+      array( 'name' => __( 'Password Policy', 'wp-auth0' ), 'opt' => 'password_policy',
+        'id' => 'wpa0_password_policy', 'function' => 'render_password_policy' ),
+      array( 'name' => __( 'Single Sign On (SSO)', 'wp-auth0' ), 'opt' => 'sso',
+        'id' => 'wpa0_sso', 'function' => 'render_sso' ),
+      array( 'name' => __( 'Single Logout (SLO)', 'wp-auth0' ), 'opt' => 'singlelogout',
+        'id' => 'wpa0_singlelogout', 'function' => 'render_singlelogout' ),
+      array( 'name' => __( 'Multifactor Authentication (MFA)', 'wp-auth0' ), 'opt' => 'mfa',
+        'id' => 'wpa0_mfa', 'function' => 'render_mfa' ),
+      array( 'name' => __( 'FullContact Integration', 'wp-auth0' ), 'opt' => 'fullcontact',
+        'id' => 'wpa0_fullcontact', 'function' => 'render_fullcontact' ),
+      array( 'name' => __( 'Store Geolocation', 'wp-auth0' ), 'opt' => 'geo_rule',
+        'id' => 'wpa0_geo', 'function' => 'render_geo' ),
+      array( 'name' => __( 'Store Zipcode Income', 'wp-auth0' ), 'opt' => 'income_rule',
+        'id' => 'wpa0_income', 'function' => 'render_income' ),
+      array( 'name' => __( 'Override WordPress Avatars', 'wp-auth0' ), 'opt' => 'override_wp_avatars',
+        'id' => 'wpa0_override_wp_avatars', 'function' => 'render_override_wp_avatars' ),
+    );
+    $this->init_option_section( '', 'features', $options );
   }
 
   public function render_password_policy() {

--- a/lib/admin/WP_Auth0_Admin_Generic.php
+++ b/lib/admin/WP_Auth0_Admin_Generic.php
@@ -19,24 +19,37 @@ class WP_Auth0_Admin_Generic {
 		$this->_option_name = $options->get_options_name();
 	}
 
-	protected function init_option_section( $sectionName, $id, $settings ) {
+	/**
+     * Add settings section and fields for each of the settings screen
+     *
+	 * @param string $section_name - name used for the settings section (usually empty)
+	 * @param string $id - settings screen id
+	 * @param array $options - array of settings fields
+	 */
+	protected function init_option_section( $section_name, $id, $options ) {
 		$options_name = $this->_option_name . '_' . strtolower( $id );
 
 		add_settings_section(
 			"wp_auth0_{$id}_settings_section",
-			$sectionName,
+			$section_name,
 			array( $this, 'render_description' ),
 			$options_name
 		);
 
-		foreach ( $settings as $setting ) {
+		$options = apply_filters( 'auth0_settings_fields', $options, $id );
+
+		foreach ($options as $setting ) {
 			add_settings_field(
 				$setting['id'],
-				__( $setting['name'], 'wp-auth0' ),
+				$setting['name'],
 				array( $this, $setting['function'] ),
 				$options_name,
 				"wp_auth0_{$id}_settings_section",
-				array( 'label_for' => $setting['id'] )
+				// TODO: Use this in render functions
+				array(
+					'label_for' => $setting['id'],
+					'opt_name' => isset( $setting['opt'] ) ? $setting['opt'] : null,
+				)
 			);
 		}
 	}


### PR DESCRIPTION
Setting names were incorrect, confusing in some cases, and used
inconsistent capitalization.

Rewrite setting names and adding proper translations. Add opt names to
the settings array for more simple HTML output (upcoming PR). Add a
filter to add or modify settings array. Changed Client => Application.