### PR TITLE
Improved code quality in WP_Auth0_LoginManager

### DIFF
--- a/lib/WP_Auth0_LoginManager.php
+++ b/lib/WP_Auth0_LoginManager.php
@@ -1,21 +1,78 @@
 <?php
+/**
+ * WP_Auth0_LoginManager class
+ *
+ * @package WordPress
+ * @subpackage WP-Auth0
+ * @since 2.0.0
+ */
 
+/**
+ * Handles login callbacks and auto-login redirecting
+ *
+ * @since 2.0.0
+ */
 class WP_Auth0_LoginManager {
 
+	/**
+	 * Instance of WP_Auth0_Options.
+	 *
+	 * @var null|WP_Auth0_Options
+	 */
 	protected $a0_options;
-	protected $default_role;
+
+	/**
+	 * Should the new user have an administrator role?
+	 *
+	 * @var bool|null
+	 */
+	protected $admin_role;
+
+	/**
+	 * Ignore verified email requirement in Settings > Advanced.
+	 *
+	 * @var bool
+	 */
 	protected $ignore_unverified_email;
+
+	/**
+	 * User strategy to use.
+	 *
+	 * @var WP_Auth0_UsersRepo
+	 */
 	protected $users_repo;
+
+	/**
+	 * State value returned from successful Auth0 login.
+	 *
+	 * @var string
+	 *
+	 * @see WP_Auth0_Lock10_Options::get_state_obj()
+	 */
 	protected $state;
+
+	/**
+	 * Decoded version of $this>state.
+	 *
+	 * @var object
+	 */
 	protected $state_decoded;
 
+	/**
+	 * WP_Auth0_LoginManager constructor.
+	 *
+	 * @param WP_Auth0_UsersRepo    $users_repo - see member variable doc comment.
+	 * @param WP_Auth0_Options|null $a0_options - see member variable doc comment.
+	 * @param null|bool             $admin_role - see member variable doc comment.
+	 * @param bool                  $ignore_unverified_email - see member variable doc comment.
+	 */
 	public function __construct(
 		WP_Auth0_UsersRepo $users_repo,
 		$a0_options = null,
-		$default_role = null,
+		$admin_role = null,
 		$ignore_unverified_email = false
 	) {
-		$this->default_role            = $default_role;
+		$this->admin_role              = $admin_role;
 		$this->ignore_unverified_email = $ignore_unverified_email;
 		$this->users_repo              = $users_repo;
 
@@ -26,16 +83,24 @@ class WP_Auth0_LoginManager {
 		}
 	}
 
+	/**
+	 * Attach methods to hooks.
+	 * See method comments for functionality.
+	 *
+	 * @see WP_Auth0::init()
+	 */
 	public function init() {
 		add_action( 'login_init', array( $this, 'login_auto' ) );
 		add_action( 'template_redirect', array( $this, 'init_auth0' ), 1 );
 		add_action( 'wp_logout', array( $this, 'logout' ) );
 		add_filter( 'login_message', array( $this, 'auth0_sso_footer' ) );
-		// add_action( 'wp_footer', array( $this, 'auth0_sso_footer' ) );
 		add_action( 'wp_footer', array( $this, 'auth0_singlelogout_footer' ) );
 		add_action( 'wp_login', array( $this, 'end_session' ) );
 	}
 
+	/**
+	 * Redirect to a specific connection designated in Settings > Advanced
+	 */
 	public function login_auto() {
 		$auto_login = absint( $this->a0_options->get( 'auto_login' ) );
 
@@ -61,38 +126,43 @@ class WP_Auth0_LoginManager {
 			// Create the link to log in.
 			$login_url = 'https://' . $this->a0_options->get( 'domain' ) .
 						'/authorize?' .
-						'scope=' . urlencode( $options['auth']['params']['scope'] ) .
+						'scope=' . rawurlencode( $options['auth']['params']['scope'] ) .
 						'&response_type=' . $response_type .
 						'&client_id=' . $this->a0_options->get( 'client_id' ) .
 						'&redirect_uri=' . $options['auth']['redirectUrl'] .
-						'&state=' . urlencode( $state ) .
+						'&state=' . rawurlencode( $state ) .
 						'&nonce=' . WP_Auth0_Nonce_Handler::getInstance()->get() .
 						'&connection=' . trim( $connection ) .
 						'&auth0Client=' . WP_Auth0_Api_Client::get_info_headers();
 
 			setcookie( WPA0_STATE_COOKIE_NAME, $state, time() + WP_Auth0_Nonce_Handler::COOKIE_EXPIRES, '/' );
 			wp_redirect( $login_url );
-			die();
+			exit;
 		}
 	}
 
+	/**
+	 * Process an incoming successful login from Auth0, aka login callback.
+	 * Auth0 must be configured and 'auth0' URL parameter not empty.
+	 * Handles errors and state validation
+	 */
 	public function init_auth0() {
 
-		// Not an Auth0 login process or settings are not configured to allow logins
+		// Not an Auth0 login process or settings are not configured to allow logins.
 		if ( ! $this->query_vars( 'auth0' ) || ! WP_Auth0::ready() ) {
 			return;
 		}
 
-		// Catch any incoming errors and stop the login process
-		// See https://auth0.com/docs/libraries/error-messages
+		// Catch any incoming errors and stop the login process.
+		// See https://auth0.com/docs/libraries/error-messages for more info.
 		if ( $this->query_vars( 'error' ) || $this->query_vars( 'error_description' ) ) {
 			$error_msg  = sanitize_text_field( $this->query_vars( 'error_description' ) );
 			$error_code = sanitize_text_field( $this->query_vars( 'error' ) );
 			$this->die_on_login( $error_msg, $error_code );
 		}
 
-		// Check for valid state nonce, set in WP_Auth0_Lock10_Options::get_state_obj()
-		// See https://auth0.com/docs/protocols/oauth2/oauth-state
+		// Check for valid state nonce, set in WP_Auth0_Lock10_Options::get_state_obj().
+		// See https://auth0.com/docs/protocols/oauth2/oauth-state for more info.
 		if ( ! $this->validate_state() ) {
 			$this->die_on_login( __( 'Invalid state', 'wp-auth0' ) );
 		}
@@ -105,33 +175,32 @@ class WP_Auth0_LoginManager {
 			}
 		} catch ( WP_Auth0_LoginFlowValidationException $e ) {
 
-			// Errors during the OAuth login flow
+			// Errors encountered during the OAuth login flow.
 			$this->die_on_login( $e->getMessage(), $e->getCode() );
 
 		} catch ( WP_Auth0_BeforeLoginException $e ) {
 
-			// Errors during the WordPress login flow
+			// Errors encountered during the WordPress login flow.
 			$this->die_on_login( $e->getMessage(), $e->getCode(), false );
 		}
 	}
 
 	/**
-	 * Main login flow, Authorization Code Grant
+	 * Main login flow using the Authorization Code Grant.
 	 *
-	 * @throws WP_Auth0_BeforeLoginException
-	 * @throws WP_Auth0_LoginFlowValidationException
+	 * @throws WP_Auth0_LoginFlowValidationException - OAuth login flow errors.
+	 * @throws WP_Auth0_BeforeLoginException - Errors encountered during the auth0_before_login action.
 	 *
-	 * @see https://auth0.com/docs/api-auth/tutorials/authorization-code-grant
+	 * @link https://auth0.com/docs/api-auth/tutorials/authorization-code-grant
 	 */
 	public function redirect_login() {
+		$domain             = $this->a0_options->get( 'domain' );
+		$client_id          = $this->a0_options->get( 'client_id' );
+		$client_secret      = $this->a0_options->get( 'client_secret' );
+		$userinfo_resp_code = null;
+		$userinfo_resp_body = null;
 
-		$domain        = $this->a0_options->get( 'domain' );
-		$client_id     = $this->a0_options->get( 'client_id' );
-		$client_secret = $this->a0_options->get( 'client_secret' );
-
-		$userinfo_resp_code = $userinfo_resp_body = null;
-
-		// Exchange authorization code for token
+		// Exchange authorization code for an access token.
 		$exchange_resp = WP_Auth0_Api_Client::get_token(
 			$domain, $client_id, $client_secret, 'authorization_code', array(
 				'redirect_uri' => home_url(),
@@ -144,7 +213,7 @@ class WP_Auth0_LoginManager {
 
 		if ( 401 === $exchange_resp_code ) {
 
-			// Not authorized
+			// Not authorized to access the site.
 			WP_Auth0_ErrorManager::insert_auth0_error(
 				__METHOD__ . ' L:' . __LINE__,
 				__( 'An /oauth/token call triggered a 401 response from Auth0. ', 'wp-auth0' ) .
@@ -154,7 +223,7 @@ class WP_Auth0_LoginManager {
 
 		} elseif ( empty( $exchange_resp_body ) ) {
 
-			// Unsuccessful for another reason
+			// Unsuccessful for another reason.
 			if ( $exchange_resp instanceof WP_Error ) {
 				WP_Auth0_ErrorManager::insert_auth0_error( __METHOD__ . ' L:' . __LINE__, $exchange_resp );
 			}
@@ -166,20 +235,20 @@ class WP_Auth0_LoginManager {
 
 		if ( empty( $data->access_token ) ) {
 
-			// Look for clues as to what went wrong
+			// Look for clues as to what went wrong.
 			$e_message = ! empty( $data->error_description ) ? $data->error_description : __( 'Unknown error', 'wp-auth0' );
 			$e_code    = ! empty( $data->error ) ? $data->error : $exchange_resp_code;
 			throw new WP_Auth0_LoginFlowValidationException( $e_message, $e_code );
 		}
 
-		// Decode our incoming ID token for the Auth0 user_id
+		// Decode the incoming ID token for the Auth0 user.
 		$decoded_token = JWT::decode(
 			$data->id_token,
 			$this->a0_options->get_client_secret_as_key(),
 			array( $this->a0_options->get_client_signing_algorithm() )
 		);
 
-		// Attempt to authenticate with the Management API
+		// Attempt to authenticate with the Management API.
 		$client_credentials_token = WP_Auth0_Api_Client::get_client_token();
 
 		if ( $client_credentials_token ) {
@@ -188,7 +257,7 @@ class WP_Auth0_LoginManager {
 			$userinfo_resp_body = wp_remote_retrieve_body( $userinfo_resp );
 		}
 
-		// Management API call failed, fallback to userinfo
+		// Management API call failed, fallback to userinfo.
 		if ( 200 !== $userinfo_resp_code || empty( $userinfo_resp_body ) ) {
 
 			$userinfo_resp      = WP_Auth0_Api_Client::get_user_info( $domain, $data->access_token );
@@ -213,11 +282,11 @@ class WP_Auth0_LoginManager {
 				include WPA0_PLUGIN_DIR . 'templates/login-interim.php';
 			} else {
 				if ( ! empty( $state_decoded->redirect_to ) && wp_login_url() !== $state_decoded->redirect_to ) {
-					$redirectURL = $state_decoded->redirect_to;
+					$redirect_url = $state_decoded->redirect_to;
 				} else {
-					$redirectURL = $this->a0_options->get( 'default_login_redirection' );
+					$redirect_url = $this->a0_options->get( 'default_login_redirection' );
 				}
-				wp_safe_redirect( $redirectURL );
+				wp_safe_redirect( $redirect_url );
 			}
 			exit();
 		}
@@ -227,39 +296,44 @@ class WP_Auth0_LoginManager {
 	 * Secondary login flow, Implicit Grant
 	 * Client should be of type "Single Page App" for this flow
 	 *
-	 * @throws WP_Auth0_BeforeLoginException
-	 * @throws WP_Auth0_LoginFlowValidationException
+	 * @throws WP_Auth0_LoginFlowValidationException - OAuth login flow errors.
+	 * @throws WP_Auth0_BeforeLoginException - Errors encountered during the auth0_before_login action.
 	 *
-	 * @see https://auth0.com/docs/api-auth/tutorials/implicit-grant
+	 * @link https://auth0.com/docs/api-auth/tutorials/implicit-grant
+	 *
 	 * @see /wp-content/plugins/auth0/assets/js/implicit-login.js
+	 *
+	 * TODO: Add a WP nonce!
 	 */
 	public function implicit_login() {
+		if ( empty( $_POST['token'] ) ) {
+			throw new WP_Auth0_LoginFlowValidationException( __( 'No ID token found', 'wp-auth0' ) );
+		}
 
-		// Posted from the login page here
-		$token = $_POST['token'];
+		// Posted from the login page to the callback URL.
+		$token = sanitize_text_field( wp_unslash( $_POST['token'] ) );
 
 		try {
-			$decodedToken = JWT::decode(
+			$decoded_token = JWT::decode(
 				$token,
 				$this->a0_options->get_client_secret_as_key(),
 				array( $this->a0_options->get_client_signing_algorithm() )
 			);
 		} catch ( UnexpectedValueException $e ) {
 			WP_Auth0_ErrorManager::insert_auth0_error( __METHOD__, $e );
-			error_log( $e->getMessage() );
 			throw new WP_Auth0_LoginFlowValidationException();
 		}
 
-		// Validate that this JWT was made for us
-		if ( $this->a0_options->get( 'client_id' ) !== $decodedToken->aud ) {
+		// Validate that this JWT was made for us.
+		if ( $this->a0_options->get( 'client_id' ) !== $decoded_token->aud ) {
 			throw new WP_Auth0_LoginFlowValidationException(
 				__( 'This token is not intended for us', 'wp-auth0' )
 			);
 		}
 
-		// Validate the nonce if one was included in the request (auto-login)
+		// Validate the nonce if one was included in the request if using auto-login.
 		if ( $this->a0_options->get( 'auto_login' ) ) {
-			$nonce = isset( $decodedToken->nonce ) ? $decodedToken->nonce : null;
+			$nonce = isset( $decoded_token->nonce ) ? $decoded_token->nonce : null;
 			if ( ! WP_Auth0_Nonce_Handler::getInstance()->validate( $nonce ) ) {
 				throw new WP_Auth0_LoginFlowValidationException(
 					__( 'Invalid nonce', 'wp-auth0' )
@@ -267,12 +341,12 @@ class WP_Auth0_LoginManager {
 			}
 		}
 
-		// Legacy userinfo property
-		$decodedToken->user_id = $decodedToken->sub;
+		// Populate legacy userinfo property.
+		$decoded_token->user_id = $decoded_token->sub;
 
-		if ( $this->login_user( $decodedToken, $token, null ) ) {
+		if ( $this->login_user( $decoded_token, $token, null ) ) {
 
-			// Validated in $this->init_auth0()
+			// Validated above in $this->init_auth0().
 			$state_decoded = $this->get_state( true );
 
 			if ( ! empty( $state_decoded->interim ) ) {
@@ -289,34 +363,31 @@ class WP_Auth0_LoginManager {
 	}
 
 	/**
-	 * @param object $userinfo - the Auth0 profile of the user
-	 * @param string $id_token - user's ID token returned from Auth0
-	 * @param string $access_token - user's access token returned from Auth0; not provided when using implicit_login()
+	 * Attempts to log the user in and create a new user, if possible/needed.
+	 *
+	 * @param object $userinfo - Auth0 profile of the user.
+	 * @param string $id_token - user's ID token returned from Auth0.
+	 * @param string $access_token - user's access token returned from Auth0; not provided when using implicit_login().
 	 *
 	 * @return bool
 	 *
-	 * @throws WP_Auth0_BeforeLoginException
-	 * @throws WP_Auth0_LoginFlowValidationException
+	 * @throws WP_Auth0_LoginFlowValidationException - OAuth login flow errors.
+	 * @throws WP_Auth0_BeforeLoginException - Errors encountered during the auth0_before_login action.
 	 */
 	public function login_user( $userinfo, $id_token, $access_token ) {
-		// If the userinfo has no email or an unverified email, and in the options we require a verified email
-		// notify the user he cant login until he does so.
-		$requires_verified_email = $this->a0_options->get( 'requires_verified_email' );
-
-		if ( ! $this->ignore_unverified_email && 1 == $requires_verified_email ) {
+		// Check that the user has a verified email, if required.
+		if ( ! $this->ignore_unverified_email && $this->a0_options->get( 'requires_verified_email' ) ) {
 			if ( empty( $userinfo->email ) ) {
-				$msg = __(
-					'This account does not have an email associated, as required by your site administrator.',
-					'wp-auth0'
+				throw new WP_Auth0_LoginFlowValidationException(
+					__( 'This account does not have an email associated, as required by your site administrator.', 'wp-auth0' )
 				);
-				throw new WP_Auth0_LoginFlowValidationException( $msg );
 			}
 			if ( ! $userinfo->email_verified ) {
 				WP_Auth0_Email_Verification::render_die( $userinfo );
 			}
 		}
 
-		// See if there is a user linked to the same auth0 user_id
+		// See if there is a user linked to the same Auth0 user_id.
 		if ( isset( $userinfo->identities ) ) {
 			foreach ( $userinfo->identities as $identity ) {
 				$user = $this->users_repo->find_auth0_user( "{$identity->provider}|{$identity->user_id}" );
@@ -331,7 +402,7 @@ class WP_Auth0_LoginManager {
 		$user = apply_filters( 'auth0_get_wp_user', $user, $userinfo );
 
 		if ( ! is_null( $user ) ) {
-			// User exists! Log in
+			// User exists so log them in.
 			if ( isset( $userinfo->email ) && $user->data->user_email !== $userinfo->email ) {
 				$description = $user->data->description;
 				if ( empty( $description ) ) {
@@ -348,13 +419,12 @@ class WP_Auth0_LoginManager {
 						$description = $userinfo->about;
 					}
 				}
-				$user_id = wp_update_user(
-					array(
-						'ID'          => $user->data->ID,
-						'user_email'  => $userinfo->email,
-						'description' => $description,
-					)
-				);
+
+				wp_update_user( array(
+					'ID'          => $user->data->ID,
+					'user_email'  => $userinfo->email,
+					'description' => $description,
+				) );
 			}
 
 			$this->users_repo->update_auth0_object( $user->data->ID, $userinfo );
@@ -370,7 +440,7 @@ class WP_Auth0_LoginManager {
 					$userinfo,
 					$id_token,
 					$access_token,
-					$this->default_role,
+					$this->admin_role,
 					$this->ignore_unverified_email
 				);
 				$user    = get_user_by( 'id', $user_id );
@@ -396,19 +466,17 @@ class WP_Auth0_LoginManager {
 	/**
 	 * Does all actions required to log the user in to WordPress, invoking hooks as necessary
 	 *
-	 * @param object $user - the WP user object, such as returned by get_user_by()
-	 * @param object $userinfo - the Auth0 profile of the user
-	 * @param bool   $is_new - `true` if the user was created in the WordPress database, `false` if not
-	 * @param string $id_token - user's ID token returned from Auth0
-	 * @param string $access_token - user's access token returned from Auth0; not provided when using implicit_login()
+	 * @param object $user - the WP user object, such as returned by get_user_by().
+	 * @param object $userinfo - the Auth0 profile of the user.
+	 * @param bool   $is_new - `true` if the user was created in the WordPress database, `false` if not.
+	 * @param string $id_token - user's ID token returned from Auth0.
+	 * @param string $access_token - user's access token returned from Auth0; not provided when using implicit_login().
 	 *
-	 * @throws WP_Auth0_BeforeLoginException
+	 * @throws WP_Auth0_BeforeLoginException - Errors encountered during the auth0_before_login action.
 	 */
 	private function do_login( $user, $userinfo, $is_new, $id_token, $access_token ) {
 		$remember_users_session = $this->a0_options->get( 'remember_users_session' );
 
-		// allow other hooks to run prior to login
-		// if something goes wrong with the login, they should throw an exception.
 		try {
 			do_action( 'auth0_before_login', $user );
 		} catch ( Exception $e ) {
@@ -417,7 +485,7 @@ class WP_Auth0_LoginManager {
 
 		$secure_cookie = is_ssl();
 
-		// See wp_signon() for documentation on this filter
+		// See wp_signon() for documentation on this filter.
 		$secure_cookie = apply_filters(
 			'secure_signon_cookie', $secure_cookie, array(
 				'user_login'    => $user->user_login,
@@ -431,6 +499,12 @@ class WP_Auth0_LoginManager {
 		do_action( 'auth0_user_login', $user->ID, $userinfo, $is_new, $id_token, $access_token );
 	}
 
+	/**
+	 * Complete the logout process based on settings.
+	 * Hooked to `wp_logout` action.
+	 *
+	 * @see WP_Auth0_LoginManager::init()
+	 */
 	public function logout() {
 		$this->end_session();
 
@@ -439,28 +513,37 @@ class WP_Auth0_LoginManager {
 		$client_id  = $this->a0_options->get( 'client_id' );
 		$auto_login = absint( $this->a0_options->get( 'auto_login' ) );
 
-		if ( $slo && isset( $_REQUEST['SLO'] ) ) {
+		if ( $slo && isset( $_REQUEST['SLO'] ) && isset( $_REQUEST['redirect_to'] ) ) {
 			wp_redirect( $_REQUEST['redirect_to'] );
-			die();
+			exit;
 		}
 
 		if ( $sso ) {
 			wp_redirect(
 				'https://' . $this->a0_options->get( 'domain' ) .
-				'/v2/logout?federated&returnTo=' . urlencode( home_url() ) . '&client_id=' . $client_id .
-				'&auth0Client=' . base64_encode( json_encode( WP_Auth0_Api_Client::get_info_headers() ) )
+				'/v2/logout?federated&returnTo=' . rawurlencode( home_url() ) . '&client_id=' . $client_id .
+				'&auth0Client=' . base64_encode( wp_json_encode( WP_Auth0_Api_Client::get_info_headers() ) )
 			);
-			die();
+			exit;
 		}
 
 		if ( $auto_login ) {
 			wp_redirect( home_url() );
-			die();
+			exit;
 		}
 	}
 
+	/**
+	 * Outputs JS on wp-login.php to log a user in if an Auth0 session is found.
+	 * Hooked to `login_message` filter.
+	 *
+	 * @param string $previous_html - HTML passed into the login_message filter.
+	 *
+	 * @see WP_Auth0_LoginManager::init()
+	 */
 	public function auth0_sso_footer( $previous_html ) {
 
+		// TODO: Filter handling is incorrect here!
 		echo $previous_html;
 
 		if ( is_user_logged_in() ) {
@@ -481,29 +564,36 @@ class WP_Auth0_LoginManager {
 		}
 	}
 
-	public function auth0_singlelogout_footer( $previous_html ) {
-
-		echo $previous_html;
-
-		if ( ! is_user_logged_in() ) {
-			return;
+	/**
+	 * Outputs JS on all pages to log a user out if no Auth0 session is found.
+	 * Hooked to `wp_footer` action.
+	 *
+	 * @see WP_Auth0_LoginManager::init()
+	 */
+	public function auth0_singlelogout_footer() {
+		if ( is_user_logged_in() && $this->a0_options->get( 'singlelogout' ) ) {
+			include WPA0_PLUGIN_DIR . 'templates/auth0-singlelogout-handler.php';
 		}
-
-		$singlelogout = $this->a0_options->get( 'singlelogout' );
-
-		if ( ! $singlelogout ) {
-			return;
-		}
-
-		include WPA0_PLUGIN_DIR . 'templates/auth0-singlelogout-handler.php';
 	}
 
+	/**
+	 * End the PHP session.
+	 *
+	 * TODO: Remove, not necessary!
+	 */
 	public function end_session() {
 		if ( session_id() ) {
 			session_destroy();
 		}
 	}
 
+	/**
+	 * Get a value from query_vars or $_REQUEST global.
+	 *
+	 * @param string $key - query var key to return.
+	 *
+	 * @return string|null
+	 */
 	protected function query_vars( $key ) {
 		global $wp_query;
 		if ( isset( $wp_query->query_vars[ $key ] ) ) {
@@ -516,21 +606,21 @@ class WP_Auth0_LoginManager {
 	}
 
 	/**
-	 * Get and store state returned from Auth0
+	 * Get the state value returned from Auth0 during login processing.
 	 *
-	 * @param bool $decoded - `true` to return decoded state
+	 * @param bool $decoded - pass `true` to return decoded state, leave blank for raw string.
 	 *
 	 * @return string|object|null
 	 */
 	protected function get_state( $decoded = false ) {
 
 		if ( empty( $this->state ) ) {
-			// Get and store base64 encoded state
+			// Get and store base64 encoded state.
 			$state_val   = isset( $_REQUEST['state'] ) ? $_REQUEST['state'] : '';
 			$state_val   = urldecode( $state_val );
 			$this->state = $state_val;
 
-			// Decode and store
+			// Decode and store the state.
 			$state_val           = base64_decode( $state_val );
 			$this->state_decoded = json_decode( $state_val );
 		}
@@ -543,7 +633,7 @@ class WP_Auth0_LoginManager {
 	}
 
 	/**
-	 * Check the state send back from Auth0 with the one stored in the user's browser
+	 * Check the state send back from Auth0 with the one stored in the user's browser.
 	 *
 	 * @return bool
 	 */
@@ -558,9 +648,9 @@ class WP_Auth0_LoginManager {
 	/**
 	 * Die during login process with a message
 	 *
-	 * @param string     $msg - translated error message to display
-	 * @param string|int $code - error code, if given
-	 * @param bool       $login_link - TRUE for login link, FALSE for logout link
+	 * @param string     $msg - translated error message to display.
+	 * @param string|int $code - error code, if given.
+	 * @param bool       $login_link - TRUE for login link, FALSE for logout link.
 	 */
 	protected function die_on_login( $msg = '', $code = 0, $login_link = true ) {
 		wp_die(
@@ -583,23 +673,23 @@ class WP_Auth0_LoginManager {
 	}
 
 	/**
-	 * Deprecated to conform to OIDC standards
+	 * Login using oauth/ro endpoint
 	 *
-	 * @see https://auth0.com/docs/api-auth/intro#other-authentication-api-endpoints
+	 * @deprecated 3.6.0 - Use Password Grant instead.
 	 *
-	 * @deprecated 3.6.0
-	 *
-	 * @param string $username
-	 * @param string $password
-	 * @param string $connection
+	 * @param string $username - Username from the login form.
+	 * @param string $password - Password from the login form.
+	 * @param string $connection - Database connection to use.
 	 *
 	 * @return bool
 	 *
-	 * @throws Exception
-	 * @throws WP_Auth0_BeforeLoginException
-	 * @throws WP_Auth0_LoginFlowValidationException
+	 * @throws WP_Auth0_LoginFlowValidationException - OAuth login flow errors.
+	 * @throws WP_Auth0_BeforeLoginException - Errors encountered during the auth0_before_login action.
+	 *
+	 * @link https://auth0.com/docs/api-auth/intro#other-authentication-api-endpoints
 	 */
 	public function login_with_credentials( $username, $password, $connection = 'Username-Password-Authentication' ) {
+		// phpcs:ignore
 		trigger_error( sprintf( __( 'Method %s is deprecated.', 'wp-auth0' ), E_USER_DEPRECATED ) );
 		$domain    = $this->a0_options->get( 'domain' );
 		$client_id = $this->a0_options->get( 'client_id' );
@@ -609,23 +699,22 @@ class WP_Auth0_LoginManager {
 			'openid name email nickname email_verified identities'
 		);
 		try {
-			// Decode the user
-			$decodedToken = JWT::decode(
+			// Decode the returned ID token.
+			$decoded_token = JWT::decode(
 				$response->id_token,
 				$secret,
 				array( $this->a0_options->get_client_signing_algorithm() )
 			);
-			// validate that this JWT was made for us
-			if ( $this->a0_options->get( 'client_id' ) !== $decodedToken->aud ) {
-				throw new Exception( 'This token is not intended for us.' );
+			// Validate that this JWT was made for us.
+			if ( $this->a0_options->get( 'client_id' ) !== $decoded_token->aud ) {
+				throw new WP_Auth0_LoginFlowValidationException( 'This token is not intended for us.' );
 			}
-			$decodedToken->user_id = $decodedToken->sub;
-			if ( $this->login_user( $decodedToken, $response->id_token, $response->access_token ) ) {
+			$decoded_token->user_id = $decoded_token->sub;
+			if ( $this->login_user( $decoded_token, $response->id_token, $response->access_token ) ) {
 				return false;
 			}
 		} catch ( UnexpectedValueException $e ) {
 			WP_Auth0_ErrorManager::insert_auth0_error( __METHOD__, $e );
-			error_log( $e->getMessage() );
 		}
 		return false;
 	}
@@ -633,14 +722,16 @@ class WP_Auth0_LoginManager {
 	/**
 	 * Deprecated to improve the functionality and move to a new class
 	 *
-	 * @see \WP_Auth0_Email_Verification::render_die()
-	 *
 	 * @deprecated 3.5.0
 	 *
-	 * @param $userinfo
-	 * @param $id_token
+	 * @param object $userinfo - Auth0 profile.
+	 * @param string $id_token - ID token.
+	 *
+	 * @see WP_Auth0_Email_Verification::render_die()
 	 */
+	// phpcs:ignore
 	private function dieWithVerifyEmail( $userinfo, $id_token = '' ) {
+		// phpcs:ignore
 		trigger_error( sprintf( __( 'Method %s is deprecated.', 'wp-auth0' ), __METHOD__ ), E_USER_DEPRECATED );
 		WP_Auth0_Email_Verification::render_die( $userinfo );
 	}


### PR DESCRIPTION
Very minimal functional changes, mostly comments. 

- Added docblocks, parameter + error descriptions, and better inline comments
- Renamed internal variables to conform to snake_case and better describe what they're for
- Changed `urlencode` -> `rawurlencode` per `phpcs` suggestion (RFC-compliant encoding, improves interoperability)
- Changed `die()` -> `exit` for standardization (identical functionality)
- Changed `json_encode()` to `wp_ json_encode()` to catch more problematic encoding