### PR TITLE
Remove dashboard widgets

### DIFF
--- a/WP_Auth0.php
+++ b/WP_Auth0.php
@@ -98,9 +98,6 @@ class WP_Auth0 {
 		$configure_jwt_auth = new WP_Auth0_Configure_JWTAUTH( $this->a0_options );
 		$configure_jwt_auth->init();
 
-		$dashboard_widgets = new WP_Auth0_Dashboard_Widgets( $this->a0_options, $this->db_manager );
-		$dashboard_widgets->init();
-
 		$woocommerce_override = new WP_Auth0_WooCommerceOverrides( $this );
 		$woocommerce_override->init();
 
@@ -436,7 +433,6 @@ class WP_Auth0 {
 		$paths[] = $path.'lib/exceptions/';
 		$paths[] = $path.'lib/wizard/';
 		$paths[] = $path.'lib/initial-setup/';
-		$paths[] = $path.'lib/dashboard-widgets/';
 		$paths[] = $path.'lib/twitter-api-php/';
 		$paths[] = $path.'lib/php-jwt/Exceptions/';
 		$paths[] = $path.'lib/php-jwt/Authentication/';

--- a/lib/admin/WP_Auth0_Admin.php
+++ b/lib/admin/WP_Auth0_Admin.php
@@ -137,11 +137,6 @@ class WP_Auth0_Admin {
 		$this->sections['advanced'] = new WP_Auth0_Admin_Advanced( $this->a0_options, $this->router );
 		$this->sections['advanced']->init();
 
-		/* ------------------------- DASHBOARD ------------------------- */
-
-		$this->sections['dashboard'] = new WP_Auth0_Admin_Dashboard( $this->a0_options );
-		$this->sections['dashboard']->init();
-
 		register_setting( $this->a0_options->get_options_name() . '_basic', $this->a0_options->get_options_name(), array( $this, 'input_validator' ) );
 
 	}

--- a/lib/admin/WP_Auth0_Admin_Dashboard.php
+++ b/lib/admin/WP_Auth0_Admin_Dashboard.php
@@ -1,8 +1,7 @@
 <?php
-
+// TODO: Deprecate
 class WP_Auth0_Admin_Dashboard extends WP_Auth0_Admin_Generic {
 
-	// TODO: Deprecate
 	const DASHBOARD_DESCRIPTION = 'Settings related to the dashboard widgets.';
 
 	protected $_description;

--- a/lib/dashboard-widgets/WP_Auth0_Dashboard_Plugins_Age.php
+++ b/lib/dashboard-widgets/WP_Auth0_Dashboard_Plugins_Age.php
@@ -1,5 +1,5 @@
 <?php
-
+// TODO: Deprecate
 class WP_Auth0_Dashboard_Plugins_Age extends WP_Auth0_Dashboard_Plugins_Generic {
 
 	protected $id = 'auth0_dashboard_widget_age';

--- a/lib/dashboard-widgets/WP_Auth0_Dashboard_Plugins_Gender.php
+++ b/lib/dashboard-widgets/WP_Auth0_Dashboard_Plugins_Gender.php
@@ -1,5 +1,5 @@
 <?php
-
+// TODO: Deprecate
 class WP_Auth0_Dashboard_Plugins_Gender extends WP_Auth0_Dashboard_Plugins_Generic {
 
 	protected $id = 'auth0_dashboard_widget_gender';

--- a/lib/dashboard-widgets/WP_Auth0_Dashboard_Plugins_Generic.php
+++ b/lib/dashboard-widgets/WP_Auth0_Dashboard_Plugins_Generic.php
@@ -1,5 +1,5 @@
 <?php
-
+// TODO: Deprecate
 class WP_Auth0_Dashboard_Plugins_Generic {
 
 	protected function gettype( $user ) {

--- a/lib/dashboard-widgets/WP_Auth0_Dashboard_Plugins_IdP.php
+++ b/lib/dashboard-widgets/WP_Auth0_Dashboard_Plugins_IdP.php
@@ -1,5 +1,5 @@
 <?php
-
+// TODO: Deprecate
 class WP_Auth0_Dashboard_Plugins_IdP extends WP_Auth0_Dashboard_Plugins_Generic {
 
 	protected $id = 'auth0_dashboard_widget_idp';

--- a/lib/dashboard-widgets/WP_Auth0_Dashboard_Plugins_Income.php
+++ b/lib/dashboard-widgets/WP_Auth0_Dashboard_Plugins_Income.php
@@ -1,5 +1,5 @@
 <?php
-
+// TODO: Deprecate
 class WP_Auth0_Dashboard_Plugins_Income extends WP_Auth0_Dashboard_Plugins_Generic {
 
 	protected $id = 'auth0_dashboard_widget_income';

--- a/lib/dashboard-widgets/WP_Auth0_Dashboard_Plugins_Location.php
+++ b/lib/dashboard-widgets/WP_Auth0_Dashboard_Plugins_Location.php
@@ -1,5 +1,5 @@
 <?php
-
+// TODO: Deprecate
 class WP_Auth0_Dashboard_Plugins_Location extends WP_Auth0_Dashboard_Plugins_Generic {
 
 	protected $id = 'auth0_dashboard_widget_Location';

--- a/lib/dashboard-widgets/WP_Auth0_Dashboard_Plugins_Signups.php
+++ b/lib/dashboard-widgets/WP_Auth0_Dashboard_Plugins_Signups.php
@@ -1,5 +1,5 @@
 <?php
-
+// TODO: Deprecate
 class WP_Auth0_Dashboard_Plugins_Signups extends WP_Auth0_Dashboard_Plugins_Generic {
 
 	protected $id = 'auth0_dashboard_widget_signups';

--- a/lib/dashboard-widgets/WP_Auth0_Dashboard_Widgets.php
+++ b/lib/dashboard-widgets/WP_Auth0_Dashboard_Widgets.php
@@ -1,5 +1,5 @@
 <?php
-
+// TODO: Deprecate
 class WP_Auth0_Dashboard_Widgets {
 
 	protected $db_manager;

--- a/templates/settings.php
+++ b/templates/settings.php
@@ -23,7 +23,6 @@
 		    <li role="presentation"><a id="tab-features" href="#features" aria-controls="features" role="tab" data-toggle="tab">Features</a></li>
 			<li role="presentation"><a id="tab-appearance" href="#appearance" aria-controls="appearance" role="tab" data-toggle="tab">Appearance</a></li>
 		    <li role="presentation"><a id="tab-advanced" href="#advanced" aria-controls="advanced" role="tab" data-toggle="tab">Advanced</a></li>
-		    <li role="presentation"><a id="tab-dashboard" href="#dashboard" aria-controls="dashboard" role="tab" data-toggle="tab">Dashboard</a></li>
 		    <li role="presentation"><a id="tab-help" href="#help" aria-controls="help" role="tab" data-toggle="tab">Help</a></li>
 		  </ul>
 		</div>
@@ -42,9 +41,6 @@
 		    </div>
 		    <div role="tabpanel" class="tab-pane row" id="advanced">
 					<?php do_settings_sections( WP_Auth0_Options::Instance()->get_options_name() . '_advanced' ); ?>
-		    </div>
-		    <div role="tabpanel" class="tab-pane row" id="dashboard">
-					<?php do_settings_sections( WP_Auth0_Options::Instance()->get_options_name() . '_dashboard' ); ?>
 		    </div>
 		    <div role="tabpanel" class="tab-pane row" id="help">
 


### PR DESCRIPTION
The dashboard widgets clutter the admin, do not display usable data,
and create an unecessary maintenance burden. This functionality can
easily be re-created as a separate plugin if necessary.

This commit will remove the dashboard widgets output, remove related
settings, and add TODOs for proper deprecation.