### PR TITLE
Deprecating admin_enqueue functions

### DIFF
--- a/lib/WP_Auth0_Configure_JWTAUTH.php
+++ b/lib/WP_Auth0_Configure_JWTAUTH.php
@@ -31,16 +31,12 @@ class WP_Auth0_Configure_JWTAUTH {
 		<?php
 	}
 
-	// TODO: Deprecate
+	/**
+	 * @deprecated 3.6.0 - Not needed, handled in WP_Auth0_Admin::admin_enqueue()
+	 */
 	public function admin_enqueue() {
-		if ( ! isset( $_REQUEST['page'] ) || 'wpa0-jwt-auth' !== $_REQUEST['page'] ) {
-			return;
-		}
-		wp_enqueue_media();
-		wp_enqueue_style( 'wpa0_bootstrap', WPA0_PLUGIN_URL . 'assets/bootstrap/css/bootstrap.min.css' );
-		wp_enqueue_script( 'wpa0_bootstrap', WPA0_PLUGIN_URL . 'assets/bootstrap/js/bootstrap.min.js' );
-		wp_enqueue_style( 'wpa0_admin_initial_settup', WPA0_PLUGIN_URL . 'assets/css/initial-setup.css' );
-		wp_enqueue_style( 'media' );
+		// phpcs:ignore
+		trigger_error( sprintf( __( 'Method %s is deprecated.', 'wp-auth0' ), __METHOD__ ), E_USER_DEPRECATED );
 	}
 
 	public function render_settings_page() {

--- a/lib/WP_Auth0_ErrorLog.php
+++ b/lib/WP_Auth0_ErrorLog.php
@@ -1,22 +1,20 @@
 <?php
 class WP_Auth0_ErrorLog {
 
-	// TODO: Deprecate
+	/**
+	 * @deprecated 3.6.0 - Not needed, handled in WP_Auth0_Admin::admin_enqueue()
+	 */
 	public function init() {
-		add_action( 'admin_enqueue_scripts', array( $this, 'admin_enqueue' ) );
+		// phpcs:ignore
+		trigger_error( sprintf( __( 'Method %s is deprecated.', 'wp-auth0' ), __METHOD__ ), E_USER_DEPRECATED );
 	}
 
-	// TODO: Deprecate
+	/**
+	 * @deprecated 3.6.0 - Not needed, handled in WP_Auth0_Admin::admin_enqueue()
+	 */
 	public function admin_enqueue() {
-		if ( ! isset( $_REQUEST['page'] ) || 'wpa0-errors' !== $_REQUEST['page'] ) {
-			return;
-		}
-
-		wp_enqueue_media();
-		wp_enqueue_style( 'wpa0_bootstrap', WPA0_PLUGIN_URL . 'assets/bootstrap/css/bootstrap.min.css' );
-		wp_enqueue_script( 'wpa0_bootstrap', WPA0_PLUGIN_URL . 'assets/bootstrap/js/bootstrap.min.js' );
-		wp_enqueue_style( 'wpa0_admin_initial_settup', WPA0_PLUGIN_URL . 'assets/css/initial-setup.css' );
-		wp_enqueue_style( 'media' );
+		// phpcs:ignore
+		trigger_error( sprintf( __( 'Method %s is deprecated.', 'wp-auth0' ), __METHOD__ ), E_USER_DEPRECATED );
 	}
 
 	public function render_settings_page() {

--- a/lib/WP_Auth0_Export_Users.php
+++ b/lib/WP_Auth0_Export_Users.php
@@ -14,16 +14,12 @@ class WP_Auth0_Export_Users {
 		add_action( 'admin_action_wpauth0_export_users', array( $this, 'a0_export_users' ) );
 	}
 
-	// TODO: Deprecate
+	/**
+	 * @deprecated 3.6.0 - Not needed, handled in WP_Auth0_Admin::admin_enqueue()
+	 */
 	public function admin_enqueue() {
-		if ( ! isset( $_REQUEST['page'] ) || 'wpa0-users-export' !== $_REQUEST['page'] ) {
-			return;
-		}
-		wp_enqueue_media();
-		wp_enqueue_style( 'wpa0_bootstrap', WPA0_PLUGIN_URL . 'assets/bootstrap/css/bootstrap.min.css' );
-		wp_enqueue_script( 'wpa0_bootstrap', WPA0_PLUGIN_URL . 'assets/bootstrap/js/bootstrap.min.js' );
-		wp_enqueue_style( 'wpa0_admin_initial_settup', WPA0_PLUGIN_URL . 'assets/css/initial-setup.css' );
-		wp_enqueue_style( 'media' );
+		// phpcs:ignore
+		trigger_error( sprintf( __( 'Method %s is deprecated.', 'wp-auth0' ), __METHOD__ ), E_USER_DEPRECATED );
 	}
 
 	public function a0_add_users_export() {

--- a/lib/initial-setup/WP_Auth0_InitialSetup.php
+++ b/lib/initial-setup/WP_Auth0_InitialSetup.php
@@ -59,23 +59,12 @@ class WP_Auth0_InitialSetup {
 
 	}
 
-	// TODO: Deprecate
+	/**
+	 * @deprecated 3.6.0 - Not needed, handled in WP_Auth0_Admin::admin_enqueue()
+	 */
 	public function admin_enqueue() {
-		if ( ! isset( $_REQUEST['page'] ) || 'wpa0-setup' !== $_REQUEST['page'] ) {
-			return;
-		}
-
-		wp_enqueue_media();
-		wp_enqueue_style( 'wpa0_bootstrap', WPA0_PLUGIN_URL . 'assets/bootstrap/css/bootstrap.min.css' );
-		wp_enqueue_script( 'wpa0_bootstrap', WPA0_PLUGIN_URL . 'assets/bootstrap/js/bootstrap.min.js' );
-		wp_enqueue_style( 'wpa0_admin_initial_settup', WPA0_PLUGIN_URL . 'assets/css/initial-setup.css' );
-
-		if ( isset( $_REQUEST['signup'] ) ) {
-			$cdn_url = $this->a0_options->get( 'cdn_url' );
-			wp_enqueue_script( 'wpa0_lock', $cdn_url, 'jquery' );
-		}
-
-		wp_enqueue_style( 'media' );
+		// phpcs:ignore
+		trigger_error( sprintf( __( 'Method %s is deprecated.', 'wp-auth0' ), __METHOD__ ), E_USER_DEPRECATED );
 	}
 
 	// TODO: Deprecate


### PR DESCRIPTION
- WP_Auth0_InitialSetup::admin_enqueue()
- WP_Auth0_Configure_JWTAUTH::admin_enqueue()
- WP_Auth0_ErrorLog::init()
- WP_Auth0_ErrorLog::admin_enqueue()
- WP_Auth0_Export_Users::admin_enqueue()