### PR TITLE
Whitespace and method order for wp-admin files

### DIFF
--- a/lib/admin/WP_Auth0_Admin.php
+++ b/lib/admin/WP_Auth0_Admin.php
@@ -3,61 +3,201 @@
 class WP_Auth0_Admin {
 
 	protected $a0_options;
+
 	protected $router;
 
 	protected $providers = array(
-		array( 'provider' => 'facebook', 'name' => 'Facebook', "icon" => 'Facebook', 'options' => array(
-				"public_profile" => true,
-				"email" => true,
-				"user_birthday" => true,
-				"publish_actions" => true,
-			) ),
-		array( 'provider' => 'twitter', 'name' => 'Twitter', "icon" => 'Twitter', 'options' => array(
-				"profile" => true,
-			) ),
-		array( 'provider' => 'google-oauth2', 'name' => 'Google +', "icon" => 'Google', 'options' => array(
-				"google_plus" => true,
-				"email" => true,
-				"profile" => true,
-			) ),
-		array( "provider" => 'windowslive', "name" => 'Microsoft Accounts', "icon" => 'Windows LiveID' ),
-		array( "provider" => 'yahoo', "name" => 'Yahoo', "icon" => 'Yahoo' ),
-		array( "provider" => 'aol', "name" => 'AOL', "icon" => 'Aol' ),
-		array( "provider" => 'linkedin', "name" => 'Linkedin', "icon" => 'LinkedIn' ),
-		array( "provider" => 'paypal', "name" => 'Paypal', "icon" => 'PayPal' ),
-		array( "provider" => 'github', "name" => 'GitHub', "icon" => 'GitHub' ),
-		array( "provider" => 'amazon', "name" => 'Amazon', "icon" => 'Amazon' ),
-		array( "provider" => 'vkontakte', "name" => 'vkontakte', "icon" => 'vk' ),
-		array( "provider" => 'yandex', "name" => 'yandex', "icon" => 'Yandex Metrica' ),
-		array( "provider" => 'thirtysevensignals', "name" => 'thirtysevensignals', "icon" => '37signals' ),
-		array( "provider" => 'box', "name" => 'box', "icon" => 'Box' ),
-		array( "provider" => 'salesforce', "name" => 'salesforce', "icon" => 'Salesforce' ),
-		array( "provider" => 'salesforce-sandbox', "name" => 'salesforce-sandbox', "icon" => 'SalesforceSandbox' ),
-		array( "provider" => 'salesforce-community', "name" => 'salesforce-community', "icon" => 'SalesforceCommunity' ),
-		array( "provider" => 'fitbit', "name" => 'Fitbit', "icon" => 'Fitbit' ),
-		array( "provider" => 'baidu', "name" => '百度 (Baidu)', "icon" => 'Baidu' ),
-		array( "provider" => 'renren', "name" => '人人 (RenRen)', "icon" => 'RenRen' ),
-		array( "provider" => 'weibo', "name" => '新浪微 (Weibo)', "icon" => 'Weibo' ),
-		array( "provider" => 'shopify', "name" => 'Shopify', "icon" => 'Shopify' ),
-		array( "provider" => 'dwolla', "name" => 'Dwolla', "icon" => 'dwolla' ),
-		array( "provider" => 'miicard', "name" => 'miiCard', "icon" => 'miiCard' ),
-		array( "provider" => 'wordpress', "name" => 'wordpress', "icon" => 'WordPress' ),
-		array( "provider" => 'yammer', "name" => 'Yammer', "icon" => 'Yammer' ),
-		array( "provider" => 'soundcloud', "name" => 'soundcloud', "icon" => 'Soundcloud' ),
-		array( "provider" => 'instagram', "name" => 'instagram', "icon" => 'Instagram' ),
-		array( "provider" => 'evernote', "name" => 'evernote', "icon" => 'Evernote' ),
-		array( "provider" => 'evernote-sandbox', "name" => 'evernote-sandbox', "icon" => 'Evernote' ),
-		array( "provider" => 'thecity', "name" => 'thecity', "icon" => 'The City' ),
-		array( "provider" => 'thecity-sandbox', "name" => 'thecity-sandbox', "icon" => 'The City Sandbox' ),
-		array( "provider" => 'planningcenter', "name" => 'planningcenter', "icon" => 'Planning Center' ),
-		array( "provider" => 'exact', "name" => 'exact', "icon" => 'Exact' ),
+		array(
+			'provider' => 'facebook',
+			'name'     => 'Facebook',
+			'icon'     => 'Facebook',
+			'options'  => array(
+				'public_profile'  => true,
+				'email'           => true,
+				'user_birthday'   => true,
+				'publish_actions' => true,
+			),
+		),
+		array(
+			'provider' => 'twitter',
+			'name'     => 'Twitter',
+			'icon'     => 'Twitter',
+			'options'  => array(
+				'profile' => true,
+			),
+		),
+		array(
+			'provider' => 'google-oauth2',
+			'name'     => 'Google +',
+			'icon'     => 'Google',
+			'options'  => array(
+				'google_plus' => true,
+				'email'       => true,
+				'profile'     => true,
+			),
+		),
+		array(
+			'provider' => 'windowslive',
+			'name'     => 'Microsoft Accounts',
+			'icon'     => 'Windows LiveID',
+		),
+		array(
+			'provider' => 'yahoo',
+			'name'     => 'Yahoo',
+			'icon'     => 'Yahoo',
+		),
+		array(
+			'provider' => 'aol',
+			'name'     => 'AOL',
+			'icon'     => 'Aol',
+		),
+		array(
+			'provider' => 'linkedin',
+			'name'     => 'Linkedin',
+			'icon'     => 'LinkedIn',
+		),
+		array(
+			'provider' => 'paypal',
+			'name'     => 'Paypal',
+			'icon'     => 'PayPal',
+		),
+		array(
+			'provider' => 'github',
+			'name'     => 'GitHub',
+			'icon'     => 'GitHub',
+		),
+		array(
+			'provider' => 'amazon',
+			'name'     => 'Amazon',
+			'icon'     => 'Amazon',
+		),
+		array(
+			'provider' => 'vkontakte',
+			'name'     => 'vkontakte',
+			'icon'     => 'vk',
+		),
+		array(
+			'provider' => 'yandex',
+			'name'     => 'yandex',
+			'icon'     => 'Yandex Metrica',
+		),
+		array(
+			'provider' => 'thirtysevensignals',
+			'name'     => 'thirtysevensignals',
+			'icon'     => '37signals',
+		),
+		array(
+			'provider' => 'box',
+			'name'     => 'box',
+			'icon'     => 'Box',
+		),
+		array(
+			'provider' => 'salesforce',
+			'name'     => 'salesforce',
+			'icon'     => 'Salesforce',
+		),
+		array(
+			'provider' => 'salesforce-sandbox',
+			'name'     => 'salesforce-sandbox',
+			'icon'     => 'SalesforceSandbox',
+		),
+		array(
+			'provider' => 'salesforce-community',
+			'name'     => 'salesforce-community',
+			'icon'     => 'SalesforceCommunity',
+		),
+		array(
+			'provider' => 'fitbit',
+			'name'     => 'Fitbit',
+			'icon'     => 'Fitbit',
+		),
+		array(
+			'provider' => 'baidu',
+			'name'     => '百度 (Baidu)',
+			'icon'     => 'Baidu',
+		),
+		array(
+			'provider' => 'renren',
+			'name'     => '人人 (RenRen)',
+			'icon'     => 'RenRen',
+		),
+		array(
+			'provider' => 'weibo',
+			'name'     => '新浪微 (Weibo)',
+			'icon'     => 'Weibo',
+		),
+		array(
+			'provider' => 'shopify',
+			'name'     => 'Shopify',
+			'icon'     => 'Shopify',
+		),
+		array(
+			'provider' => 'dwolla',
+			'name'     => 'Dwolla',
+			'icon'     => 'dwolla',
+		),
+		array(
+			'provider' => 'miicard',
+			'name'     => 'miiCard',
+			'icon'     => 'miiCard',
+		),
+		array(
+			'provider' => 'wordpress',
+			'name'     => 'wordpress',
+			'icon'     => 'WordPress',
+		),
+		array(
+			'provider' => 'yammer',
+			'name'     => 'Yammer',
+			'icon'     => 'Yammer',
+		),
+		array(
+			'provider' => 'soundcloud',
+			'name'     => 'soundcloud',
+			'icon'     => 'Soundcloud',
+		),
+		array(
+			'provider' => 'instagram',
+			'name'     => 'instagram',
+			'icon'     => 'Instagram',
+		),
+		array(
+			'provider' => 'evernote',
+			'name'     => 'evernote',
+			'icon'     => 'Evernote',
+		),
+		array(
+			'provider' => 'evernote-sandbox',
+			'name'     => 'evernote-sandbox',
+			'icon'     => 'Evernote',
+		),
+		array(
+			'provider' => 'thecity',
+			'name'     => 'thecity',
+			'icon'     => 'The City',
+		),
+		array(
+			'provider' => 'thecity-sandbox',
+			'name'     => 'thecity-sandbox',
+			'icon'     => 'The City Sandbox',
+		),
+		array(
+			'provider' => 'planningcenter',
+			'name'     => 'planningcenter',
+			'icon'     => 'Planning Center',
+		),
+		array(
+			'provider' => 'exact',
+			'name'     => 'exact',
+			'icon'     => 'Exact',
+		),
 	);
 
 	protected $sections = array();
 
 	public function __construct( WP_Auth0_Options $a0_options, WP_Auth0_Routes $router ) {
 		$this->a0_options = $a0_options;
-		$this->router = $router;
+		$this->router     = $router;
 	}
 
 	public function init() {
@@ -69,34 +209,36 @@ class WP_Auth0_Admin {
 	 * Enqueue scripts for all Auth0 wp-admin pages
 	 */
 	public function admin_enqueue() {
-		$wpa0_pages = [ 'wpa0', 'wpa0-errors', 'wpa0-users-export', 'wpa0-import-settings', 'wpa0-setup' ];
+		$wpa0_pages     = [ 'wpa0', 'wpa0-errors', 'wpa0-users-export', 'wpa0-import-settings', 'wpa0-setup' ];
 		$wpa0_curr_page = ! empty( $_REQUEST['page'] ) ? $_REQUEST['page'] : '';
-		if ( ! in_array( $wpa0_curr_page, $wpa0_pages )  ) {
+		if ( ! in_array( $wpa0_curr_page, $wpa0_pages ) ) {
 			return;
 		}
 
 		if ( ! WP_Auth0::ready() ) {
 			add_action( 'admin_notices', array( $this, 'create_account_message' ) );
 		}
-		
+
 		if ( 'wpa0' === $wpa0_curr_page ) {
 			wp_enqueue_script( 'wpa0_admin', WPA0_PLUGIN_JS_URL . 'admin.js', array( 'jquery' ), WPA0_VERSION );
-			wp_localize_script( 'wpa0_admin', 'wpa0', array(
-				'media_title' => __( 'Choose your icon', 'wp-auth0' ),
-				'media_button' => __( 'Choose icon', 'wp-auth0' ),
-				'clear_cache_working' => __( 'Working ...', 'wp-auth0' ),
-				'clear_cache_done' => __( 'Done!', 'wp-auth0' ),
-				'clear_cache_nonce' => wp_create_nonce( 'auth0_delete_cache_transient' ),
-				'ajax_url' => admin_url( 'admin-ajax.php' ),
-			) );
+			wp_localize_script(
+				'wpa0_admin', 'wpa0', array(
+					'media_title'         => __( 'Choose your icon', 'wp-auth0' ),
+					'media_button'        => __( 'Choose icon', 'wp-auth0' ),
+					'clear_cache_working' => __( 'Working ...', 'wp-auth0' ),
+					'clear_cache_done'    => __( 'Done!', 'wp-auth0' ),
+					'clear_cache_nonce'   => wp_create_nonce( 'auth0_delete_cache_transient' ),
+					'ajax_url'            => admin_url( 'admin-ajax.php' ),
+				)
+			);
 
-			wp_enqueue_script( 'wpa0_async', WPA0_PLUGIN_LIB_URL . 'async.min.js', FALSE, WPA0_VERSION );
+			wp_enqueue_script( 'wpa0_async', WPA0_PLUGIN_LIB_URL . 'async.min.js', false, WPA0_VERSION );
 		}
 
 		wp_enqueue_media();
-		wp_enqueue_style( 'wpa0_bootstrap', WPA0_PLUGIN_BS_URL . 'css/bootstrap.min.css', FALSE, '3.3.5' );
+		wp_enqueue_style( 'wpa0_bootstrap', WPA0_PLUGIN_BS_URL . 'css/bootstrap.min.css', false, '3.3.5' );
 		wp_enqueue_script( 'wpa0_bootstrap', WPA0_PLUGIN_BS_URL . 'js/bootstrap.min.js', array( 'jquery' ), '3.3.6' );
-		wp_enqueue_style( 'wpa0_admin_initial_settup', WPA0_PLUGIN_CSS_URL . 'initial-setup.css', FALSE, WPA0_VERSION );
+		wp_enqueue_style( 'wpa0_admin_initial_settup', WPA0_PLUGIN_CSS_URL . 'initial-setup.css', false, WPA0_VERSION );
 
 		if ( 'wpa0-setup' === $wpa0_curr_page && isset( $_REQUEST['signup'] ) ) {
 			$cdn_url = $this->a0_options->get( 'cdn_url' );
@@ -162,12 +304,12 @@ class WP_Auth0_Admin {
 
 	protected function get_social_connection( $provider, $name, $icon ) {
 		return array(
-			'name' => $name,
+			'name'     => $name,
 			'provider' => $provider,
-			'icon' => $icon,
-			'status' => $this->a0_options->get_connection( "social_{$provider}" ),
-			'key' => $this->a0_options->get_connection( "social_{$provider}_key" ),
-			'secret' => $this->a0_options->get_connection( "social_{$provider}_secret" ),
+			'icon'     => $icon,
+			'status'   => $this->a0_options->get_connection( "social_{$provider}" ),
+			'key'      => $this->a0_options->get_connection( "social_{$provider}_key" ),
+			'secret'   => $this->a0_options->get_connection( "social_{$provider}_secret" ),
 		);
 	}
 
@@ -179,17 +321,15 @@ class WP_Auth0_Admin {
 		}
 
 		$domain = $this->a0_options->get( 'domain' );
-		$parts = explode( '.', $domain );
+		$parts  = explode( '.', $domain );
 
 		$tenant = $parts[0];
 
 		if ( strpos( $domain, 'au.auth0.com' ) !== false ) {
 			$tenant .= '@au';
-		}
-		elseif ( strpos( $domain, 'eu.auth0.com' ) !== false ) {
+		} elseif ( strpos( $domain, 'eu.auth0.com' ) !== false ) {
 			$tenant .= '@eu';
-		}
-		elseif ( strpos( $domain, 'auth0.com' ) !== false ) {
+		} elseif ( strpos( $domain, 'auth0.com' ) !== false ) {
 			$tenant .= '@us';
 		}
 

--- a/lib/admin/WP_Auth0_Admin_Advanced.php
+++ b/lib/admin/WP_Auth0_Admin_Advanced.php
@@ -2,581 +2,690 @@
 
 class WP_Auth0_Admin_Advanced extends WP_Auth0_Admin_Generic {
 
-  // TODO: Deprecate
-  const ADVANCED_DESCRIPTION = 'Settings related to specific scenarios.';
-
-  protected $_description;
-
-  protected $actions_middlewares = array(
-    'basic_validation',
-    'migration_ws_validation',
-    'link_accounts_validation',
-    'loginredirection_validation',
-  );
-
-  protected $router;
-
-  /**
-   * WP_Auth0_Admin_Advanced constructor.
-   *
-   * @param WP_Auth0_Options_Generic $options
-   * @param WP_Auth0_Routes $router
-   */
-  public function __construct( WP_Auth0_Options_Generic $options, WP_Auth0_Routes $router ) {
-    parent::__construct( $options );
-    $this->router = $router;
-    $this->_description = __( 'Settings related to specific scenarios.', 'wp-auth0' );
-  }
-
-  /**
-   * All settings in the Advanced tab
-   *
-   * @see \WP_Auth0_Admin::init_admin
-   * @see \WP_Auth0_Admin_Generic::init_option_section
-   */
-  public function init() {
-    $options = array(
-      array( 'name' => __( 'Require Verified Email', 'wp-auth0' ), 'opt' => 'requires_verified_email',
-        'id' => 'wpa0_verified_email', 'function' => 'render_verified_email' ),
-      array( 'name' => __( 'Remember User Session', 'wp-auth0' ), 'opt' => 'remember_users_session',
-        'id' => 'wpa0_remember_users_session', 'function' => 'render_remember_users_session' ),
-      array( 'name' => __( 'Login Redirection URL', 'wp-auth0' ), 'opt' => 'default_login_redirection',
-        'id' => 'wpa0_default_login_redirection', 'function' => 'render_default_login_redirection' ),
-      array( 'name' => __( 'Connections to Show', 'wp-auth0' ), 'opt' => 'lock_connections',
-        'id' => 'wpa0_connections', 'function' => 'render_connections' ),
-      array( 'name' => __( 'Force HTTPS Callback', 'wp-auth0' ), 'opt' => 'force_https_callback',
-        'id' => 'wpa0_force_https_callback', 'function' => 'render_force_https_callback' ),
-      array( 'name' => __( 'Lock JS CDN URL', 'wp-auth0' ), 'opt' => 'cdn_url',
-        'id' => 'wpa0_cdn_url', 'function' => 'render_cdn_url' ),
-      array( 'name' => __( 'Link Users with Same Email', 'wp-auth0' ), 'opt' => 'link_auth0_users',
-        'id' => 'wpa0_link_auth0_users', 'function' => 'render_link_auth0_users' ),
-      array( 'name' => __( 'Auto Provisioning', 'wp-auth0' ), 'opt' => 'auto_provisioning',
-        'id' => 'wpa0_auto_provisioning', 'function' => 'render_auto_provisioning' ),
-      array( 'name' => __( 'User Migration', 'wp-auth0' ), 'opt' => 'migration_ws',
-        'id' => 'wpa0_migration_ws', 'function' => 'render_migration_ws' ),
-      array( 'name' => __( 'Migration IPs Whitelist', 'wp-auth0' ), 'opt' => 'migration_ips_filter',
-        'id' => 'wpa0_migration_ws_ips_filter', 'function' => 'render_migration_ws_ips_filter' ),
-      array( 'name' => __( 'IP Addresses', 'wp-auth0' ), 'opt' => 'migration_ips',
-        'id' => 'wpa0_migration_ws_ips', 'function' => 'render_migration_ws_ips' ),
-      array( 'name' => __( 'Auto Login', 'wp-auth0' ), 'opt' => 'auto_login',
-        'id' => 'wpa0_auto_login', 'function' => 'render_auto_login' ),
-      array( 'name' => __( 'Auto Login Method', 'wp-auth0' ), 'opt' => 'auto_login_method',
-        'id' => 'wpa0_auto_login_method', 'function' => 'render_auto_login_method' ),
-      array( 'name' => __( 'Implicit Login Flow', 'wp-auth0' ), 'opt' => 'auth0_implicit_workflow',
-        'id' => 'wpa0_auth0_implicit_workflow', 'function' => 'render_auth0_implicit_workflow' ),
-      array( 'name' => __( 'Enable IP Ranges', 'wp-auth0' ), 'opt' => 'ip_range_check',
-        'id' => 'wpa0_ip_range_check', 'function' => 'render_ip_range_check' ),
-      array( 'name' => __( 'IP Ranges', 'wp-auth0' ), 'opt' => 'ip_ranges',
-        'id' => 'wpa0_ip_ranges', 'function' => 'render_ip_ranges' ),
-      array( 'name' => __( 'Valid Proxy IP', 'wp-auth0' ), 'opt' => 'valid_proxy_ip',
-        'id' => 'wpa0_valid_proxy_ip', 'function' => 'render_valid_proxy_ip' ),
-      array( 'name' => __( 'Custom Signup Fields', 'wp-auth0' ), 'opt' => 'custom_signup_fields',
-        'id' => 'wpa0_custom_signup_fields', 'function' => 'render_custom_signup_fields' ),
-      array( 'name' => __( 'Extra Settings', 'wp-auth0' ), 'opt' => 'extra_conf',
-        'id' => 'wpa0_extra_conf', 'function' => 'render_extra_conf' ),
-      array( 'name' => __( 'Twitter Consumer Key', 'wp-auth0' ), 'opt' => 'social_twitter_key',
-        'id' => 'wpa0_social_twitter_key', 'function' => 'render_social_twitter_key' ),
-      array( 'name' => __( 'Twitter Consumer Secret', 'wp-auth0' ), 'opt' => 'social_twitter_secret',
-        'id' => 'wpa0_social_twitter_secret', 'function' => 'render_social_twitter_secret' ),
-      array( 'name' => __( 'Facebook App Key', 'wp-auth0' ), 'opt' => 'social_facebook_key',
-        'id' => 'wpa0_social_facebook_key', 'function' => 'render_social_facebook_key' ),
-      array( 'name' => __( 'Facebook App Secret', 'wp-auth0' ), 'opt' => 'social_facebook_secret',
-        'id' => 'wpa0_social_facebook_secret', 'function' => 'render_social_facebook_secret' ),
-      array( 'name' => __( 'Auth0 Server Domain', 'wp-auth0' ), 'opt' => 'auth0_server_domain',
-        'id' => 'wpa0_auth0_server_domain', 'function' => 'render_auth0_server_domain' ),
-      array( 'name' => __( 'Report Anonymous Data', 'wp-auth0' ), 'opt' => 'metrics',
-        'id' => 'wpa0_metrics', 'function' => 'render_metrics' ),
-    );
-
-    if ( WP_Auth0_Configure_JWTAUTH::is_jwt_auth_enabled() ) {
-      $options[] = array( 'name' => 'Enable JWT Auth Integration', 'opt' => 'jwt_auth_integration',
-        'id' => 'wpa0_jwt_auth_integration', 'function' => 'render_jwt_auth_integration' );
-    }
-
-    $this->init_option_section( '', 'advanced', $options );
-  }
-
-  // TODO: Deprecate
-  public function render_passwordless_method() {
-    $v = $this->options->get( 'passwordless_method' );
-?>
-      <input type="radio" name="<?php echo $this->options->get_options_name(); ?>[passwordless_method]" id="wpa0_passwordless_method_social" value="social" <?php echo checked( $v, 'social', false ); ?>/><label for="wpa0_passwordless_method_social">Social</label>
-
-      <br>
-
-      <input type="radio" name="<?php echo $this->options->get_options_name(); ?>[passwordless_method]" id="wpa0_passwordless_method_sms" value="sms" <?php echo checked( $v, 'sms', false ); ?>/><label for="wpa0_passwordless_method_sms">SMS</label>
-
-      <input type="radio" name="<?php echo $this->options->get_options_name(); ?>[passwordless_method]" id="wpa0_passwordless_method_social_sms" value="socialOrSms" <?php echo checked( $v, 'socialOrSms', false ); ?>/><label for="wpa0_passwordless_method_social_sms">Social or SMS</label>
-
-      <br>
-
-      <input type="radio" name="<?php echo $this->options->get_options_name(); ?>[passwordless_method]" id="wpa0_passwordless_method_magiclink" value="magiclink" <?php echo checked( $v, 'magiclink', false ); ?>/><label for="wpa0_passwordless_method_magiclink">Magic Link</label>
-
-      <input type="radio" name="<?php echo $this->options->get_options_name(); ?>[passwordless_method]" id="wpa0_passwordless_method_social_magiclink" value="socialOrMagiclink" <?php echo checked( $v, 'socialOrMagiclink', false ); ?>/><label for="wpa0_passwordless_method_social_magiclink">Social or Magic Link</label>
-
-      <br>
-
-      <input type="radio" name="<?php echo $this->options->get_options_name(); ?>[passwordless_method]" id="wpa0_passwordless_method_emailcode" value="emailcode" <?php echo checked( $v, 'emailcode', false ); ?>/><label for="wpa0_passwordless_method_emailcode">Email Code</label>
-
-      <input type="radio" name="<?php echo $this->options->get_options_name(); ?>[passwordless_method]" id="wpa0_passwordless_method_social_emailcode" value="socialOrEmailcode" <?php echo checked( $v, 'socialOrEmailcode', false ); ?>/><label for="wpa0_passwordless_method_social_emailcode">Social or Email Code</label>
-
-
-
-
-      <div class="subelement">
-        <span class="description">
-          <?php echo __( 'For more info about the password policies check ', 'wp-auth0' ); ?>
-          <a target="_blank" href="https://auth0.com/docs/password-strength"><?php echo __( 'HERE', 'wp-auth0' ); ?></a>
-        </span>
-      </div>
-    <?php
-  }
-
-  public function render_jwt_auth_integration( $args = array() ) {
-    $this->render_switch( $args[ 'label_for' ], $args[ 'opt_name' ] );
-    $this->render_field_description( __( 'This will enable the JWT Auth Users Repository override', 'wp-auth0' ) );
-  }
-
-  public function render_default_login_redirection( $args = array() ) {
-    $this->render_text_field( $args[ 'label_for' ], $args[ 'opt_name' ] );
-    $this->render_field_description(
-      __( 'URL where successfully logged-in users are redirected when using the wp-login.php page. ', 'wp-auth0' ) .
-      __( 'This can be overridden with the <code>redirect_to</code> URL parameter', 'wp-auth0' )
-    );
-  }
-
-  public function render_extra_conf( $args = array() ) {
-    $this->render_textarea_field( $args[ 'label_for' ], $args[ 'opt_name' ] );
-    $this->render_field_description(
-      __( 'Valid JSON for Lock options configuration; will override all options set elsewhere. ', 'wp-auth0' ) .
-      $this->get_docs_link( 'libraries/lock/customization', 'See options and examples' )
-    );
-  }
-
-  public function render_custom_signup_fields( $args = array() ) {
-    $this->render_textarea_field( $args[ 'label_for' ], $args[ 'opt_name' ] );
-    $this->render_field_description(
-      __( 'Valid JSON for additional signup fields in the Auth0 signup form. ', 'wp-auth0' ) .
-      $this->get_docs_link(
-        'libraries/lock/v11/configuration#additionalsignupfields-array-',
-        __( 'More information and examples', 'wp-auth0' )
-      )
-    );
-  }
-
-  public function render_link_auth0_users( $args = array() ) {
-    $this->render_switch( $args[ 'label_for' ], $args[ 'opt_name' ] );
-    $this->render_field_description(
-      __( 'Link accounts with the same verified e-mail address. ', 'wp-auth0' ) .
-      __( 'See the "Require Verified Email" setting above for more information on email verification', 'wp-auth0' )
-    );
-  }
-
-  public function render_auto_provisioning( $args = array() ) {
-    $this->render_switch( $args[ 'label_for' ], $args[ 'opt_name' ] );
-    $this->render_field_description(
-      __( 'Create new users in the WordPress database when signups are off. ', 'wp-auth0' ) .
-      __( 'Signups will not be allowed but successful Auth0 logins will add the user in WordPress', 'wp-auth0' )
-    );
-  }
-
-  // TODO: Deprecate, moved to WP_Auth0_Admin_features
-  public function render_passwordless_enabled( $args = array() ) {
-    $this->render_switch( $args[ 'label_for' ], $args[ 'opt_name' ] );
-    $this->render_field_description(
-      __( 'Turns on Passwordless login (email or SMS) in the Auth0 form. ', 'wp-auth0' ) .
-      __( 'Passwordless connections are managed in the ', 'wp-auth0' ) .
-      $this->get_dashboard_link( 'connections/passwordless' ) .
-      __( ' and at least one must be active and enabled on this Application for this to work. ', 'wp-auth0' ) .
-      __( 'Username/password login is not enabled when Passwordless is on', 'wp-auth0' )
-    );
-  }
-
-  public function render_force_https_callback( $args = array() ) {
-    $this->render_switch( $args[ 'label_for' ], $args[ 'opt_name' ] );
-    $this->render_field_description(
-      __( 'Forces the plugin to use HTTPS for the callback URL when a site supports both; ', 'wp-auth0' ) .
-      __( 'if disabled, the protocol from the WordPress home URL will be used', 'wp-auth0' )
-    );
-  }
-
-  public function render_remember_users_session( $args = array() ) {
-    $this->render_switch( $args[ 'label_for' ], $args[ 'opt_name' ] );
-    $this->render_field_description(
-      __( 'A user session by default is kept for two days. ', 'wp-auth0' ) .
-      __( 'Enabling this setting will extend that and make the session be kept for 14 days', 'wp-auth0' )
-    );
-  }
-
-  public function render_migration_ws( $args = array() ) {
-    $value = $this->options->get( $args[ 'opt_name' ] );
-    $this->render_switch( $args[ 'label_for' ], $args[ 'opt_name' ] );
-
-    if ( $value ) {
-
-      $this->render_field_description(
-        __( 'Users migration is enabled. ', 'wp-auth0' ) .
-        __( 'If you disable this setting, it must be re-enabled manually in the ', 'wp-auth0' ) .
-        $this->get_dashboard_link()
-      );
-
-      $this->render_field_description( 'Security token:' );
-
-      printf(
-        '<textarea class="code" rows="%d" disabled>%s</textarea>',
-        $this->_textarea_rows,
-        sanitize_text_field(  $this->options->get( 'migration_token' ) )
-      );
-
-    } else {
-      $this->render_field_description(
-        __( 'Users migration is disabled. ', 'wp-auth0' ) .
-        __( 'Enabling this exposes migration webservices but the Connection must be updated manually. ', 'wp-auth0' ) .
-        $this->get_docs_link( 'users/migrations/automatic', __( 'More information here', 'wp-auth0' ) )
-      );
-    }
-  }
-
-  public function render_migration_ws_ips_filter( $args = array() ) {
-    $this->render_switch( $args[ 'label_for' ], $args[ 'opt_name' ], 'wpa0_migration_ws_ips' );
-  }
-
-  public function render_migration_ws_ips( $args = array() ) {
-    $this->render_textarea_field( $args[ 'label_for' ], $args[ 'opt_name' ] );
-    $this->render_field_description(
-      __( 'Only requests from these IPs will be allowed to access the migration webservice. ', 'wp-auth0' ) .
-      __( 'Separate multiple IPs with commas', 'wp-auth0' )
-    );
-  }
-
-  public function render_auth0_implicit_workflow( $args = array() ) {
-    $this->render_switch( $args[ 'label_for' ], $args[ 'opt_name' ] );
-    $this->render_field_description(
-      __( 'Turns on implicit login flow, which most sites will not need. ', 'wp-auth0' ) .
-      __( 'Only enable this if outbound connections to auth0.com are disabled on your server. ', 'wp-auth0' ) .
-      __( 'Your Application should be set to "Single Page App" in your ', 'wp-auth0' ) .
-      $this->get_dashboard_link( 'clients' ) .
-      __( ' for this setting to work properly. ', 'wp-auth0' ) .
-      __( 'This will limit profile changes and other functionality in the plugin', 'wp-auth0' )
-    );
-  }
-
-  public function render_auto_login( $args = array() ) {
-    $this->render_switch( $args[ 'label_for' ], $args[ 'opt_name' ], 'wpa0_auto_login_method' );
-    $this->render_field_description(
-      __( 'Send logins directly to a specific Connection, skipping the login page', 'wp-auth0' )
-    );
-  }
-
-  public function render_auto_login_method( $args = array() ) {
-    $this->render_text_field( $args[ 'label_for' ], $args[ 'opt_name' ] );
-    $this->render_field_description(
-      sprintf(
-          __( 'Find the method name to use under Connections > [Connection Type] in your %s. ', 'wp-auth0' ),
-          $this->get_dashboard_link()
-      ) .
-      __( 'Click the expand icon and use the value in the "Name" field (like "google-oauth2")', 'wp-auth0' )
-    );
-  }
-
-  public function render_ip_range_check( $args = array() ) {
-    $this->render_switch( $args[ 'label_for' ], $args[ 'opt_name' ], 'wpa0_ip_ranges' );
-  }
-
-  public function render_ip_ranges( $args = array() ) {
-    $this->render_textarea_field( $args[ 'label_for' ], $args[ 'opt_name' ] );
-    $this->render_field_description(
-      __( 'Only one range per line! Range format should be as follows (spaces ignored): ', 'wp-auth0' ) .
-      __( '<br><code>xx.xx.xx.xx - yy.yy.yy.yy</code>', 'wp-auth0' )
-    );
-  }
-
-  public function render_social_twitter_key( $args = array() ) {
-    $this->render_social_key_field( $args[ 'label_for' ], $args[ 'opt_name' ] );
-    $this->render_field_description(
-      __( 'Used for the Social Amplification Widget. ', 'wp-auth0' ) .
-      $this->get_docs_link(
-        'connections/social/twitter#2-get-your-consumer-key-and-consumer-secret',
-        __( 'Instructions here', 'wp-auth0' )
-      )
-    );
-  }
-
-  public function render_social_twitter_secret( $args = array() ) {
-    $this->render_social_key_field( $args[ 'label_for' ], $args[ 'opt_name' ] );
-    $this->render_field_description(
-      __( 'Used for the Social Amplification Widget. ', 'wp-auth0' ) .
-      $this->get_docs_link(
-        'connections/social/twitter#2-get-your-consumer-key-and-consumer-secret',
-        __( 'Instructions here', 'wp-auth0' )
-      )
-    );
-  }
-
-  public function render_social_facebook_key( $args = array() ) {
-    $this->render_social_key_field( $args[ 'label_for' ], $args[ 'opt_name' ] );
-    $this->render_field_description(
-      __( 'Used for the Social Amplification Widget. ', 'wp-auth0' ) .
-      $this->get_docs_link(
-        'connections/social/facebook#5-get-your-app-id-and-app-secret',
-        __( 'Instructions here', 'wp-auth0' )
-      )
-    );
-  }
-
-  public function render_social_facebook_secret( $args = array() ) {
-    $this->render_social_key_field( $args[ 'label_for' ], $args[ 'opt_name' ] );
-    $this->render_field_description(
-      __( 'Used for the Social Amplification Widget. ', 'wp-auth0' ) .
-      $this->get_docs_link(
-        'connections/social/facebook#5-get-your-app-id-and-app-secret',
-        __( 'Instructions here', 'wp-auth0' )
-      )
-    );
-  }
-
-  public function render_valid_proxy_ip( $args = array() ) {
-    $this->render_text_field( $args[ 'label_for' ], $args[ 'opt_name' ] );
-    $this->render_field_description(
-      __( 'Whitelist for proxy and load balancer IPs to enable logins and migration webservices', 'wp-auth0' )
-    );
-  }
-
-  public function render_cdn_url( $args = array() ) {
-    $this->render_text_field( $args[ 'label_for' ], $args[ 'opt_name' ] );
-    $this->render_field_description(
-      __( 'This should point to the latest Lock JS available in the CDN and rarely needs to change', 'wp-auth0' )
-    );
-  }
-
-  public function render_auth0_server_domain( $args = array() ) {
-    $this->render_text_field( $args[ 'label_for' ], $args[ 'opt_name' ] );
-    $this->render_field_description(
-      __( 'The Auth0 domain used by the setup wizard to fetch your account information', 'wp-auth0' )
-    );
-  }
-
-  public function render_connections( $args = array() ) {
-    $this->render_text_field( $args[ 'label_for' ], $args[ 'opt_name' ], 'text', 'eg: "sms, google-oauth2, github"' );
-    $this->render_field_description(
-      __( 'Specify which Social, Database, or Passwordless connections to display in the Auth0 form. ', 'wp-auth0' ) .
-      __( 'If this is empty, all enabled connections for this Application will be shown. ', 'wp-auth0' ) .
-      __( 'Separate multiple connection names with a comma. ', 'wp-auth0' ) .
-      sprintf(
-          __( 'Connections listed here must already be active in your %s', 'wp-auth0' ),
-          $this->get_dashboard_link( 'connections/social' )
-      ) .
-      __( ' and enabled for this Application. ', 'wp-auth0' ) .
-      __( 'Click on a Connection and use the "Name" value in this field', 'wp-auth0' )
-    );
-  }
-
-  public function render_metrics() {
-    $v = absint( $this->options->get( 'metrics' ) );
-
-    echo $this->render_a0_switch( "wpa0_metrics", "metrics", 1, 1 == $v );
-?>
-
-      <div class="subelement">
-        <span class="description">
-          <?php echo __( 'This plugin tracks anonymous usage data. Click to disable.', 'wp-auth0' ); ?>
-        </span>
-      </div>
-    <?php
-  }
-
-  public function render_verified_email( $args = array() ) {
-    $this->render_switch( $args[ 'label_for' ], $args[ 'opt_name' ] );
-    $this->render_field_description(
-      __( 'Require new users to both provide and verify their email before logging in. ', 'wp-auth0' ) .
-      __( 'An email is verified manually by an email from Auth0 or automatically by the provider. ', 'wp-auth0' ) .
-      __( 'This will disallow logins from social connections that do not provide email (like Twitter)', 'wp-auth0' )
-    );
-  }
-
-  // TODO: Deprecate
-  public function render_advanced_description() {
-?>
-
-    <p class=\"a0-step-text\"><?php echo self::ADVANCED_DESCRIPTION; ?></p>
-
-    <?php
-  }
-
-  public function basic_validation( $old_options, $input ) {
-    $input['requires_verified_email'] = ( isset( $input['requires_verified_email'] ) ? $input['requires_verified_email'] : 0 );
-    $input['auto_provisioning'] = ( isset( $input['auto_provisioning'] ) ? $input['auto_provisioning'] : 0 );
-    $input['remember_users_session'] = ( isset( $input['remember_users_session'] ) ? $input['remember_users_session'] : 0 ) == 1;
-    $input['passwordless_enabled'] = ( isset( $input['passwordless_enabled'] ) ? $input['passwordless_enabled'] : 0 ) == 1;
-    $input['jwt_auth_integration'] = ( isset( $input['jwt_auth_integration'] ) ? $input['jwt_auth_integration'] : 0 );
-    $input['auth0_implicit_workflow'] = ( isset( $input['auth0_implicit_workflow'] ) ? $input['auth0_implicit_workflow'] : 0 );
-    $input['metrics'] = ( isset( $input['metrics'] ) ? $input['metrics'] : 0 );
-    $input['force_https_callback'] = ( isset( $input['force_https_callback'] ) ? $input['force_https_callback'] : 0 );
-    $input['default_login_redirection'] = esc_url_raw( $input['default_login_redirection'] );
-
-    if ( isset( $input['connections'] ) ) {
-      if ( isset( $input['connections']['social_twitter_key'] ) ) $input['connections']['social_twitter_key'] = sanitize_text_field( $input['connections']['social_twitter_key'] );
-      if ( isset( $input['connections']['social_twitter_secret'] ) ) $input['connections']['social_twitter_secret'] = sanitize_text_field( $input['connections']['social_twitter_secret'] );
-      if ( isset( $input['connections']['social_facebook_key'] ) ) $input['connections']['social_facebook_key'] = sanitize_text_field( $input['connections']['social_facebook_key'] );
-      if ( isset( $input['connections']['social_facebook_secret'] ) ) $input['connections']['social_facebook_secret'] = sanitize_text_field( $input['connections']['social_facebook_secret'] );
-    }
-
-    $input['migration_ips_filter'] =  ( ! empty( $input['migration_ips_filter'] ) ? 1 : 0 );
-    $input['migration_ips'] = sanitize_text_field( $input['migration_ips'] );
-
-    $input['valid_proxy_ip'] = ( isset( $input['valid_proxy_ip'] ) ? $input['valid_proxy_ip'] : null );
-
-    $input['lock_connections'] = trim( $input['lock_connections'] );
-    $input['custom_signup_fields'] = trim( $input['custom_signup_fields'] );
-
-    if ( trim( $input["extra_conf"] ) != '' ) {
-      if ( json_decode( $input["extra_conf"] ) === null ) {
-        $error = __( "The Extra settings parameter should be a valid json object", "wp-auth0" );
-        self::add_validation_error( $error );
-      }
-    }
-
-    return $input;
-  }
-
-  public function migration_ws_validation( $old_options, $input ) {
-    $input['migration_ws'] = ( isset( $input['migration_ws'] ) ? $input['migration_ws'] : 0 );
-
-    if ( $old_options['migration_ws'] != $input['migration_ws'] ) {
-
-      if ( 1 == $input['migration_ws'] ) {
-
-	      $token_id = uniqid();
-	      $secret = $input['client_secret'];
-	      if ( $input['client_secret_b64_encoded'] ) {
-		      $secret = JWT::urlsafeB64Decode( $secret );
-	      }
-
-        $input['migration_token'] = JWT::encode( array( 'scope' => 'migration_ws', 'jti' => $token_id ), $secret );
-        $input['migration_token_id'] = $token_id;
-
-	      $this->add_validation_error(
-		      __( 'User Migration needs to be configured manually. ', 'wp-auth0' )
-		      . __( 'Please see Advanced > Users Migration below for your token, instructions are ', 'wp-auth0' )
-		      . '<a href="https://auth0.com/docs/users/migrations/automatic">HERE</a>.'
-	      );
-
-      } else {
-        $input['migration_token'] = null;
-        $input['migration_token_id'] = null;
-
-        if (isset($old_options['db_connection_id'])) {
-
-
-          $connection = WP_Auth0_Api_Client::get_connection($input['domain'], $input['auth0_app_token'], $old_options['db_connection_id']);
-
-          $connection->options->enabledDatabaseCustomization = false;
-          $connection->options->import_mode = false;
-
-
-          unset($connection->name);
-          unset($connection->strategy);
-          unset($connection->id);
-
-          $response = WP_Auth0_Api_Client::update_connection($input['domain'], $input['auth0_app_token'], $old_options['db_connection_id'], $connection);
-        } else {
-          $response = false;
-        }
-
-        if ( $response === false ) {
-          $error = __( 'There was an error disabling your custom database. Check how to do it manually ', 'wp-auth0' );
-          $error .= '<a href="https://manage.auth0.com/#/connections/database">HERE</a>.';
-          $this->add_validation_error( $error );
-        }
-      }
-
-      $this->router->setup_rewrites( $input['migration_ws'] == 1 );
-      flush_rewrite_rules();
-    } else {
-      $input['migration_token'] = $old_options['migration_token'];
-      $input['migration_token_id'] = $old_options['migration_token_id'];
-    }
-    return $input;
-  }
-
-  public function link_accounts_validation( $old_options, $input ) {
-    $link_script = WP_Auth0_RulesLib::$link_accounts['script'];
-    $link_script = str_replace( 'REPLACE_WITH_YOUR_CLIENT_ID', $input['client_id'], $link_script );
-    $link_script = str_replace( 'REPLACE_WITH_YOUR_DOMAIN', $input['domain'], $link_script );
-    $link_script = str_replace( 'REPLACE_WITH_YOUR_API_TOKEN', $input['auth0_app_token'], $link_script );
-    return $this->rule_validation($old_options, $input, 'link_auth0_users', WP_Auth0_RulesLib::$link_accounts['name'] . '-' . get_auth0_curatedBlogName(), $link_script);
-  }
-
-  // TODO: Deprecate
-  public function connections_validation( $old_options, $input ) {
-
-    $check_if_enabled = array();
-    $passwordless_connections = array(
-      'sms' => 'sms',
-      'magiclink' => 'email',
-      'emailcode' => 'email');
-
-    if ($input['passwordless_enabled'] && $input['passwordless_enabled'] != $old_options['passwordless_enabled']) {
-
-      foreach ($passwordless_connections as $alias => $name) {
-        if (strpos($input['passwordless_method'], $alias) !== false) {
-          $check_if_enabled[] = $name;
-        }
-      }
-
-    } elseif ($input['passwordless_method'] != $old_options['passwordless_method']) {
-
-      foreach ($passwordless_connections as $name) {
-        if (strpos($input['passwordless_method'], $name) !== false) {
-          $check_if_enabled[] = $name;
-        }
-      }
-    }
-
-    if (!empty($check_if_enabled)) {
-
-      $response = WP_Auth0_Api_Client::search_connection($input['domain'], $input['auth0_app_token']);
-      $enabled_connections = array();
-      foreach ($response as $connection) {
-        if (in_array($input['client_id'], $connection->enabled_clients)) {
-          $enabled_connections[] = $connection->strategy;
-        }
-      }
-
-      $matching = array_intersect($enabled_connections, $check_if_enabled);
-
-      if (array_diff($matching, $check_if_enabled) !== array_diff($check_if_enabled, $matching)) {
-        $error = __( 'The passwordless connection is not enabled. Please go to the Auth0 Dashboard and configure it.', 'wp-auth0' );
-        $this->add_validation_error( $error );
-      }
-
-    }
-
-    return $input;
-  }
-
-  public function loginredirection_validation( $old_options, $input ) {
-    $home_url = home_url();
-
-    if ( empty( $input['default_login_redirection'] ) ) {
-      $input['default_login_redirection'] = $home_url;
-    } else {
-      if ( strpos( $input['default_login_redirection'], $home_url ) !== 0 ) {
-        if ( strpos( $input['default_login_redirection'], 'http' ) === 0 ) {
-          $input['default_login_redirection'] = $home_url;
-          $error = __( "The 'Login redirect URL' cannot point to a foreign page.", "wp-auth0" );
-          $this->add_validation_error( $error );
-        }
-      }
-
-      if ( strpos( $input['default_login_redirection'], 'action=logout' ) !== false ) {
-        $input['default_login_redirection'] = $home_url;
-
-        $error = __( "The 'Login redirect URL' cannot point to the logout page. ", "wp-auth0" );
-        $this->add_validation_error( $error );
-      }
-    }
-    return $input;
-  }
-
+	// TODO: Deprecate
+	const ADVANCED_DESCRIPTION = 'Settings related to specific scenarios.';
+
+	protected $_description;
+
+	protected $actions_middlewares = array(
+		'basic_validation',
+		'migration_ws_validation',
+		'link_accounts_validation',
+		'loginredirection_validation',
+	);
+
+	protected $router;
+
+	/**
+	 * WP_Auth0_Admin_Advanced constructor.
+	 *
+	 * @param WP_Auth0_Options_Generic $options
+	 * @param WP_Auth0_Routes          $router
+	 */
+	public function __construct( WP_Auth0_Options_Generic $options, WP_Auth0_Routes $router ) {
+		parent::__construct( $options );
+		$this->router       = $router;
+		$this->_description = __( 'Settings related to specific scenarios.', 'wp-auth0' );
+	}
+
+	/**
+	 * All settings in the Advanced tab
+	 *
+	 * @see \WP_Auth0_Admin::init_admin
+	 * @see \WP_Auth0_Admin_Generic::init_option_section
+	 */
+	public function init() {
+		$options = array(
+			array(
+				'name'     => __( 'Require Verified Email', 'wp-auth0' ),
+				'opt'      => 'requires_verified_email',
+				'id'       => 'wpa0_verified_email',
+				'function' => 'render_verified_email',
+			),
+			array(
+				'name'     => __( 'Remember User Session', 'wp-auth0' ),
+				'opt'      => 'remember_users_session',
+				'id'       => 'wpa0_remember_users_session',
+				'function' => 'render_remember_users_session',
+			),
+			array(
+				'name'     => __( 'Login Redirection URL', 'wp-auth0' ),
+				'opt'      => 'default_login_redirection',
+				'id'       => 'wpa0_default_login_redirection',
+				'function' => 'render_default_login_redirection',
+			),
+			array(
+				'name'     => __( 'Connections to Show', 'wp-auth0' ),
+				'opt'      => 'lock_connections',
+				'id'       => 'wpa0_connections',
+				'function' => 'render_connections',
+			),
+			array(
+				'name'     => __( 'Force HTTPS Callback', 'wp-auth0' ),
+				'opt'      => 'force_https_callback',
+				'id'       => 'wpa0_force_https_callback',
+				'function' => 'render_force_https_callback',
+			),
+			array(
+				'name'     => __( 'Lock JS CDN URL', 'wp-auth0' ),
+				'opt'      => 'cdn_url',
+				'id'       => 'wpa0_cdn_url',
+				'function' => 'render_cdn_url',
+			),
+			array(
+				'name'     => __( 'Link Users with Same Email', 'wp-auth0' ),
+				'opt'      => 'link_auth0_users',
+				'id'       => 'wpa0_link_auth0_users',
+				'function' => 'render_link_auth0_users',
+			),
+			array(
+				'name'     => __( 'Auto Provisioning', 'wp-auth0' ),
+				'opt'      => 'auto_provisioning',
+				'id'       => 'wpa0_auto_provisioning',
+				'function' => 'render_auto_provisioning',
+			),
+			array(
+				'name'     => __( 'User Migration', 'wp-auth0' ),
+				'opt'      => 'migration_ws',
+				'id'       => 'wpa0_migration_ws',
+				'function' => 'render_migration_ws',
+			),
+			array(
+				'name'     => __( 'Migration IPs Whitelist', 'wp-auth0' ),
+				'opt'      => 'migration_ips_filter',
+				'id'       => 'wpa0_migration_ws_ips_filter',
+				'function' => 'render_migration_ws_ips_filter',
+			),
+			array(
+				'name'     => __( 'IP Addresses', 'wp-auth0' ),
+				'opt'      => 'migration_ips',
+				'id'       => 'wpa0_migration_ws_ips',
+				'function' => 'render_migration_ws_ips',
+			),
+			array(
+				'name'     => __( 'Auto Login', 'wp-auth0' ),
+				'opt'      => 'auto_login',
+				'id'       => 'wpa0_auto_login',
+				'function' => 'render_auto_login',
+			),
+			array(
+				'name'     => __( 'Auto Login Method', 'wp-auth0' ),
+				'opt'      => 'auto_login_method',
+				'id'       => 'wpa0_auto_login_method',
+				'function' => 'render_auto_login_method',
+			),
+			array(
+				'name'     => __( 'Implicit Login Flow', 'wp-auth0' ),
+				'opt'      => 'auth0_implicit_workflow',
+				'id'       => 'wpa0_auth0_implicit_workflow',
+				'function' => 'render_auth0_implicit_workflow',
+			),
+			array(
+				'name'     => __( 'Enable IP Ranges', 'wp-auth0' ),
+				'opt'      => 'ip_range_check',
+				'id'       => 'wpa0_ip_range_check',
+				'function' => 'render_ip_range_check',
+			),
+			array(
+				'name'     => __( 'IP Ranges', 'wp-auth0' ),
+				'opt'      => 'ip_ranges',
+				'id'       => 'wpa0_ip_ranges',
+				'function' => 'render_ip_ranges',
+			),
+			array(
+				'name'     => __( 'Valid Proxy IP', 'wp-auth0' ),
+				'opt'      => 'valid_proxy_ip',
+				'id'       => 'wpa0_valid_proxy_ip',
+				'function' => 'render_valid_proxy_ip',
+			),
+			array(
+				'name'     => __( 'Extra Settings', 'wp-auth0' ),
+				'opt'      => 'extra_conf',
+				'id'       => 'wpa0_extra_conf',
+				'function' => 'render_extra_conf',
+			),
+			array(
+				'name'     => __( 'Custom Signup Fields', 'wp-auth0' ),
+				'opt'      => 'custom_signup_fields',
+				'id'       => 'wpa0_custom_signup_fields',
+				'function' => 'render_custom_signup_fields',
+			),
+			array(
+				'name'     => __( 'Twitter Consumer Key', 'wp-auth0' ),
+				'opt'      => 'social_twitter_key',
+				'id'       => 'wpa0_social_twitter_key',
+				'function' => 'render_social_twitter_key',
+			),
+			array(
+				'name'     => __( 'Twitter Consumer Secret', 'wp-auth0' ),
+				'opt'      => 'social_twitter_secret',
+				'id'       => 'wpa0_social_twitter_secret',
+				'function' => 'render_social_twitter_secret',
+			),
+			array(
+				'name'     => __( 'Facebook App Key', 'wp-auth0' ),
+				'opt'      => 'social_facebook_key',
+				'id'       => 'wpa0_social_facebook_key',
+				'function' => 'render_social_facebook_key',
+			),
+			array(
+				'name'     => __( 'Facebook App Secret', 'wp-auth0' ),
+				'opt'      => 'social_facebook_secret',
+				'id'       => 'wpa0_social_facebook_secret',
+				'function' => 'render_social_facebook_secret',
+			),
+			array(
+				'name'     => __( 'Auth0 Server Domain', 'wp-auth0' ),
+				'opt'      => 'auth0_server_domain',
+				'id'       => 'wpa0_auth0_server_domain',
+				'function' => 'render_auth0_server_domain',
+			),
+			array(
+				'name'     => __( 'Report Anonymous Data', 'wp-auth0' ),
+				'opt'      => 'metrics',
+				'id'       => 'wpa0_metrics',
+				'function' => 'render_metrics',
+			),
+		);
+
+		if ( WP_Auth0_Configure_JWTAUTH::is_jwt_auth_enabled() ) {
+			$options[] = array(
+				'name'     => 'Enable JWT Auth Integration',
+				'opt'      => 'jwt_auth_integration',
+				'id'       => 'wpa0_jwt_auth_integration',
+				'function' => 'render_jwt_auth_integration',
+			);
+		}
+
+		$this->init_option_section( '', 'advanced', $options );
+	}
+
+	public function render_verified_email( $args = array() ) {
+		$this->render_switch( $args['label_for'], $args['opt_name'] );
+		$this->render_field_description(
+			__( 'Require new users to both provide and verify their email before logging in. ', 'wp-auth0' ) .
+			__( 'An email is verified manually by an email from Auth0 or automatically by the provider. ', 'wp-auth0' ) .
+			__( 'This will disallow logins from social connections that do not provide email (like Twitter)', 'wp-auth0' )
+		);
+	}
+
+	public function render_remember_users_session( $args = array() ) {
+		$this->render_switch( $args['label_for'], $args['opt_name'] );
+		$this->render_field_description(
+			__( 'A user session by default is kept for two days. ', 'wp-auth0' ) .
+			__( 'Enabling this setting will extend that and make the session be kept for 14 days', 'wp-auth0' )
+		);
+	}
+
+	public function render_default_login_redirection( $args = array() ) {
+		$this->render_text_field( $args['label_for'], $args['opt_name'] );
+		$this->render_field_description(
+			__( 'URL where successfully logged-in users are redirected when using the wp-login.php page. ', 'wp-auth0' ) .
+			__( 'This can be overridden with the <code>redirect_to</code> URL parameter', 'wp-auth0' )
+		);
+	}
+
+	public function render_connections( $args = array() ) {
+		$this->render_text_field( $args['label_for'], $args['opt_name'], 'text', 'eg: "sms, google-oauth2, github"' );
+		$this->render_field_description(
+			__( 'Specify which Social, Database, or Passwordless connections to display in the Auth0 form. ', 'wp-auth0' ) .
+			__( 'If this is empty, all enabled connections for this Application will be shown. ', 'wp-auth0' ) .
+			__( 'Separate multiple connection names with a comma. ', 'wp-auth0' ) .
+			sprintf(
+				__( 'Connections listed here must already be active in your %s', 'wp-auth0' ),
+				$this->get_dashboard_link( 'connections/social' )
+			) .
+			__( ' and enabled for this Application. ', 'wp-auth0' ) .
+			__( 'Click on a Connection and use the "Name" value in this field', 'wp-auth0' )
+		);
+	}
+
+	public function render_force_https_callback( $args = array() ) {
+		$this->render_switch( $args['label_for'], $args['opt_name'] );
+		$this->render_field_description(
+			__( 'Forces the plugin to use HTTPS for the callback URL when a site supports both; ', 'wp-auth0' ) .
+			__( 'if disabled, the protocol from the WordPress home URL will be used', 'wp-auth0' )
+		);
+	}
+
+	public function render_cdn_url( $args = array() ) {
+		$this->render_text_field( $args['label_for'], $args['opt_name'] );
+		$this->render_field_description(
+			__( 'This should point to the latest Lock JS available in the CDN and rarely needs to change', 'wp-auth0' )
+		);
+	}
+
+	public function render_link_auth0_users( $args = array() ) {
+		$this->render_switch( $args['label_for'], $args['opt_name'] );
+		$this->render_field_description(
+			__( 'Link accounts with the same verified e-mail address. ', 'wp-auth0' ) .
+			__( 'See the "Require Verified Email" setting above for more information on email verification', 'wp-auth0' )
+		);
+	}
+
+	public function render_auto_provisioning( $args = array() ) {
+		$this->render_switch( $args['label_for'], $args['opt_name'] );
+		$this->render_field_description(
+			__( 'Create new users in the WordPress database when signups are off. ', 'wp-auth0' ) .
+			__( 'Signups will not be allowed but successful Auth0 logins will add the user in WordPress', 'wp-auth0' )
+		);
+	}
+
+	public function render_migration_ws( $args = array() ) {
+		$value = $this->options->get( $args['opt_name'] );
+		$this->render_switch( $args['label_for'], $args['opt_name'] );
+
+		if ( $value ) {
+			$this->render_field_description(
+				__( 'Users migration is enabled. ', 'wp-auth0' ) .
+				__( 'If you disable this setting, it must be re-enabled manually in the ', 'wp-auth0' ) .
+				$this->get_dashboard_link()
+			);
+			$this->render_field_description( 'Security token:' );
+			printf(
+				'<textarea class="code" rows="%d" disabled>%s</textarea>',
+				$this->_textarea_rows,
+				sanitize_text_field( $this->options->get( 'migration_token' ) )
+			);
+		} else {
+			$this->render_field_description(
+				__( 'Users migration is disabled. ', 'wp-auth0' ) .
+				__( 'Enabling this exposes migration webservices but the Connection must be updated manually. ', 'wp-auth0' ) .
+				$this->get_docs_link( 'users/migrations/automatic', __( 'More information here', 'wp-auth0' ) )
+			);
+		}
+	}
+
+	public function render_migration_ws_ips_filter( $args = array() ) {
+		$this->render_switch( $args['label_for'], $args['opt_name'], 'wpa0_migration_ws_ips' );
+	}
+
+	public function render_migration_ws_ips( $args = array() ) {
+		$this->render_textarea_field( $args['label_for'], $args['opt_name'] );
+		$this->render_field_description(
+			__( 'Only requests from these IPs will be allowed to access the migration webservice. ', 'wp-auth0' ) .
+			__( 'Separate multiple IPs with commas', 'wp-auth0' )
+		);
+	}
+
+	public function render_auto_login( $args = array() ) {
+		$this->render_switch( $args['label_for'], $args['opt_name'], 'wpa0_auto_login_method' );
+		$this->render_field_description(
+			__( 'Send logins directly to a specific Connection, skipping the login page', 'wp-auth0' )
+		);
+	}
+
+	public function render_auto_login_method( $args = array() ) {
+		$this->render_text_field( $args['label_for'], $args['opt_name'] );
+		$this->render_field_description(
+			sprintf(
+				__( 'Find the method name to use under Connections > [Connection Type] in your %s. ', 'wp-auth0' ),
+				$this->get_dashboard_link()
+			) .
+			__( 'Click the expand icon and use the value in the "Name" field (like "google-oauth2")', 'wp-auth0' )
+		);
+	}
+
+	public function render_auth0_implicit_workflow( $args = array() ) {
+		$this->render_switch( $args['label_for'], $args['opt_name'] );
+		$this->render_field_description(
+			__( 'Turns on implicit login flow, which most sites will not need. ', 'wp-auth0' ) .
+			__( 'Only enable this if outbound connections to auth0.com are disabled on your server. ', 'wp-auth0' ) .
+			__( 'Your Application should be set to "Single Page App" in your ', 'wp-auth0' ) .
+			$this->get_dashboard_link( 'clients' ) .
+			__( ' for this setting to work properly. ', 'wp-auth0' ) .
+			__( 'This will limit profile changes and other functionality in the plugin', 'wp-auth0' )
+		);
+	}
+
+	public function render_ip_range_check( $args = array() ) {
+		$this->render_switch( $args['label_for'], $args['opt_name'], 'wpa0_ip_ranges' );
+	}
+
+	public function render_ip_ranges( $args = array() ) {
+		$this->render_textarea_field( $args['label_for'], $args['opt_name'] );
+		$this->render_field_description(
+			__( 'Only one range per line! Range format should be as follows (spaces ignored): ', 'wp-auth0' ) .
+			__( '<br><code>xx.xx.xx.xx - yy.yy.yy.yy</code>', 'wp-auth0' )
+		);
+	}
+
+	public function render_valid_proxy_ip( $args = array() ) {
+		$this->render_text_field( $args['label_for'], $args['opt_name'] );
+		$this->render_field_description(
+			__( 'Whitelist for proxy and load balancer IPs to enable logins and migration webservices', 'wp-auth0' )
+		);
+	}
+
+	public function render_extra_conf( $args = array() ) {
+		$this->render_textarea_field( $args['label_for'], $args['opt_name'] );
+		$this->render_field_description(
+			__( 'Valid JSON for Lock options configuration; will override all options set elsewhere. ', 'wp-auth0' ) .
+			$this->get_docs_link( 'libraries/lock/customization', 'See options and examples' )
+		);
+	}
+
+	public function render_custom_signup_fields( $args = array() ) {
+		$this->render_textarea_field( $args['label_for'], $args['opt_name'] );
+		$this->render_field_description(
+			__( 'Valid JSON for additional signup fields in the Auth0 signup form. ', 'wp-auth0' ) .
+			$this->get_docs_link(
+				'libraries/lock/v11/configuration#additionalsignupfields-array-',
+				__( 'More information and examples', 'wp-auth0' )
+			)
+		);
+	}
+
+	public function render_social_twitter_key( $args = array() ) {
+		$this->render_social_key_field( $args['label_for'], $args['opt_name'] );
+		$this->render_field_description(
+			__( 'Used for the Social Amplification Widget. ', 'wp-auth0' ) .
+			$this->get_docs_link(
+				'connections/social/twitter#2-get-your-consumer-key-and-consumer-secret',
+				__( 'Instructions here', 'wp-auth0' )
+			)
+		);
+	}
+
+	public function render_social_twitter_secret( $args = array() ) {
+		$this->render_social_key_field( $args['label_for'], $args['opt_name'] );
+		$this->render_field_description(
+			__( 'Used for the Social Amplification Widget. ', 'wp-auth0' ) .
+			$this->get_docs_link(
+				'connections/social/twitter#2-get-your-consumer-key-and-consumer-secret',
+				__( 'Instructions here', 'wp-auth0' )
+			)
+		);
+	}
+
+	public function render_social_facebook_key( $args = array() ) {
+		$this->render_social_key_field( $args['label_for'], $args['opt_name'] );
+		$this->render_field_description(
+			__( 'Used for the Social Amplification Widget. ', 'wp-auth0' ) .
+			$this->get_docs_link(
+				'connections/social/facebook#5-get-your-app-id-and-app-secret',
+				__( 'Instructions here', 'wp-auth0' )
+			)
+		);
+	}
+
+	public function render_social_facebook_secret( $args = array() ) {
+		$this->render_social_key_field( $args['label_for'], $args['opt_name'] );
+		$this->render_field_description(
+			__( 'Used for the Social Amplification Widget. ', 'wp-auth0' ) .
+			$this->get_docs_link(
+				'connections/social/facebook#5-get-your-app-id-and-app-secret',
+				__( 'Instructions here', 'wp-auth0' )
+			)
+		);
+	}
+
+	public function render_auth0_server_domain( $args = array() ) {
+		$this->render_text_field( $args['label_for'], $args['opt_name'] );
+		$this->render_field_description(
+			__( 'The Auth0 domain used by the setup wizard to fetch your account information', 'wp-auth0' )
+		);
+	}
+
+	public function render_metrics() {
+		$v = absint( $this->options->get( 'metrics' ) );
+
+		echo $this->render_a0_switch( 'wpa0_metrics', 'metrics', 1, 1 == $v );
+		?>
+
+		<div class="subelement">
+		<span class="description">
+			<?php echo __( 'This plugin tracks anonymous usage data. Click to disable.', 'wp-auth0' ); ?>
+		</span>
+		</div>
+		<?php
+	}
+
+	public function render_jwt_auth_integration( $args = array() ) {
+		$this->render_switch( $args['label_for'], $args['opt_name'] );
+		$this->render_field_description( __( 'This will enable the JWT Auth Users Repository override', 'wp-auth0' ) );
+	}
+
+	// TODO: Deprecate, moved to WP_Auth0_Admin_features
+	public function render_passwordless_enabled( $args = array() ) {
+		$this->render_switch( $args['label_for'], $args['opt_name'] );
+		$this->render_field_description(
+			__( 'Turns on Passwordless login (email or SMS) in the Auth0 form. ', 'wp-auth0' ) .
+			__( 'Passwordless connections are managed in the ', 'wp-auth0' ) .
+			$this->get_dashboard_link( 'connections/passwordless' ) .
+			__( ' and at least one must be active and enabled on this Application for this to work. ', 'wp-auth0' ) .
+			__( 'Username/password login is not enabled when Passwordless is on', 'wp-auth0' )
+		);
+	}
+
+	// TODO: Deprecate
+	public function render_passwordless_method() {
+		$v = $this->options->get( 'passwordless_method' );
+		?>
+		<input type="radio" name="<?php echo $this->options->get_options_name(); ?>[passwordless_method]" id="wpa0_passwordless_method_social" value="social" <?php echo checked( $v, 'social', false ); ?>/><label for="wpa0_passwordless_method_social">Social</label>
+
+		<br>
+
+		<input type="radio" name="<?php echo $this->options->get_options_name(); ?>[passwordless_method]" id="wpa0_passwordless_method_sms" value="sms" <?php echo checked( $v, 'sms', false ); ?>/><label for="wpa0_passwordless_method_sms">SMS</label>
+
+		<input type="radio" name="<?php echo $this->options->get_options_name(); ?>[passwordless_method]" id="wpa0_passwordless_method_social_sms" value="socialOrSms" <?php echo checked( $v, 'socialOrSms', false ); ?>/><label for="wpa0_passwordless_method_social_sms">Social or SMS</label>
+
+		<br>
+
+		<input type="radio" name="<?php echo $this->options->get_options_name(); ?>[passwordless_method]" id="wpa0_passwordless_method_magiclink" value="magiclink" <?php echo checked( $v, 'magiclink', false ); ?>/><label for="wpa0_passwordless_method_magiclink">Magic Link</label>
+
+		<input type="radio" name="<?php echo $this->options->get_options_name(); ?>[passwordless_method]" id="wpa0_passwordless_method_social_magiclink" value="socialOrMagiclink" <?php echo checked( $v, 'socialOrMagiclink', false ); ?>/><label for="wpa0_passwordless_method_social_magiclink">Social or Magic Link</label>
+
+		<br>
+
+		<input type="radio" name="<?php echo $this->options->get_options_name(); ?>[passwordless_method]" id="wpa0_passwordless_method_emailcode" value="emailcode" <?php echo checked( $v, 'emailcode', false ); ?>/><label for="wpa0_passwordless_method_emailcode">Email Code</label>
+
+		<input type="radio" name="<?php echo $this->options->get_options_name(); ?>[passwordless_method]" id="wpa0_passwordless_method_social_emailcode" value="socialOrEmailcode" <?php echo checked( $v, 'socialOrEmailcode', false ); ?>/><label for="wpa0_passwordless_method_social_emailcode">Social or Email Code</label>
+
+
+
+
+		<div class="subelement">
+		<span class="description">
+			<?php echo __( 'For more info about the password policies check ', 'wp-auth0' ); ?>
+			<a target="_blank" href="https://auth0.com/docs/password-strength"><?php echo __( 'HERE', 'wp-auth0' ); ?></a>
+		</span>
+		</div>
+		<?php
+	}
+
+	// TODO: Deprecate
+	public function render_advanced_description() {
+		?>
+
+		<p class=\"a0-step-text\"><?php echo self::ADVANCED_DESCRIPTION; ?></p>
+
+		<?php
+	}
+
+	public function basic_validation( $old_options, $input ) {
+		$input['requires_verified_email']   = ( isset( $input['requires_verified_email'] ) ? $input['requires_verified_email'] : 0 );
+		$input['auto_provisioning']         = ( isset( $input['auto_provisioning'] ) ? $input['auto_provisioning'] : 0 );
+		$input['remember_users_session']    = ( isset( $input['remember_users_session'] ) ? $input['remember_users_session'] : 0 ) == 1;
+		$input['passwordless_enabled']      = ( isset( $input['passwordless_enabled'] ) ? $input['passwordless_enabled'] : 0 ) == 1;
+		$input['jwt_auth_integration']      = ( isset( $input['jwt_auth_integration'] ) ? $input['jwt_auth_integration'] : 0 );
+		$input['auth0_implicit_workflow']   = ( isset( $input['auth0_implicit_workflow'] ) ? $input['auth0_implicit_workflow'] : 0 );
+		$input['metrics']                   = ( isset( $input['metrics'] ) ? $input['metrics'] : 0 );
+		$input['force_https_callback']      = ( isset( $input['force_https_callback'] ) ? $input['force_https_callback'] : 0 );
+		$input['default_login_redirection'] = esc_url_raw( $input['default_login_redirection'] );
+
+		if ( isset( $input['connections'] ) ) {
+			if ( isset( $input['connections']['social_twitter_key'] ) ) {
+				$input['connections']['social_twitter_key'] = sanitize_text_field( $input['connections']['social_twitter_key'] );
+			}
+			if ( isset( $input['connections']['social_twitter_secret'] ) ) {
+				$input['connections']['social_twitter_secret'] = sanitize_text_field( $input['connections']['social_twitter_secret'] );
+			}
+			if ( isset( $input['connections']['social_facebook_key'] ) ) {
+				$input['connections']['social_facebook_key'] = sanitize_text_field( $input['connections']['social_facebook_key'] );
+			}
+			if ( isset( $input['connections']['social_facebook_secret'] ) ) {
+				$input['connections']['social_facebook_secret'] = sanitize_text_field( $input['connections']['social_facebook_secret'] );
+			}
+		}
+
+		$input['migration_ips_filter'] = ( ! empty( $input['migration_ips_filter'] ) ? 1 : 0 );
+		$input['migration_ips']        = sanitize_text_field( $input['migration_ips'] );
+
+		$input['valid_proxy_ip'] = ( isset( $input['valid_proxy_ip'] ) ? $input['valid_proxy_ip'] : null );
+
+		$input['lock_connections']     = trim( $input['lock_connections'] );
+		$input['custom_signup_fields'] = trim( $input['custom_signup_fields'] );
+
+		if ( trim( $input['extra_conf'] ) != '' ) {
+			if ( json_decode( $input['extra_conf'] ) === null ) {
+				$error = __( 'The Extra settings parameter should be a valid json object', 'wp-auth0' );
+				self::add_validation_error( $error );
+			}
+		}
+
+		return $input;
+	}
+
+	public function migration_ws_validation( $old_options, $input ) {
+		$input['migration_ws'] = ( isset( $input['migration_ws'] ) ? $input['migration_ws'] : 0 );
+
+		if ( $old_options['migration_ws'] != $input['migration_ws'] ) {
+
+			if ( 1 == $input['migration_ws'] ) {
+
+				$token_id = uniqid();
+				$secret   = $input['client_secret'];
+				if ( $input['client_secret_b64_encoded'] ) {
+					$secret = JWT::urlsafeB64Decode( $secret );
+				}
+
+				$input['migration_token']    = JWT::encode(
+					array(
+						'scope' => 'migration_ws',
+						'jti'   => $token_id,
+					), $secret
+				);
+				$input['migration_token_id'] = $token_id;
+
+				$this->add_validation_error(
+					__( 'User Migration needs to be configured manually. ', 'wp-auth0' )
+					. __( 'Please see Advanced > Users Migration below for your token, instructions are ', 'wp-auth0' )
+					. '<a href="https://auth0.com/docs/users/migrations/automatic">HERE</a>.'
+				);
+
+			} else {
+				$input['migration_token']    = null;
+				$input['migration_token_id'] = null;
+
+				if ( isset( $old_options['db_connection_id'] ) ) {
+
+					$connection = WP_Auth0_Api_Client::get_connection( $input['domain'], $input['auth0_app_token'], $old_options['db_connection_id'] );
+
+					$connection->options->enabledDatabaseCustomization = false;
+					$connection->options->import_mode                  = false;
+
+					unset( $connection->name );
+					unset( $connection->strategy );
+					unset( $connection->id );
+
+					$response = WP_Auth0_Api_Client::update_connection( $input['domain'], $input['auth0_app_token'], $old_options['db_connection_id'], $connection );
+				} else {
+					$response = false;
+				}
+
+				if ( $response === false ) {
+					$error  = __( 'There was an error disabling your custom database. Check how to do it manually ', 'wp-auth0' );
+					$error .= '<a href="https://manage.auth0.com/#/connections/database">HERE</a>.';
+					$this->add_validation_error( $error );
+				}
+			}
+
+			$this->router->setup_rewrites( $input['migration_ws'] == 1 );
+			flush_rewrite_rules();
+		} else {
+			$input['migration_token']    = $old_options['migration_token'];
+			$input['migration_token_id'] = $old_options['migration_token_id'];
+		}
+		return $input;
+	}
+
+	public function link_accounts_validation( $old_options, $input ) {
+		$link_script = WP_Auth0_RulesLib::$link_accounts['script'];
+		$link_script = str_replace( 'REPLACE_WITH_YOUR_CLIENT_ID', $input['client_id'], $link_script );
+		$link_script = str_replace( 'REPLACE_WITH_YOUR_DOMAIN', $input['domain'], $link_script );
+		$link_script = str_replace( 'REPLACE_WITH_YOUR_API_TOKEN', $input['auth0_app_token'], $link_script );
+		return $this->rule_validation( $old_options, $input, 'link_auth0_users', WP_Auth0_RulesLib::$link_accounts['name'] . '-' . get_auth0_curatedBlogName(), $link_script );
+	}
+
+	// TODO: Deprecate
+	public function connections_validation( $old_options, $input ) {
+
+		$check_if_enabled         = array();
+		$passwordless_connections = array(
+			'sms'       => 'sms',
+			'magiclink' => 'email',
+			'emailcode' => 'email',
+		);
+
+		if ( $input['passwordless_enabled'] && $input['passwordless_enabled'] != $old_options['passwordless_enabled'] ) {
+
+			foreach ( $passwordless_connections as $alias => $name ) {
+				if ( strpos( $input['passwordless_method'], $alias ) !== false ) {
+					$check_if_enabled[] = $name;
+				}
+			}
+		} elseif ( $input['passwordless_method'] != $old_options['passwordless_method'] ) {
+
+			foreach ( $passwordless_connections as $name ) {
+				if ( strpos( $input['passwordless_method'], $name ) !== false ) {
+					$check_if_enabled[] = $name;
+				}
+			}
+		}
+
+		if ( ! empty( $check_if_enabled ) ) {
+
+			$response            = WP_Auth0_Api_Client::search_connection( $input['domain'], $input['auth0_app_token'] );
+			$enabled_connections = array();
+			foreach ( $response as $connection ) {
+				if ( in_array( $input['client_id'], $connection->enabled_clients ) ) {
+					$enabled_connections[] = $connection->strategy;
+				}
+			}
+
+			$matching = array_intersect( $enabled_connections, $check_if_enabled );
+
+			if ( array_diff( $matching, $check_if_enabled ) !== array_diff( $check_if_enabled, $matching ) ) {
+				$error = __( 'The passwordless connection is not enabled. Please go to the Auth0 Dashboard and configure it.', 'wp-auth0' );
+				$this->add_validation_error( $error );
+			}
+		}
+
+		return $input;
+	}
+
+	public function loginredirection_validation( $old_options, $input ) {
+		$home_url = home_url();
+
+		if ( empty( $input['default_login_redirection'] ) ) {
+			$input['default_login_redirection'] = $home_url;
+		} else {
+			if ( strpos( $input['default_login_redirection'], $home_url ) !== 0 ) {
+				if ( strpos( $input['default_login_redirection'], 'http' ) === 0 ) {
+					$input['default_login_redirection'] = $home_url;
+					$error                              = __( "The 'Login redirect URL' cannot point to a foreign page.", 'wp-auth0' );
+					$this->add_validation_error( $error );
+				}
+			}
+
+			if ( strpos( $input['default_login_redirection'], 'action=logout' ) !== false ) {
+				$input['default_login_redirection'] = $home_url;
+
+				$error = __( "The 'Login redirect URL' cannot point to the logout page. ", 'wp-auth0' );
+				$this->add_validation_error( $error );
+			}
+		}
+		return $input;
+	}
 }

--- a/lib/admin/WP_Auth0_Admin_Appearance.php
+++ b/lib/admin/WP_Auth0_Admin_Appearance.php
@@ -29,82 +29,110 @@ class WP_Auth0_Admin_Appearance extends WP_Auth0_Admin_Generic {
 	 */
 	public function init() {
 		$options = array(
-			array( 'name' => __( 'Icon URL', 'wp-auth0' ), 'opt' => 'icon_url',
-				'id' => 'wpa0_icon_url', 'function' => 'render_icon_url' ),
-			array( 'name' => __( 'Form Title', 'wp-auth0' ), 'opt' => 'form_title',
-				'id' => 'wpa0_form_title', 'function' => 'render_form_title' ),
-			array( 'name' => __( 'Large Social Buttons', 'wp-auth0' ), 'opt' => 'social_big_buttons',
-				'id' => 'wpa0_social_big_buttons', 'function' => 'render_social_big_buttons' ),
-			array( 'name' => __( 'Enable Gravatar Integration', 'wp-auth0' ), 'opt' => 'gravatar',
-				'id' => 'wpa0_gravatar', 'function' => 'render_gravatar' ),
-			array( 'name' => __( 'Login Form CSS', 'wp-auth0' ), 'opt' => 'custom_css',
-				'id' => 'wpa0_custom_css', 'function' => 'render_custom_css' ),
-			array( 'name' => __( 'Login Form JS', 'wp-auth0' ), 'opt' => 'custom_js',
-				'id' => 'wpa0_custom_js', 'function' => 'render_custom_js' ),
-			array( 'name' => __( 'Login Name Style', 'wp-auth0' ), 'opt' => 'username_style',
-				'id' => 'wpa0_username_style', 'function' => 'render_username_style' ),
-			array( 'name' => __( 'Primary Color', 'wp-auth0' ), 'opt' => 'primary_color',
-				'id' => 'wpa0_primary_color', 'function' => 'render_primary_color' ),
-			array( 'name' => __( 'Language', 'wp-auth0' ), 'opt' => 'language',
-				'id' => 'wpa0_language', 'function' => 'render_language' ),
-			array( 'name' => __( 'Language Dictionary', 'wp-auth0' ), 'opt' => 'language_dictionary',
-				'id' => 'wpa0_language_dictionary', 'function' => 'render_language_dictionary' ),
+			array(
+				'name'     => __( 'Icon URL', 'wp-auth0' ),
+				'opt'      => 'icon_url',
+				'id'       => 'wpa0_icon_url',
+				'function' => 'render_icon_url',
+			),
+			array(
+				'name'     => __( 'Form Title', 'wp-auth0' ),
+				'opt'      => 'form_title',
+				'id'       => 'wpa0_form_title',
+				'function' => 'render_form_title',
+			),
+			array(
+				'name'     => __( 'Large Social Buttons', 'wp-auth0' ),
+				'opt'      => 'social_big_buttons',
+				'id'       => 'wpa0_social_big_buttons',
+				'function' => 'render_social_big_buttons',
+			),
+			array(
+				'name'     => __( 'Enable Gravatar Integration', 'wp-auth0' ),
+				'opt'      => 'gravatar',
+				'id'       => 'wpa0_gravatar',
+				'function' => 'render_gravatar',
+			),
+			array(
+				'name'     => __( 'Login Form CSS', 'wp-auth0' ),
+				'opt'      => 'custom_css',
+				'id'       => 'wpa0_custom_css',
+				'function' => 'render_custom_css',
+			),
+			array(
+				'name'     => __( 'Login Form JS', 'wp-auth0' ),
+				'opt'      => 'custom_js',
+				'id'       => 'wpa0_custom_js',
+				'function' => 'render_custom_js',
+			),
+			array(
+				'name'     => __( 'Login Name Style', 'wp-auth0' ),
+				'opt'      => 'username_style',
+				'id'       => 'wpa0_username_style',
+				'function' => 'render_username_style',
+			),
+			array(
+				'name'     => __( 'Primary Color', 'wp-auth0' ),
+				'opt'      => 'primary_color',
+				'id'       => 'wpa0_primary_color',
+				'function' => 'render_primary_color',
+			),
+			array(
+				'name'     => __( 'Language', 'wp-auth0' ),
+				'opt'      => 'language',
+				'id'       => 'wpa0_language',
+				'function' => 'render_language',
+			),
+			array(
+				'name'     => __( 'Language Dictionary', 'wp-auth0' ),
+				'opt'      => 'language_dictionary',
+				'id'       => 'wpa0_language_dictionary',
+				'function' => 'render_language_dictionary',
+			),
 		);
 		$this->init_option_section( '', 'appearance', $options );
 	}
 
+	public function render_icon_url( $args = array() ) {
+		$this->render_text_field( $args['label_for'], $args['opt_name'] );
+		printf( ' <a id="wpa0_choose_icon" class="button-secondary">%s</a>', __( 'Choose Icon', 'wp-auth0' ) );
+		$this->render_field_description(
+			__( 'Icon above the title on the Auth0 login form. ', 'wp-auth0' ) .
+			__( 'This image works best as a PNG with a transparent background less than 120px tall', 'wp-auth0' )
+		);
+	}
+
 	public function render_form_title( $args = array() ) {
-		$this->render_text_field( $args[ 'label_for' ], $args[ 'opt_name' ] );
+		$this->render_text_field( $args['label_for'], $args['opt_name'] );
 		$this->render_field_description( __( 'Title used on the Auth0 login form', 'wp-auth0' ) );
 	}
 
-	public function render_language( $args = array() ) {
-		$this->render_text_field( $args[ 'label_for' ], $args[ 'opt_name' ] );
-		$this->render_field_description(
-			__( 'The language parameter for the Auth0 login form. ', 'wp-auth0' ) .
-			sprintf(
-				'<a href="https://github.com/auth0/lock/tree/master/src/i18n" target="_blank">%s</a>',
-				__( 'Available languages list', 'wp-auth0' )
-			)
-		);
+	public function render_social_big_buttons( $args = array() ) {
+		$this->render_switch( $args['label_for'], $args['opt_name'] );
+		$this->render_field_description( __( 'Use large social login buttons on the Auth0 login form', 'wp-auth0' ) );
 	}
 
-	public function render_primary_color( $args = array() ) {
-		$this->render_text_field( $args[ 'label_for' ], $args[ 'opt_name' ] );
+	public function render_gravatar( $args = array() ) {
+		$this->render_switch( $args['label_for'], $args['opt_name'] );
 		$this->render_field_description(
-			__( 'Primary color for the Auth0 login form in hex format. ', 'wp-auth0' ) .
-			$this->get_docs_link(
-				'libraries/lock/v11/configuration#primarycolor-string-',
-				__( 'More information on this settings', 'wp-auth0'	)
-			)
-		);
-	}
-
-	public function render_language_dictionary( $args = array() ) {
-		$this->render_textarea_field( $args[ 'label_for' ], $args[ 'opt_name' ] );
-		$this->render_field_description(
-			__( 'The languageDictionary parameter for the Auth0 login form. ', 'wp-auth0' ) .
-			sprintf(
-				'<a href="https://github.com/auth0/lock/blob/master/src/i18n/en.js" target="_blank">%s</a>',
-				__( 'List of all modifiable options', 'wp-auth0' )
-			)
+			__( 'Automatically display an avatar (from Gravatar) on the Auth0 login form', 'wp-auth0' )
 		);
 	}
 
 	public function render_custom_css( $args = array() ) {
-		$this->render_textarea_field( $args[ 'label_for' ], $args[ 'opt_name' ] );
+		$this->render_textarea_field( $args['label_for'], $args['opt_name'] );
 		$this->render_field_description( __( 'Valid CSS to customize the Auth0 login form', 'wp-auth0' ) );
 	}
 
 	public function render_custom_js( $args = array() ) {
-		$this->render_textarea_field( $args[ 'label_for' ], $args[ 'opt_name' ] );
+		$this->render_textarea_field( $args['label_for'], $args['opt_name'] );
 		$this->render_field_description( __( 'Valid JS to customize the Auth0 login form', 'wp-auth0' ) );
 	}
 
 	public function render_username_style( $args = array() ) {
-	    $opt_name = $args[ 'opt_name' ];
-	    $id_attr = $args[ 'label_for' ];
-		$value = $this->options->get( $opt_name );
+		$opt_name = $args['opt_name'];
+		$id_attr  = $args['label_for'];
+		$value    = $this->options->get( $opt_name );
 		$this->render_radio_button( $id_attr . '_au', $opt_name, '', 'Auto', empty( $value ) );
 		$this->render_radio_button( $id_attr . '_em', $opt_name, 'email', '', 'email' === $value );
 		$this->render_radio_button( $id_attr . '_un', $opt_name, 'username', '', 'username' === $value );
@@ -114,53 +142,63 @@ class WP_Auth0_Admin_Appearance extends WP_Auth0_Admin_Generic {
 		);
 	}
 
-	public function render_social_big_buttons( $args = array() ) {
-		$this->render_switch( $args[ 'label_for' ], $args[ 'opt_name' ] );
-		$this->render_field_description( __( 'Use large social login buttons on the Auth0 login form', 'wp-auth0' ) );
-	}
-
-	public function render_gravatar( $args = array() ) {
-		$this->render_switch( $args[ 'label_for' ], $args[ 'opt_name' ] );
+	public function render_primary_color( $args = array() ) {
+		$this->render_text_field( $args['label_for'], $args['opt_name'] );
 		$this->render_field_description(
-			__( 'Automatically display an avatar (from Gravatar) on the Auth0 login form', 'wp-auth0' )
+			__( 'Primary color for the Auth0 login form in hex format. ', 'wp-auth0' ) .
+			$this->get_docs_link(
+				'libraries/lock/v11/configuration#primarycolor-string-',
+				__( 'More information on this settings', 'wp-auth0' )
+			)
 		);
 	}
 
-	public function render_icon_url( $args = array() ) {
-		$this->render_text_field( $args[ 'label_for' ], $args[ 'opt_name' ] );
-		printf( ' <a id="wpa0_choose_icon" class="button-secondary">%s</a>', __( 'Choose Icon', 'wp-auth0' ) );
+	public function render_language( $args = array() ) {
+		$this->render_text_field( $args['label_for'], $args['opt_name'] );
 		$this->render_field_description(
-			__( 'Icon above the title on the Auth0 login form. ', 'wp-auth0' ) .
-			__( 'This image works best as a PNG with a transparent background less than 120px tall', 'wp-auth0' )
-        );
+			__( 'The language parameter for the Auth0 login form. ', 'wp-auth0' ) .
+			sprintf(
+				'<a href="https://github.com/auth0/lock/tree/master/src/i18n" target="_blank">%s</a>',
+				__( 'Available languages list', 'wp-auth0' )
+			)
+		);
+	}
+
+	public function render_language_dictionary( $args = array() ) {
+		$this->render_textarea_field( $args['label_for'], $args['opt_name'] );
+		$this->render_field_description(
+			__( 'The languageDictionary parameter for the Auth0 login form. ', 'wp-auth0' ) .
+			sprintf(
+				'<a href="https://github.com/auth0/lock/blob/master/src/i18n/en.js" target="_blank">%s</a>',
+				__( 'List of all modifiable options', 'wp-auth0' )
+			)
+		);
 	}
 
 	// TODO: Deprecate
 	public function render_appearance_description() {
 ?>
 
-    <p class=\"a0-step-text\"><?php echo self::APPEARANCE_DESCRIPTION; ?></p>
+	<p class=\"a0-step-text\"><?php echo self::APPEARANCE_DESCRIPTION; ?></p>
 
-    <?php
+	<?php
 	}
 
 	public function basic_validation( $old_options, $input ) {
-    $input['form_title'] = sanitize_text_field( $input['form_title'] );
-		$input['icon_url'] = esc_url( $input['icon_url'], array( 'http', 'https' ) );
+		$input['form_title']         = sanitize_text_field( $input['form_title'] );
+		$input['icon_url']           = esc_url( $input['icon_url'], array( 'http', 'https' ) );
 		$input['social_big_buttons'] = ( isset( $input['social_big_buttons'] ) ? $input['social_big_buttons'] : 0 );
-		$input['gravatar'] = ( isset( $input['gravatar'] ) ? $input['gravatar'] : 0 );
-    $input['language'] = sanitize_text_field( $input['language'] );
-    $input['primary_color'] = sanitize_text_field( $input['primary_color'] );
+		$input['gravatar']           = ( isset( $input['gravatar'] ) ? $input['gravatar'] : 0 );
+		$input['language']           = sanitize_text_field( $input['language'] );
+		$input['primary_color']      = sanitize_text_field( $input['primary_color'] );
 
-    if ( trim( $input['language_dictionary'] ) !== '' ) {
-      if ( json_decode( $input['language_dictionary'] ) === null ) {
-        $error = __( 'The language dictionary parameter should be a valid json object.', 'wp-auth0' );
-        $this->add_validation_error( $error );
-        $input['language'] = $old_options['language'];
-      }
-    }
+		if ( trim( $input['language_dictionary'] ) !== '' ) {
+			if ( json_decode( $input['language_dictionary'] ) === null ) {
+				$error = __( 'The language dictionary parameter should be a valid json object.', 'wp-auth0' );
+				$this->add_validation_error( $error );
+				$input['language'] = $old_options['language'];
+			}
+		}
 		return $input;
 	}
-
-
 }

--- a/lib/admin/WP_Auth0_Admin_Basic.php
+++ b/lib/admin/WP_Auth0_Admin_Basic.php
@@ -31,46 +31,76 @@ class WP_Auth0_Admin_Basic extends WP_Auth0_Admin_Generic {
 		add_action( 'wp_ajax_auth0_delete_cache_transient', array( $this, 'auth0_delete_cache_transient' ) );
 
 		$options = array(
-			array( 'name' => __( 'Domain', 'wp-auth0' ), 'opt' => 'domain',
-				'id' => 'wpa0_domain', 'function' => 'render_domain' ),
-			array( 'name' => __( 'Client ID', 'wp-auth0' ), 'opt' => 'client_id',
-				'id' => 'wpa0_client_id', 'function' => 'render_client_id' ),
-			array( 'name' => __( 'Client Secret', 'wp-auth0' ), 'opt' => 'client_secret',
-				'id' => 'wpa0_client_secret', 'function' => 'render_client_secret' ),
-			array( 'name' => __( 'Client Secret Base64 Encoded', 'wp-auth0' ), 'opt' => 'client_secret_b64_encoded',
-				'id' => 'wpa0_client_secret_b64_encoded', 'function' => 'render_client_secret_b64_encoded' ),
-			array( 'name' => __( 'JWT Signature Algorithm', 'wp-auth0' ), 'opt' => 'client_signing_algorithm',
-				'id' => 'wpa0_client_signing_algorithm', 'function' => 'render_client_signing_algorithm' ),
-			array( 'name' => __( 'Cache Time (in minutes)', 'wp-auth0' ), 'opt' => 'cache_expiration',
-				'id' => 'wpa0_cache_expiration', 'function' => 'render_cache_expiration' ),
-			array( 'name' => __( 'API Token', 'wp-auth0' ), 'opt' => 'auth0_app_token',
-				'id' => 'wpa0_auth0_app_token', 'function' => 'render_auth0_app_token' ),
-			array( 'name' => __( 'WordPress Login Enabled', 'wp-auth0' ), 'opt' => 'wordpress_login_enabled',
-				'id' => 'wpa0_login_enabled', 'function' => 'render_allow_wordpress_login' ),
-			array( 'name' => __( 'Allow Signups', 'wp-auth0' ),
-				'id' => 'wpa0_allow_signup', 'function' => 'render_allow_signup' ),
+			array(
+				'name'     => __( 'Domain', 'wp-auth0' ),
+				'opt'      => 'domain',
+				'id'       => 'wpa0_domain',
+				'function' => 'render_domain',
+			),
+			array(
+				'name'     => __( 'Client ID', 'wp-auth0' ),
+				'opt'      => 'client_id',
+				'id'       => 'wpa0_client_id',
+				'function' => 'render_client_id',
+			),
+			array(
+				'name'     => __( 'Client Secret', 'wp-auth0' ),
+				'opt'      => 'client_secret',
+				'id'       => 'wpa0_client_secret',
+				'function' => 'render_client_secret',
+			),
+			array(
+				'name'     => __( 'Client Secret Base64 Encoded', 'wp-auth0' ),
+				'opt'      => 'client_secret_b64_encoded',
+				'id'       => 'wpa0_client_secret_b64_encoded',
+				'function' => 'render_client_secret_b64_encoded',
+			),
+			array(
+				'name'     => __( 'JWT Signature Algorithm', 'wp-auth0' ),
+				'opt'      => 'client_signing_algorithm',
+				'id'       => 'wpa0_client_signing_algorithm',
+				'function' => 'render_client_signing_algorithm',
+			),
+			array(
+				'name'     => __( 'Cache Time (in minutes)', 'wp-auth0' ),
+				'opt'      => 'cache_expiration',
+				'id'       => 'wpa0_cache_expiration',
+				'function' => 'render_cache_expiration',
+			),
+			array(
+				'name'     => __( 'API Token', 'wp-auth0' ),
+				'opt'      => 'auth0_app_token',
+				'id'       => 'wpa0_auth0_app_token',
+				'function' => 'render_auth0_app_token',
+			),
+			array(
+				'name'     => __( 'WordPress Login Enabled', 'wp-auth0' ),
+				'opt'      => 'wordpress_login_enabled',
+				'id'       => 'wpa0_login_enabled',
+				'function' => 'render_allow_wordpress_login',
+			),
+			array(
+				'name'     => __( 'Allow Signups', 'wp-auth0' ),
+				'id'       => 'wpa0_allow_signup',
+				'function' => 'render_allow_signup',
+			),
 		);
 		$this->init_option_section( '', 'basic', $options );
 	}
 
+	public function render_domain( $args = array() ) {
+		$this->render_text_field( $args['label_for'], $args['opt_name'], 'text', 'your-tenant.auth0.com' );
+		$this->render_field_description(
+			__( 'Auth0 Domain, found in your Application settings in the ', 'wp-auth0' ) .
+			$this->get_dashboard_link( 'applications' )
+		);
+	}
 
 	public function render_client_id( $args = array() ) {
 		$this->render_text_field( $args['label_for'], $args['opt_name'] );
 		$this->render_field_description(
 			__( 'Client ID, found in your Application settings in the ', 'wp-auth0' ) .
 			$this->get_dashboard_link( 'applications' )
-		);
-	}
-
-	public function render_auth0_app_token( $args = array() ) {
-		$this->render_text_field( $args['label_for'], $args['opt_name'], 'password' );
-		$this->render_field_description(
-			__( 'This token should include the following scopes: ', 'wp-auth0' ) .
-			'<br><br><code>' . implode( '</code> <code>', WP_Auth0_Api_Client::ConsentRequiredScopes() ) .
-			'</code><br><br>' . $this->get_docs_link(
-				'api/management/v2/tokens#get-a-token-manually',
-				__( 'More information on manually generating tokens', 'wp-auth0' )
-			)
 		);
 	}
 
@@ -91,8 +121,8 @@ class WP_Auth0_Admin_Basic extends WP_Auth0_Admin_Generic {
 		);
 	}
 
-	public function render_client_signing_algorithm( $args = array() ){
-		$value = $this->options->get( $args['opt_name'],  WP_Auth0_Api_Client::DEFAULT_CLIENT_ALG );
+	public function render_client_signing_algorithm( $args = array() ) {
+		$value = $this->options->get( $args['opt_name'], WP_Auth0_Api_Client::DEFAULT_CLIENT_ALG );
 		$this->render_radio_button( $args['label_for'] . '_hs', $args['opt_name'], 'HS256', '', 'HS256' === $value );
 		$this->render_radio_button( $args['label_for'] . '_rs', $args['opt_name'], 'RS256', '', 'RS256' === $value );
 		$this->render_field_description(
@@ -111,7 +141,8 @@ class WP_Auth0_Admin_Basic extends WP_Auth0_Admin_Generic {
 		$this->render_field_description( __( 'JWKS cache expiration in minutes (use 0 for no caching)', 'wp-auth0' ) );
 		if ( $domain = $this->options->get( 'domain' ) ) {
 			$this->render_field_description(
-				sprintf( '<a href="https://%s/.well-known/jwks.json" target="_blank">%s</a>',
+				sprintf(
+					'<a href="https://%s/.well-known/jwks.json" target="_blank">%s</a>',
 					$domain,
 					__( 'View your JWKS here', 'wp-auth0' )
 				)
@@ -119,14 +150,17 @@ class WP_Auth0_Admin_Basic extends WP_Auth0_Admin_Generic {
 		}
 	}
 
-	public function render_domain( $args = array() ) {
-		$this->render_text_field( $args['label_for'], $args['opt_name'], 'text', 'your-tenant.auth0.com' );
+	public function render_auth0_app_token( $args = array() ) {
+		$this->render_text_field( $args['label_for'], $args['opt_name'], 'password' );
 		$this->render_field_description(
-			__( 'Auth0 Domain, found in your Application settings in the ', 'wp-auth0' ) .
-			$this->get_dashboard_link( 'applications' )
+			__( 'This token should include the following scopes: ', 'wp-auth0' ) .
+			'<br><br><code>' . implode( '</code> <code>', WP_Auth0_Api_Client::ConsentRequiredScopes() ) .
+			'</code><br><br>' . $this->get_docs_link(
+				'api/management/v2/tokens#get-a-token-manually',
+				__( 'More information on manually generating tokens', 'wp-auth0' )
+			)
 		);
 	}
-
 
 	public function render_allow_signup() {
 		if ( is_multisite() ) {
@@ -145,49 +179,6 @@ class WP_Auth0_Admin_Basic extends WP_Auth0_Admin_Generic {
 		);
 	}
 
-	// TODO: Deprecate
-	public function render_allow_signup_regular_multisite() {
-		$allow_signup = $this->options->is_wp_registration_enabled();
-?>
-      <span class="description">
-        <?php echo __( 'Signup will be', 'wp-auth0' ); ?>
-
-        <?php if ( ! $allow_signup ) { ?>
-          <b><?php echo __( 'disabled', 'wp-auth0' ); ?></b>
-          <?php echo __( ' because it is enabled by the setting "Allow new registrations" in the Network Admin.', 'wp-auth0' ); ?>
-        <?php } else { ?>
-          <b><?php echo __( 'enabled', 'wp-auth0' ); ?></b>
-          <?php echo __( ' because it is enabled by the setting "Allow new registrations" in the Network Admin.', 'wp-auth0' ); ?>
-        <?php } ?>
-
-        <?php echo __( 'You can manage this setting on <code>Network Admin > Settings > Network Settings > Allow new registrations</code> (you need to set it up to <b>User accounts may be registered</b> or <b>Both sites and user accounts can be registered</b> depending on your preferences).', 'wp-auth0' ); ?>
-      </span>
-
-    <?php
-	}
-
-	// TODO: Deprecate
-	public function render_allow_signup_regular() {
-		$allow_signup = $this->options->is_wp_registration_enabled();
-?>
-      <span class="description">
-        <?php echo __( 'Signup will be', 'wp-auth0' ); ?>
-
-        <?php if ( ! $allow_signup ) { ?>
-          <b><?php echo __( 'disabled', 'wp-auth0' ); ?></b>
-          <?php echo __( ' because it is enabled by the setting "Anyone can register" in the WordPress General Settings.', 'wp-auth0' ); ?>
-        <?php } else { ?>
-          <b><?php echo __( 'enabled', 'wp-auth0' ); ?></b>
-          <?php echo __( ' because it is enabled by the setting "Anyone can register" in the WordPress General Settings.', 'wp-auth0' ); ?>
-        <?php } ?>
-
-        <?php echo __( 'You can manage this setting on <code>Settings > General > Membership</code>, Anyone can register', 'wp-auth0' ); ?>
-	       <a href="<?php echo admin_url( 'options-general.php' ) ?>" target="_blank"><?php _e( 'here', 'wp-auth0' ) ?></a>.
-      </span>
-
-    <?php
-	}
-
 	public function render_allow_wordpress_login( $args = array() ) {
 		$this->render_switch( $args['label_for'], $args['opt_name'] );
 		$this->render_field_description(
@@ -197,12 +188,55 @@ class WP_Auth0_Admin_Basic extends WP_Auth0_Admin_Generic {
 	}
 
 	// TODO: Deprecate
+	public function render_allow_signup_regular_multisite() {
+		$allow_signup = $this->options->is_wp_registration_enabled();
+?>
+	  <span class="description">
+		<?php echo __( 'Signup will be', 'wp-auth0' ); ?>
+
+		<?php if ( ! $allow_signup ) { ?>
+		  <b><?php echo __( 'disabled', 'wp-auth0' ); ?></b>
+			<?php echo __( ' because it is enabled by the setting "Allow new registrations" in the Network Admin.', 'wp-auth0' ); ?>
+		<?php } else { ?>
+		  <b><?php echo __( 'enabled', 'wp-auth0' ); ?></b>
+			<?php echo __( ' because it is enabled by the setting "Allow new registrations" in the Network Admin.', 'wp-auth0' ); ?>
+		<?php } ?>
+
+		<?php echo __( 'You can manage this setting on <code>Network Admin > Settings > Network Settings > Allow new registrations</code> (you need to set it up to <b>User accounts may be registered</b> or <b>Both sites and user accounts can be registered</b> depending on your preferences).', 'wp-auth0' ); ?>
+	  </span>
+
+	<?php
+	}
+
+	// TODO: Deprecate
+	public function render_allow_signup_regular() {
+		$allow_signup = $this->options->is_wp_registration_enabled();
+?>
+	  <span class="description">
+		<?php echo __( 'Signup will be', 'wp-auth0' ); ?>
+
+		<?php if ( ! $allow_signup ) { ?>
+		  <b><?php echo __( 'disabled', 'wp-auth0' ); ?></b>
+			<?php echo __( ' because it is enabled by the setting "Anyone can register" in the WordPress General Settings.', 'wp-auth0' ); ?>
+		<?php } else { ?>
+		  <b><?php echo __( 'enabled', 'wp-auth0' ); ?></b>
+			<?php echo __( ' because it is enabled by the setting "Anyone can register" in the WordPress General Settings.', 'wp-auth0' ); ?>
+		<?php } ?>
+
+		<?php echo __( 'You can manage this setting on <code>Settings > General > Membership</code>, Anyone can register', 'wp-auth0' ); ?>
+		   <a href="<?php echo admin_url( 'options-general.php' ); ?>" target="_blank"><?php _e( 'here', 'wp-auth0' ); ?></a>.
+	  </span>
+
+	<?php
+	}
+
+	// TODO: Deprecate
 	public function render_basic_description() {
 ?>
 
-    <p class=\"a0-step-text\"><?php echo self::BASIC_DESCRIPTION; ?></p>
+	<p class=\"a0-step-text\"><?php echo self::BASIC_DESCRIPTION; ?></p>
 
-    <?php
+	<?php
 	}
 
 	public function auth0_delete_cache_transient() {
@@ -217,7 +251,7 @@ class WP_Auth0_Admin_Basic extends WP_Auth0_Admin_Generic {
 			return $input;
 		}
 
-		$input['client_id'] = sanitize_text_field( $input['client_id'] );
+		$input['client_id']        = sanitize_text_field( $input['client_id'] );
 		$input['cache_expiration'] = absint( $input['cache_expiration'] );
 
 		$input['wordpress_login_enabled'] = ( isset( $input['wordpress_login_enabled'] )

--- a/lib/admin/WP_Auth0_Admin_Dashboard.php
+++ b/lib/admin/WP_Auth0_Admin_Dashboard.php
@@ -22,17 +22,43 @@ class WP_Auth0_Admin_Dashboard extends WP_Auth0_Admin_Generic {
 
 	public function init() {
 
-		$this->init_option_section( '', 'dashboard', array(
+		$this->init_option_section(
+			'', 'dashboard', array(
 
-				array( 'id' => 'wpa0_chart_age_type', 'name' => 'Age', 'function' => 'render_age_chart_type' ),
-				array( 'id' => 'wpa0_chart_idp_type', 'name' => 'Identity providers', 'function' => 'render_idp_chart_type' ),
-				array( 'id' => 'wpa0_chart_gender_type', 'name' => 'Gender', 'function' => 'render_gender_chart_type' ),
+				array(
+					'id'       => 'wpa0_chart_age_type',
+					'name'     => 'Age',
+					'function' => 'render_age_chart_type',
+				),
+				array(
+					'id'       => 'wpa0_chart_idp_type',
+					'name'     => 'Identity providers',
+					'function' => 'render_idp_chart_type',
+				),
+				array(
+					'id'       => 'wpa0_chart_gender_type',
+					'name'     => 'Gender',
+					'function' => 'render_gender_chart_type',
+				),
 
-				array( 'id' => 'wpa0_chart_age_from', 'name' => 'Age buckets start', 'function' => 'render_age_from' ),
-				array( 'id' => 'wpa0_chart_age_to', 'name' => 'Age buckets end', 'function' => 'render_age_to' ),
-				array( 'id' => 'wpa0_chart_age_step', 'name' => 'Age buckets step', 'function' => 'render_age_step' ),
+				array(
+					'id'       => 'wpa0_chart_age_from',
+					'name'     => 'Age buckets start',
+					'function' => 'render_age_from',
+				),
+				array(
+					'id'       => 'wpa0_chart_age_to',
+					'name'     => 'Age buckets end',
+					'function' => 'render_age_to',
+				),
+				array(
+					'id'       => 'wpa0_chart_age_step',
+					'name'     => 'Age buckets step',
+					'function' => 'render_age_step',
+				),
 
-			) );
+			)
+		);
 
 	}
 
@@ -40,36 +66,36 @@ class WP_Auth0_Admin_Dashboard extends WP_Auth0_Admin_Generic {
 	public function render_dashboard_description() {
 ?>
 
-    <p class=\"a0-step-text\"><?php echo self::DASHBOARD_DESCRIPTION; ?></p>
+	<p class=\"a0-step-text\"><?php echo self::DASHBOARD_DESCRIPTION; ?></p>
 
-    <?php
+	<?php
 	}
 
 	public function render_age_from() {
 		$v = absint( $this->options->get( 'chart_age_from' ) );
 ?>
 
-    <input type="number" name="<?php echo $this->options->get_options_name() ?>[chart_age_from]" id="wpa0_auth0_age_from" value="<?php echo $v; ?>" />
+	<input type="number" name="<?php echo $this->options->get_options_name(); ?>[chart_age_from]" id="wpa0_auth0_age_from" value="<?php echo $v; ?>" />
 
-    <?php
+	<?php
 	}
 
 	public function render_age_to() {
 		$v = absint( $this->options->get( 'chart_age_to' ) );
 ?>
 
-    <input type="number" name="<?php echo $this->options->get_options_name() ?>[chart_age_to]" id="wpa0_auth0_age_to" value="<?php echo $v; ?>" />
+	<input type="number" name="<?php echo $this->options->get_options_name(); ?>[chart_age_to]" id="wpa0_auth0_age_to" value="<?php echo $v; ?>" />
 
-    <?php
+	<?php
 	}
 
 	public function render_age_step() {
 		$v = absint( $this->options->get( 'chart_age_step' ) );
 ?>
 
-    <input type="number" name="<?php echo $this->options->get_options_name() ?>[chart_age_step]" id="wpa0_auth0_age_step" value="<?php echo $v; ?>" />
+	<input type="number" name="<?php echo $this->options->get_options_name(); ?>[chart_age_step]" id="wpa0_auth0_age_step" value="<?php echo $v; ?>" />
 
-    <?php
+	<?php
 	}
 
 	public function render_age_chart_type() {
@@ -77,16 +103,16 @@ class WP_Auth0_Admin_Dashboard extends WP_Auth0_Admin_Generic {
 
 ?>
 
-    <input type="radio" name="<?php echo $this->options->get_options_name() ?>[chart_age_type]" id="wpa0_auth0_age_chart_type_donut" value="donut" <?php echo checked( $v, 'donut', false ); ?>/>
-    <label for="wpa0_auth0_age_chart_type_donut"><?php echo __( 'Donut', 'wp-auth0' ); ?></label>
+	<input type="radio" name="<?php echo $this->options->get_options_name(); ?>[chart_age_type]" id="wpa0_auth0_age_chart_type_donut" value="donut" <?php echo checked( $v, 'donut', false ); ?>/>
+	<label for="wpa0_auth0_age_chart_type_donut"><?php echo __( 'Donut', 'wp-auth0' ); ?></label>
 
-    <input type="radio" name="<?php echo $this->options->get_options_name() ?>[chart_age_type]" id="wpa0_auth0_age_chart_type_pie" value="pie" <?php echo checked( $v, 'pie', false ); ?>/>
-    <label for="wpa0_auth0_age_chart_type_pie"><?php echo __( 'Pie', 'wp-auth0' ); ?></label>
-    &nbsp;
-    <input type="radio" name="<?php echo $this->options->get_options_name() ?>[chart_age_type]" id="wpa0_auth0_age_chart_type_bar" value="bar" <?php echo checked( $v, 'bar', false ); ?>/>
-    <label for="wpa0_auth0_age_chart_type_bars"><?php echo __( 'Bars', 'wp-auth0' ); ?></label>
+	<input type="radio" name="<?php echo $this->options->get_options_name(); ?>[chart_age_type]" id="wpa0_auth0_age_chart_type_pie" value="pie" <?php echo checked( $v, 'pie', false ); ?>/>
+	<label for="wpa0_auth0_age_chart_type_pie"><?php echo __( 'Pie', 'wp-auth0' ); ?></label>
+	&nbsp;
+	<input type="radio" name="<?php echo $this->options->get_options_name(); ?>[chart_age_type]" id="wpa0_auth0_age_chart_type_bar" value="bar" <?php echo checked( $v, 'bar', false ); ?>/>
+	<label for="wpa0_auth0_age_chart_type_bars"><?php echo __( 'Bars', 'wp-auth0' ); ?></label>
 
-    <?php
+	<?php
 	}
 
 	public function render_idp_chart_type() {
@@ -94,16 +120,16 @@ class WP_Auth0_Admin_Dashboard extends WP_Auth0_Admin_Generic {
 
 ?>
 
-    <input type="radio" name="<?php echo $this->options->get_options_name() ?>[chart_idp_type]" id="wpa0_auth0_idp_chart_type_donut" value="donut" <?php echo checked( $v, 'donut', false ); ?>/>
-    <label for="wpa0_auth0_idp_chart_type_donut"><?php echo __( 'Donut', 'wp-auth0' ); ?></label>
+	<input type="radio" name="<?php echo $this->options->get_options_name(); ?>[chart_idp_type]" id="wpa0_auth0_idp_chart_type_donut" value="donut" <?php echo checked( $v, 'donut', false ); ?>/>
+	<label for="wpa0_auth0_idp_chart_type_donut"><?php echo __( 'Donut', 'wp-auth0' ); ?></label>
 
-    <input type="radio" name="<?php echo $this->options->get_options_name() ?>[chart_idp_type]" id="wpa0_auth0_idp_chart_type_pie" value="pie" <?php echo checked( $v, 'pie', false ); ?>/>
-    <label for="wpa0_auth0_idp_chart_type_pie"><?php echo __( 'Pie', 'wp-auth0' ); ?></label>
-    &nbsp;
-    <input type="radio" name="<?php echo $this->options->get_options_name() ?>[chart_idp_type]" id="wpa0_auth0_idp_chart_type_bar" value="bar" <?php echo checked( $v, 'bar', false ); ?>/>
-    <label for="wpa0_auth0_idp_chart_type_bars"><?php echo __( 'Bars', 'wp-auth0' ); ?></label>
+	<input type="radio" name="<?php echo $this->options->get_options_name(); ?>[chart_idp_type]" id="wpa0_auth0_idp_chart_type_pie" value="pie" <?php echo checked( $v, 'pie', false ); ?>/>
+	<label for="wpa0_auth0_idp_chart_type_pie"><?php echo __( 'Pie', 'wp-auth0' ); ?></label>
+	&nbsp;
+	<input type="radio" name="<?php echo $this->options->get_options_name(); ?>[chart_idp_type]" id="wpa0_auth0_idp_chart_type_bar" value="bar" <?php echo checked( $v, 'bar', false ); ?>/>
+	<label for="wpa0_auth0_idp_chart_type_bars"><?php echo __( 'Bars', 'wp-auth0' ); ?></label>
 
-    <?php
+	<?php
 	}
 
 	public function render_gender_chart_type() {
@@ -111,16 +137,16 @@ class WP_Auth0_Admin_Dashboard extends WP_Auth0_Admin_Generic {
 
 ?>
 
-    <input type="radio" name="<?php echo $this->options->get_options_name() ?>[chart_gender_type]" id="wpa0_auth0_gender_chart_type_donut" value="donut" <?php echo checked( $v, 'donut', false ); ?>/>
-    <label for="wpa0_auth0_gender_chart_type_donut"><?php echo __( 'Donut', 'wp-auth0' ); ?></label>
+	<input type="radio" name="<?php echo $this->options->get_options_name(); ?>[chart_gender_type]" id="wpa0_auth0_gender_chart_type_donut" value="donut" <?php echo checked( $v, 'donut', false ); ?>/>
+	<label for="wpa0_auth0_gender_chart_type_donut"><?php echo __( 'Donut', 'wp-auth0' ); ?></label>
 
-    <input type="radio" name="<?php echo $this->options->get_options_name() ?>[chart_gender_type]" id="wpa0_auth0_gender_chart_type_pie" value="pie" <?php echo checked( $v, 'pie', false ); ?>/>
-    <label for="wpa0_auth0_gender_chart_type_pie"><?php echo __( 'Pie', 'wp-auth0' ); ?></label>
-    &nbsp;
-    <input type="radio" name="<?php echo $this->options->get_options_name() ?>[chart_gender_type]" id="wpa0_auth0_gender_chart_type_bar" value="bar" <?php echo checked( $v, 'bar', false ); ?>/>
-    <label for="wpa0_auth0_gender_chart_type_bars"><?php echo __( 'Bars', 'wp-auth0' ); ?></label>
+	<input type="radio" name="<?php echo $this->options->get_options_name(); ?>[chart_gender_type]" id="wpa0_auth0_gender_chart_type_pie" value="pie" <?php echo checked( $v, 'pie', false ); ?>/>
+	<label for="wpa0_auth0_gender_chart_type_pie"><?php echo __( 'Pie', 'wp-auth0' ); ?></label>
+	&nbsp;
+	<input type="radio" name="<?php echo $this->options->get_options_name(); ?>[chart_gender_type]" id="wpa0_auth0_gender_chart_type_bar" value="bar" <?php echo checked( $v, 'bar', false ); ?>/>
+	<label for="wpa0_auth0_gender_chart_type_bars"><?php echo __( 'Bars', 'wp-auth0' ); ?></label>
 
-    <?php
+	<?php
 	}
 
 	protected function validate_chart_type( $type ) {
@@ -135,8 +161,8 @@ class WP_Auth0_Admin_Dashboard extends WP_Auth0_Admin_Generic {
 
 	public function basic_validation( $old_options, $input ) {
 		$input['chart_gender_type'] = $this->validate_chart_type( $input['chart_gender_type'] );
-		$input['chart_idp_type'] = $this->validate_chart_type( $input['chart_idp_type'] );
-		$input['chart_age_type'] = $this->validate_chart_type( $input['chart_age_type'] );
+		$input['chart_idp_type']    = $this->validate_chart_type( $input['chart_idp_type'] );
+		$input['chart_age_type']    = $this->validate_chart_type( $input['chart_age_type'] );
 
 		return $input;
 	}

--- a/lib/admin/WP_Auth0_Admin_Features.php
+++ b/lib/admin/WP_Auth0_Admin_Features.php
@@ -2,270 +2,308 @@
 
 class WP_Auth0_Admin_Features extends WP_Auth0_Admin_Generic {
 
-  // TODO: Deprecate
-  const FEATURES_DESCRIPTION = 'Settings related to specific features provided by the plugin.';
+	// TODO: Deprecate
+	const FEATURES_DESCRIPTION = 'Settings related to specific features provided by the plugin.';
 
-  protected $_description;
+	protected $_description;
 
-  protected $actions_middlewares = array(
-    'basic_validation',
-    'georule_validation',
-    'sso_validation',
-    'security_validation',
-    'incomerule_validation',
-    'fullcontact_validation',
-    'mfa_validation',
-  );
+	protected $actions_middlewares = array(
+		'basic_validation',
+		'georule_validation',
+		'sso_validation',
+		'security_validation',
+		'incomerule_validation',
+		'fullcontact_validation',
+		'mfa_validation',
+	);
 
-  /**
-   * WP_Auth0_Admin_Features constructor.
-   *
-   * @param WP_Auth0_Options_Generic $options
-   */
-  public function __construct( WP_Auth0_Options_Generic $options ) {
-    parent::__construct( $options );
-    $this->_description = __( 'Settings related to specific features provided by the plugin.', 'wp-auth0' );
-  }
+	/**
+	 * WP_Auth0_Admin_Features constructor.
+	 *
+	 * @param WP_Auth0_Options_Generic $options
+	 */
+	public function __construct( WP_Auth0_Options_Generic $options ) {
+		parent::__construct( $options );
+		$this->_description = __( 'Settings related to specific features provided by the plugin.', 'wp-auth0' );
+	}
 
-  /**
-   * All settings in the Features tab
-   *
-   * @see \WP_Auth0_Admin::init_admin
-   * @see \WP_Auth0_Admin_Generic::init_option_section
-   */
-  public function init() {
-    $options = array(
-      array( 'name' => __( 'Password Policy', 'wp-auth0' ), 'opt' => 'password_policy',
-        'id' => 'wpa0_password_policy', 'function' => 'render_password_policy' ),
-      array( 'name' => __( 'Single Sign On (SSO)', 'wp-auth0' ), 'opt' => 'sso',
-        'id' => 'wpa0_sso', 'function' => 'render_sso' ),
-      array( 'name' => __( 'Single Logout', 'wp-auth0' ), 'opt' => 'singlelogout',
-        'id' => 'wpa0_singlelogout', 'function' => 'render_singlelogout' ),
-      array( 'name' => __( 'Passwordless Login', 'wp-auth0' ), 'opt' => 'passwordless_enabled',
-        'id' => 'wpa0_passwordless_enabled', 'function' => 'render_passwordless_enabled' ),
-      array( 'name' => __( 'Multifactor Authentication (MFA)', 'wp-auth0' ), 'opt' => 'mfa',
-        'id' => 'wpa0_mfa', 'function' => 'render_mfa' ),
-      array( 'name' => __( 'FullContact Integration', 'wp-auth0' ), 'opt' => 'fullcontact',
-        'id' => 'wpa0_fullcontact', 'function' => 'render_fullcontact' ),
-      array( 'name' => __( 'FullContact API Key', 'wp-auth0' ), 'opt' => 'fullcontact_apikey',
-        'id' => 'wpa0_fullcontact_key', 'function' => 'render_fullcontact_apikey' ),
-      array( 'name' => __( 'Store Geolocation', 'wp-auth0' ), 'opt' => 'geo_rule',
-        'id' => 'wpa0_geo', 'function' => 'render_geo' ),
-      array( 'name' => __( 'Store Zipcode Income', 'wp-auth0' ), 'opt' => 'income_rule',
-        'id' => 'wpa0_income', 'function' => 'render_income' ),
-      array( 'name' => __( 'Override WordPress Avatars', 'wp-auth0' ), 'opt' => 'override_wp_avatars',
-        'id' => 'wpa0_override_wp_avatars', 'function' => 'render_override_wp_avatars' ),
-    );
-    $this->init_option_section( '', 'features', $options );
-  }
+	/**
+	 * All settings in the Features tab
+	 *
+	 * @see \WP_Auth0_Admin::init_admin
+	 * @see \WP_Auth0_Admin_Generic::init_option_section
+	 */
+	public function init() {
+		$options = array(
+			array(
+				'name'     => __( 'Password Policy', 'wp-auth0' ),
+				'opt'      => 'password_policy',
+				'id'       => 'wpa0_password_policy',
+				'function' => 'render_password_policy',
+			),
+			array(
+				'name'     => __( 'Single Sign On (SSO)', 'wp-auth0' ),
+				'opt'      => 'sso',
+				'id'       => 'wpa0_sso',
+				'function' => 'render_sso',
+			),
+			array(
+				'name'     => __( 'Single Logout', 'wp-auth0' ),
+				'opt'      => 'singlelogout',
+				'id'       => 'wpa0_singlelogout',
+				'function' => 'render_singlelogout',
+			),
+			array(
+				'name'     => __( 'Passwordless Login', 'wp-auth0' ),
+				'opt'      => 'passwordless_enabled',
+				'id'       => 'wpa0_passwordless_enabled',
+				'function' => 'render_passwordless_enabled',
+			),
+			array(
+				'name'     => __( 'Multifactor Authentication (MFA)', 'wp-auth0' ),
+				'opt'      => 'mfa',
+				'id'       => 'wpa0_mfa',
+				'function' => 'render_mfa',
+			),
+			array(
+				'name'     => __( 'FullContact Integration', 'wp-auth0' ),
+				'opt'      => 'fullcontact',
+				'id'       => 'wpa0_fullcontact',
+				'function' => 'render_fullcontact',
+			),
+			array(
+				'name'     => __( 'FullContact API Key', 'wp-auth0' ),
+				'opt'      => 'fullcontact_apikey',
+				'id'       => 'wpa0_fullcontact_key',
+				'function' => 'render_fullcontact_apikey',
+			),
+			array(
+				'name'     => __( 'Store Geolocation', 'wp-auth0' ),
+				'opt'      => 'geo_rule',
+				'id'       => 'wpa0_geo',
+				'function' => 'render_geo',
+			),
+			array(
+				'name'     => __( 'Store Zipcode Income', 'wp-auth0' ),
+				'opt'      => 'income_rule',
+				'id'       => 'wpa0_income',
+				'function' => 'render_income',
+			),
+			array(
+				'name'     => __( 'Override WordPress Avatars', 'wp-auth0' ),
+				'opt'      => 'override_wp_avatars',
+				'id'       => 'wpa0_override_wp_avatars',
+				'function' => 'render_override_wp_avatars',
+			),
+		);
+		$this->init_option_section( '', 'features', $options );
+	}
 
-  public function render_password_policy( $args = array() ) {
-    $opt_name = $args[ 'opt_name' ];
-    $id_attr = $args[ 'label_for' ];
-    $curr_val = $this->options->get( $opt_name );
+	public function render_password_policy( $args = array() ) {
+		$opt_name = $args['opt_name'];
+		$id_attr  = $args['label_for'];
+		$curr_val = $this->options->get( $opt_name );
 
-    $this->render_radio_button( $id_attr . '_none', $opt_name, '', 'None', empty( $curr_val ) );
-    foreach ( array( 'low', 'fair', 'good', 'excellent' ) as $val ) {
-      $this->render_radio_button( $id_attr . '_' . $val, $opt_name, $val, '', $val === $curr_val );
-    }
-    $this->render_field_description(
-      __( 'Password security policy for the database connection used by this application. ', 'wp-auth0' ) .
-      __( 'Changing the policy here will change it for all other applications using this database. ', 'wp-auth0' ) .
-      __( 'For information on policy levels, see our ', 'wp-auth0' ) .
-      $this->get_docs_link(
-        'connections/database/password-strength',
-        __( 'help page on password strength', 'wp-auth0' )
-      )
-    );
-  }
+		$this->render_radio_button( $id_attr . '_none', $opt_name, '', 'None', empty( $curr_val ) );
+		foreach ( array( 'low', 'fair', 'good', 'excellent' ) as $val ) {
+			$this->render_radio_button( $id_attr . '_' . $val, $opt_name, $val, '', $val === $curr_val );
+		}
+		$this->render_field_description(
+			__( 'Password security policy for the database connection used by this application. ', 'wp-auth0' ) .
+			__( 'Changing the policy here will change it for all other applications using this database. ', 'wp-auth0' ) .
+			__( 'For information on policy levels, see our ', 'wp-auth0' ) .
+			$this->get_docs_link(
+				'connections/database/password-strength',
+				__( 'help page on password strength', 'wp-auth0' )
+			)
+		);
+	}
 
-  public function render_sso( $args = array() ) {
-    $this->render_switch( $args['label_for'], $args['opt_name'] );
-    $this->render_field_description(
-      __( 'SSO allows users to sign in once to multiple Applications in the same tenant. ', 'wp-auth0' ) .
-      __( 'Turning this on will attempt to automatically log a user in when they visit wp-login.php. ', 'wp-auth0' ) .
-      __( 'This setting will not affect how shortcodes and widgets work. ', 'wp-auth0' ) .
-      __( 'For more information, see our ', 'wp-auth0' ) .
-      $this->get_docs_link( 'sso/current/introduction', __( 'help page on SSO', 'wp-auth0' ) )
-    );
-  }
+	public function render_sso( $args = array() ) {
+		$this->render_switch( $args['label_for'], $args['opt_name'] );
+		$this->render_field_description(
+			__( 'SSO allows users to sign in once to multiple Applications in the same tenant. ', 'wp-auth0' ) .
+			__( 'Turning this on will attempt to automatically log a user in when they visit wp-login.php. ', 'wp-auth0' ) .
+			__( 'This setting will not affect how shortcodes and widgets work. ', 'wp-auth0' ) .
+			__( 'For more information, see our ', 'wp-auth0' ) .
+			$this->get_docs_link( 'sso/current/introduction', __( 'help page on SSO', 'wp-auth0' ) )
+		);
+	}
 
-  public function render_singlelogout( $args = array() ) {
-    $this->render_switch( $args['label_for'], $args['opt_name'] );
-    $this->render_field_description(
-      __( 'Log users out of this site and all others connected to the tenant', 'wp-auth0' )
-    );
-  }
+	public function render_singlelogout( $args = array() ) {
+		$this->render_switch( $args['label_for'], $args['opt_name'] );
+		$this->render_field_description(
+			__( 'Log users out of this site and all others connected to the tenant', 'wp-auth0' )
+		);
+	}
 
-  public function render_mfa( $args = array() ) {
-    $this->render_switch( $args['label_for'], $args['opt_name'] );
-    $this->render_field_description(
-      __( 'Mark this if you want to enable multifactor authentication with Auth0 Guardian. ', 'wp-auth0' ) .
-      sprintf(
-        __( 'You can enable other MFA providers in the %s. ', 'wp-auth0' ),
-        $this->get_dashboard_link( 'multifactor' )
-      ) . __( 'For more information, see our ', 'wp-auth0' ) .
-      $this->get_docs_link( 'multifactor-authentication', __( 'help page on MFA', 'wp-auth0' ) )
-    );
-  }
+	public function render_passwordless_enabled( $args = array() ) {
+		$this->render_switch( $args['label_for'], $args['opt_name'] );
+		$this->render_field_description(
+			__( 'Turn on Passwordless login (email or SMS) in the Auth0 form. ', 'wp-auth0' ) .
+			__( 'Passwordless connections are managed in the ', 'wp-auth0' ) .
+			$this->get_dashboard_link( 'connections/passwordless' ) .
+			__( ' and at least one must be active and enabled on this Application for this to work. ', 'wp-auth0' ) .
+			__( 'Username/password login is not enabled when Passwordless is on', 'wp-auth0' )
+		);
+	}
 
-  public function render_geo( $args = array() ) {
-    $this->render_switch( $args[ 'label_for' ], $args[ 'opt_name' ] );
-    $this->render_field_description(
-      __( 'Mark this if you want to store geolocation data based on the IP of the user logging in', 'wp-auth0' )
-    );
-  }
+	public function render_mfa( $args = array() ) {
+		$this->render_switch( $args['label_for'], $args['opt_name'] );
+		$this->render_field_description(
+			__( 'Mark this if you want to enable multifactor authentication with Auth0 Guardian. ', 'wp-auth0' ) .
+			sprintf(
+				__( 'You can enable other MFA providers in the %s. ', 'wp-auth0' ),
+				$this->get_dashboard_link( 'multifactor' )
+			) . __( 'For more information, see our ', 'wp-auth0' ) .
+			$this->get_docs_link( 'multifactor-authentication', __( 'help page on MFA', 'wp-auth0' ) )
+		);
+	}
 
-  public function render_income( $args = array() ) {
-    $this->render_switch( $args[ 'label_for' ], $args[ 'opt_name' ] );
-    $this->render_field_description(
-      __( 'Mark this if you want to store projected income data based on the zipcode of the user\'s IP', 'wp-auth0' )
-    );
-  }
+	public function render_fullcontact( $args = array() ) {
+		$this->render_switch( $args['label_for'], $args['opt_name'], 'wpa0_fullcontact_key' );
+		$this->render_field_description(
+			__( 'Enriches your user profiles with the data provided by FullContact. ', 'wp-auth0' ) .
+			__( 'A valid FullContact API key is required for this to work. ', 'wp-auth0' ) .
+			__( 'For more details, see our ', 'wp-auth0' ) .
+			$this->get_docs_link(
+				'monitoring/track-signups-enrich-user-profile-generate-leads',
+				__( 'help page on tracking signups', 'wp-auth0' )
+			)
+		);
+	}
 
-  public function render_override_wp_avatars( $args = array() ) {
-    $this->render_switch( $args[ 'label_for' ], $args[ 'opt_name' ] );
-    $this->render_field_description(
-      __( 'Overrides the WordPress avatar with the Auth0 profile avatar', 'wp-auth0' )
-    );
-  }
+	public function render_fullcontact_apikey( $args = array() ) {
+		$this->render_text_field( $args['label_for'], $args['opt_name'] );
+	}
 
-  public function render_fullcontact( $args = array() ) {
-    $this->render_switch( $args['label_for'], $args['opt_name'], 'wpa0_fullcontact_key' );
-    $this->render_field_description(
-      __( 'Enriches your user profiles with the data provided by FullContact. ', 'wp-auth0' ) .
-      __( 'A valid FullContact API key is required for this to work. ', 'wp-auth0' ) .
-      __( 'For more details, see our ', 'wp-auth0' ) .
-      $this->get_docs_link(
-        'monitoring/track-signups-enrich-user-profile-generate-leads',
-        __( 'help page on tracking signups', 'wp-auth0' )
-      )
-    );
-  }
+	public function render_geo( $args = array() ) {
+		$this->render_switch( $args['label_for'], $args['opt_name'] );
+		$this->render_field_description(
+			__( 'Mark this if you want to store geolocation data based on the IP of the user logging in', 'wp-auth0' )
+		);
+	}
 
-  public function render_fullcontact_apikey( $args = array() ) {
-    $this->render_text_field( $args['label_for'], $args['opt_name'] );
-  }
+	public function render_income( $args = array() ) {
+		$this->render_switch( $args['label_for'], $args['opt_name'] );
+		$this->render_field_description(
+			__( 'Mark this if you want to store projected income data based on the zipcode of the user\'s IP', 'wp-auth0' )
+		);
+	}
 
-  public function render_passwordless_enabled( $args = array() ) {
-    $this->render_switch( $args[ 'label_for' ], $args[ 'opt_name' ] );
-    $this->render_field_description(
-      __( 'Turn on Passwordless login (email or SMS) in the Auth0 form. ', 'wp-auth0' ) .
-      __( 'Passwordless connections are managed in the ', 'wp-auth0' ) .
-      $this->get_dashboard_link( 'connections/passwordless' ) .
-      __( ' and at least one must be active and enabled on this Application for this to work. ', 'wp-auth0' ) .
-      __( 'Username/password login is not enabled when Passwordless is on', 'wp-auth0' )
-    );
-  }
+	public function render_override_wp_avatars( $args = array() ) {
+		$this->render_switch( $args['label_for'], $args['opt_name'] );
+		$this->render_field_description(
+			__( 'Overrides the WordPress avatar with the Auth0 profile avatar', 'wp-auth0' )
+		);
+	}
 
-  // TODO: Deprecate
-  public function render_features_description() {
-?>
+	// TODO: Deprecate
+	public function render_features_description() {
+	?>
 
-    <p class=\"a0-step-text\"><?php echo self::FEATURES_DESCRIPTION; ?></p>
+	<p class=\"a0-step-text\"><?php echo self::FEATURES_DESCRIPTION; ?></p>
 
-    <?php
-  }
+	<?php
+	}
 
-  public function basic_validation( $old_options, $input ) {
-    $input['singlelogout'] = ( isset( $input['singlelogout'] ) ? $input['singlelogout'] : 0 );
-    $input['override_wp_avatars'] = ( isset( $input['override_wp_avatars'] ) ? $input['override_wp_avatars'] : 0 );
+	public function basic_validation( $old_options, $input ) {
+		$input['singlelogout']        = ( isset( $input['singlelogout'] ) ? $input['singlelogout'] : 0 );
+		$input['override_wp_avatars'] = ( isset( $input['override_wp_avatars'] ) ? $input['override_wp_avatars'] : 0 );
 
-    return $input;
-  }
+		return $input;
+	}
 
-  public function sso_validation( $old_options, $input ) {
-    $input['sso'] = ( isset( $input['sso'] ) ? $input['sso'] : 0 );
+	public function sso_validation( $old_options, $input ) {
+		$input['sso'] = ( isset( $input['sso'] ) ? $input['sso'] : 0 );
 
-    if ( $old_options['sso'] != $input['sso'] && 1 == $input['sso'] ) {
-      if ( false === WP_Auth0_Api_Client::update_client( $input['domain'], $input['auth0_app_token'], $input['client_id'], $input['sso'] == 1 ) ) {
+		if ( $old_options['sso'] != $input['sso'] && 1 == $input['sso'] ) {
+			if ( false === WP_Auth0_Api_Client::update_client( $input['domain'], $input['auth0_app_token'], $input['client_id'], $input['sso'] == 1 ) ) {
 
-        $error = __( 'There was an error updating your Auth0 App to enable SSO. To do it manually, turn it ', 'wp-auth0' );
-        $error .= '<a href="https://auth0.com/docs/sso/single-sign-on#1">HERE</a>.';
-        $this->add_validation_error( $error );
+				$error  = __( 'There was an error updating your Auth0 App to enable SSO. To do it manually, turn it ', 'wp-auth0' );
+				$error .= '<a href="https://auth0.com/docs/sso/single-sign-on#1">HERE</a>.';
+				$this->add_validation_error( $error );
 
-      }
-    }
-    return $input;
-  }
+			}
+		}
+		return $input;
+	}
 
-  /**
-   * Update the password policy for the database connection used with this application
-   *
-   * @param array $old_options - previous option values
-   * @param array $input - new option values
-   *
-   * @return array
-   */
-  public function security_validation( $old_options, $input ) {
-    $input['password_policy'] = ! empty( $input['password_policy'] ) ? $input['password_policy'] : null;
+	/**
+	 * Update the password policy for the database connection used with this application
+	 *
+	 * @param array $old_options - previous option values
+	 * @param array $input - new option values
+	 *
+	 * @return array
+	 */
+	public function security_validation( $old_options, $input ) {
+		$input['password_policy'] = ! empty( $input['password_policy'] ) ? $input['password_policy'] : null;
 
-    if ( $old_options['password_policy'] !== $input['password_policy'] ) {
-      $domain = $input['domain'];
-      $app_token = $input['auth0_app_token'];
-      $connections = WP_Auth0_Api_Client::search_connection( $domain, $app_token, 'auth0' );
+		if ( $old_options['password_policy'] !== $input['password_policy'] ) {
+			$domain      = $input['domain'];
+			$app_token   = $input['auth0_app_token'];
+			$connections = WP_Auth0_Api_Client::search_connection( $domain, $app_token, 'auth0' );
 
-      if ( empty( $connections ) ) {
-        $this->add_validation_error(
-          __( 'No database connections found for this application. ', 'wp-auth0' ) .
-          $this->get_dashboard_link( 'connections/database', __( 'See all database connections', 'wp-auth0' ) )
-        );
-      }
+			if ( empty( $connections ) ) {
+				$this->add_validation_error(
+					__( 'No database connections found for this application. ', 'wp-auth0' ) .
+					$this->get_dashboard_link( 'connections/database', __( 'See all database connections', 'wp-auth0' ) )
+				);
+			}
 
-      foreach ( $connections as $connection ) {
-        if ( in_array( $input['client_id'], $connection->enabled_clients ) ) {
-          $patch = array( 'options' => array( 'passwordPolicy' => $input['password_policy'] ) );
-          $update_resp = WP_Auth0_Api_Client::update_connection( $domain, $app_token, $connection->id, $patch );
+			foreach ( $connections as $connection ) {
+				if ( in_array( $input['client_id'], $connection->enabled_clients ) ) {
+					$patch       = array( 'options' => array( 'passwordPolicy' => $input['password_policy'] ) );
+					$update_resp = WP_Auth0_Api_Client::update_connection( $domain, $app_token, $connection->id, $patch );
 
-          if ( false === $update_resp ) {
-            $this->add_validation_error(
-              __( 'There was a problem updating the password policy. ', 'wp-auth0' ) .
-              __( 'Please manually review and update the policy. ', 'wp-auth0' ) .
-              $this->get_dashboard_link( 'connections/database', __( 'See all database connections', 'wp-auth0' ) )
-            );
-          }
-        }
-      }
-    }
-    return $input;
-  }
+					if ( false === $update_resp ) {
+						$this->add_validation_error(
+							__( 'There was a problem updating the password policy. ', 'wp-auth0' ) .
+							__( 'Please manually review and update the policy. ', 'wp-auth0' ) .
+							$this->get_dashboard_link( 'connections/database', __( 'See all database connections', 'wp-auth0' ) )
+						);
+					}
+				}
+			}
+		}
+		return $input;
+	}
 
-  public function fullcontact_validation( $old_options, $input ) {
-    $fullcontact_script = WP_Auth0_RulesLib::$fullcontact['script'];
-    $fullcontact_script = str_replace( 'REPLACE_WITH_YOUR_CLIENT_ID', $input['client_id'], $fullcontact_script );
-    $fullcontact_script = str_replace( 'REPLACE_WITH_YOUR_FULLCONTACT_API_KEY', $input['fullcontact_apikey'], $fullcontact_script );
-    return $this->rule_validation( $old_options, $input, 'fullcontact', WP_Auth0_RulesLib::$fullcontact['name']. '-' . get_auth0_curatedBlogName(), $fullcontact_script );
-  }
+	public function fullcontact_validation( $old_options, $input ) {
+		$fullcontact_script = WP_Auth0_RulesLib::$fullcontact['script'];
+		$fullcontact_script = str_replace( 'REPLACE_WITH_YOUR_CLIENT_ID', $input['client_id'], $fullcontact_script );
+		$fullcontact_script = str_replace( 'REPLACE_WITH_YOUR_FULLCONTACT_API_KEY', $input['fullcontact_apikey'], $fullcontact_script );
+		return $this->rule_validation( $old_options, $input, 'fullcontact', WP_Auth0_RulesLib::$fullcontact['name'] . '-' . get_auth0_curatedBlogName(), $fullcontact_script );
+	}
 
-  public function mfa_validation( $old_options, $input ) {
+	public function mfa_validation( $old_options, $input ) {
 
-    if (!isset($input['mfa'])) {
-      $input['mfa'] = null;
-    }
-    if (!isset($old_options['mfa'])) {
-      $old_options['mfa'] = null;
-    }
+		if ( ! isset( $input['mfa'] ) ) {
+			$input['mfa'] = null;
+		}
+		if ( ! isset( $old_options['mfa'] ) ) {
+			$old_options['mfa'] = null;
+		}
 
-    if ($old_options['mfa'] != $input['mfa'] && $input['mfa'] !== null) {
-      WP_Auth0_Api_Client::update_guardian($input['domain'], $input['auth0_app_token'], 'push-notification', true);
-    }
-    
-    $mfa_script = WP_Auth0_RulesLib::$guardian_MFA['script'];
-    $mfa_script = str_replace( 'REPLACE_WITH_YOUR_CLIENT_ID', $input['client_id'], $mfa_script );
-    return $this->rule_validation( $old_options, $input, 'mfa', WP_Auth0_RulesLib::$guardian_MFA['name'] . '-' . get_auth0_curatedBlogName(), $mfa_script );
-  }
+		if ( $old_options['mfa'] != $input['mfa'] && $input['mfa'] !== null ) {
+			WP_Auth0_Api_Client::update_guardian( $input['domain'], $input['auth0_app_token'], 'push-notification', true );
+		}
 
+		$mfa_script = WP_Auth0_RulesLib::$guardian_MFA['script'];
+		$mfa_script = str_replace( 'REPLACE_WITH_YOUR_CLIENT_ID', $input['client_id'], $mfa_script );
+		return $this->rule_validation( $old_options, $input, 'mfa', WP_Auth0_RulesLib::$guardian_MFA['name'] . '-' . get_auth0_curatedBlogName(), $mfa_script );
+	}
 
-  public function georule_validation( $old_options, $input ) {
-    $geo_script = WP_Auth0_RulesLib::$geo['script'];
-    $geo_script = str_replace( 'REPLACE_WITH_YOUR_CLIENT_ID', $input['client_id'], $geo_script );
-    return $this->rule_validation( $old_options, $input, 'geo_rule', WP_Auth0_RulesLib::$geo['name'] . '-' . get_auth0_curatedBlogName(), $geo_script );
-  }
+	public function georule_validation( $old_options, $input ) {
+		$geo_script = WP_Auth0_RulesLib::$geo['script'];
+		$geo_script = str_replace( 'REPLACE_WITH_YOUR_CLIENT_ID', $input['client_id'], $geo_script );
+		return $this->rule_validation( $old_options, $input, 'geo_rule', WP_Auth0_RulesLib::$geo['name'] . '-' . get_auth0_curatedBlogName(), $geo_script );
+	}
 
-  public function incomerule_validation( $old_options, $input ) {
-    $income_script = WP_Auth0_RulesLib::$income['script'];
-    $income_script = str_replace( 'REPLACE_WITH_YOUR_CLIENT_ID', $input['client_id'], $income_script );
-    return $this->rule_validation( $old_options, $input, 'income_rule', WP_Auth0_RulesLib::$income['name'] . '-' . get_auth0_curatedBlogName(), $income_script );
-  }
-
+	public function incomerule_validation( $old_options, $input ) {
+		$income_script = WP_Auth0_RulesLib::$income['script'];
+		$income_script = str_replace( 'REPLACE_WITH_YOUR_CLIENT_ID', $input['client_id'], $income_script );
+		return $this->rule_validation( $old_options, $input, 'income_rule', WP_Auth0_RulesLib::$income['name'] . '-' . get_auth0_curatedBlogName(), $income_script );
+	}
 }

--- a/lib/admin/WP_Auth0_Admin_Generic.php
+++ b/lib/admin/WP_Auth0_Admin_Generic.php
@@ -3,8 +3,11 @@
 class WP_Auth0_Admin_Generic {
 
 	protected $options;
+
 	protected $_option_name;
+
 	protected $_description;
+
 	protected $_textarea_rows = 4;
 
 	protected $actions_middlewares = array();
@@ -15,20 +18,20 @@ class WP_Auth0_Admin_Generic {
 	 * @param WP_Auth0_Options_Generic $options
 	 */
 	public function __construct( WP_Auth0_Options_Generic $options ) {
-		$this->options = $options;
+		$this->options      = $options;
 		$this->_option_name = $options->get_options_name();
 	}
 
 	/**
-     * Add settings section and fields for each of the settings screen
-     *
+	 * Add settings section and fields for each of the settings screen
+	 *
 	 * @param string $section_name - name used for the settings section (usually empty)
 	 * @param string $id - settings screen id
-	 * @param array $options - array of settings fields
+	 * @param array  $options - array of settings fields
 	 */
 	protected function init_option_section( $section_name, $id, $options ) {
 		$options_name = $this->_option_name . '_' . strtolower( $id );
-		$section_id = "wp_auth0_{$id}_settings_section";
+		$section_id   = "wp_auth0_{$id}_settings_section";
 
 		add_settings_section(
 			$section_id,
@@ -39,7 +42,7 @@ class WP_Auth0_Admin_Generic {
 
 		$options = apply_filters( 'auth0_settings_fields', $options, $id );
 
-		foreach ($options as $setting ) {
+		foreach ( $options as $setting ) {
 			$callback = function_exists( $setting['function'] )
 				? $setting['function']
 				: array( $this, $setting['function'] );
@@ -52,7 +55,7 @@ class WP_Auth0_Admin_Generic {
 				$section_id,
 				array(
 					'label_for' => $setting['id'],
-					'opt_name' => isset( $setting['opt'] ) ? $setting['opt'] : null,
+					'opt_name'  => isset( $setting['opt'] ) ? $setting['opt'] : null,
 				)
 			);
 		}
@@ -94,35 +97,34 @@ class WP_Auth0_Admin_Generic {
 	}
 
 	protected function rule_validation( $old_options, $input, $key, $rule_name, $rule_script ) {
-		$input[$key] = ( isset( $input[$key] ) ? $input[$key] : null );
+		$input[ $key ] = ( isset( $input[ $key ] ) ? $input[ $key ] : null );
 
-		if ( ( $input[$key] !== null && $old_options[$key] === null ) || ( $input[$key] === null && $old_options[$key] !== null ) ) {
+		if ( ( $input[ $key ] !== null && $old_options[ $key ] === null ) || ( $input[ $key ] === null && $old_options[ $key ] !== null ) ) {
 
 			try {
 
-				$operations = new WP_Auth0_Api_Operations( $this->options );
-				$input[$key] = $operations->toggle_rule ( $this->options->get( 'auth0_app_token' ), ( is_null( $input[$key] ) ? $old_options[$key] : null ), $rule_name, $rule_script );
+				$operations    = new WP_Auth0_Api_Operations( $this->options );
+				$input[ $key ] = $operations->toggle_rule( $this->options->get( 'auth0_app_token' ), ( is_null( $input[ $key ] ) ? $old_options[ $key ] : null ), $rule_name, $rule_script );
 
 			} catch ( Exception $e ) {
 				$this->add_validation_error( $e->getMessage() );
-				$input[$key] = null;
+				$input[ $key ] = null;
 			}
 		}
 
 		return $input;
 	}
 
-
 	// TODO: Deprecate
 	protected function render_a0_switch( $id, $name, $value, $checked ) {
 ?>
 
-    <div class="a0-switch">
-      <input type="checkbox" name="<?php echo $this->_option_name; ?>[<?php echo $name; ?>]" id="<?php echo $id; ?>" value="<?php echo $value; ?>" <?php echo checked( $checked ); ?>/>
-      <label for="<?php echo $id; ?>"></label>
-    </div>
+	<div class="a0-switch">
+	  <input type="checkbox" name="<?php echo $this->_option_name; ?>[<?php echo $name; ?>]" id="<?php echo $id; ?>" value="<?php echo $value; ?>" <?php echo checked( $checked ); ?>/>
+	  <label for="<?php echo $id; ?>"></label>
+	</div>
 
-    <?php
+	<?php
 	}
 
 	/**
@@ -141,7 +143,7 @@ class WP_Auth0_Admin_Generic {
 			esc_attr( $input_name ),
 			esc_attr( $id ),
 			! empty( $expand_id ) ? esc_attr( $expand_id ) : '',
-			checked( empty( $value ), FALSE, FALSE ),
+			checked( empty( $value ), false, false ),
 			esc_attr( $id )
 		);
 	}
@@ -160,7 +162,7 @@ class WP_Auth0_Admin_Generic {
 		// Secure fields are not output by default; validation keeps last value if a new one is not entered
 		if ( 'password' === $type ) {
 			$placeholder = ! empty( $value ) ? 'Not visible' : '';
-			$value = '';
+			$value       = '';
 		}
 		printf(
 			'<input type="%s" name="%s[%s]" id="%s" value="%s" placeholder="%s" style="%s">',
@@ -211,13 +213,13 @@ class WP_Auth0_Admin_Generic {
 	/**
 	 * Output a radio button
 	 *
-	 * @param string $id - input id attribute
-	 * @param string $input_name - input name attribute
+	 * @param string               $id - input id attribute
+	 * @param string               $input_name - input name attribute
 	 * @param string|integer|float $value - input value attribute
-	 * @param string $label - input label text
-	 * @param bool $selected - is it active?
+	 * @param string               $label - input label text
+	 * @param bool                 $selected - is it active?
 	 */
-	protected function render_radio_button( $id, $input_name, $value, $label = '', $selected = FALSE ) {
+	protected function render_radio_button( $id, $input_name, $value, $label = '', $selected = false ) {
 		printf(
 			'<label for="%s"><input type="radio" name="%s[%s]" id="%s" value="%s" %s>&nbsp;%s</label>',
 			esc_attr( $id ),
@@ -225,7 +227,7 @@ class WP_Auth0_Admin_Generic {
 			esc_attr( $input_name ),
 			esc_attr( $id ),
 			esc_attr( $value ),
-			checked( $selected, TRUE, FALSE ),
+			checked( $selected, true, false ),
 			sanitize_text_field( ! empty( $label ) ? $label : ucfirst( $value ) )
 		);
 	}
@@ -247,7 +249,8 @@ class WP_Auth0_Admin_Generic {
 	 * @return string
 	 */
 	protected function get_dashboard_link( $path = '' ) {
-		return sprintf( '<a href="https://manage.auth0.com/#/%s" target="_blank">%s</a>',
+		return sprintf(
+			'<a href="https://manage.auth0.com/#/%s" target="_blank">%s</a>',
 			$path,
 			__( 'Auth0 dashboard', 'wp-auth0' )
 		);
@@ -264,7 +267,6 @@ class WP_Auth0_Admin_Generic {
 	protected function get_docs_link( $path, $text = '' ) {
 		$path = '/' === $path[0] ? substr( $path, 1 ) : $path;
 		$text = empty( $text ) ? __( 'here', 'wp-auth0' ) : sanitize_text_field( $text );
-		return sprintf( '<a href="https://auth0.com/docs/%s" target="_blank">%s</a>',	$path, $text );
+		return sprintf( '<a href="https://auth0.com/docs/%s" target="_blank">%s</a>', $path, $text );
 	}
-
 }


### PR DESCRIPTION
No functionality changes!

Corrected whitespace with:

```bash
phpcbf ./lib/admin --standard=WordPress
```

Then manually reordered methods to match display order and a handful of empty lines added/removed. 