### PR TITLE
Only show email verification resend for DB connections

### DIFF
--- a/lib/WP_Auth0_Email_Verification.php
+++ b/lib/WP_Auth0_Email_Verification.php
@@ -20,30 +20,36 @@ class WP_Auth0_Email_Verification {
 	 * @param object $userinfo
 	 */
 	public static function render_die( $userinfo ) {
+		$user_id = isset( $userinfo->user_id ) ? $userinfo->user_id : $userinfo->sub;
 
-		$html = sprintf(
-			'<p>%s<br><a id="js-a0-resend-verification" href="#">%s</a></p>
+		$html = sprintf( '<p>%s</p>', __( 'This site requires a verified email address. ', 'wp-auth0' ) );
+
+		// Only provide resend verification link for DB connection users
+		if ( 0 === strpos( $user_id, 'auth0|' ) ) {
+			$html .= sprintf(
+				'<p><a id="js-a0-resend-verification" href="#">%s</a></p>
 			<p><a href="%s?%d">%s</a></p>
 			<script>var WPAuth0EmailVerification={ajaxUrl:"%s",sub:"%s",nonce:"%s",e_msg:"%s",s_msg:"%s"}</script>
 			<script src="%s"></script>
 			<script src="%s"></script>',
-
-			__( 'Please verify your email and log in again.', 'wp-auth0' ),
-			__( 'Resend verification email.', 'wp-auth0' ),
-			wp_login_url(),
-			time(),
-			__( '← Login', 'wp-auth0' ),
-			esc_url( admin_url( 'admin-ajax.php' ) ),
-			esc_js( isset( $userinfo->user_id ) ? $userinfo->user_id : $userinfo->sub ),
-			esc_js( wp_create_nonce( self::RESEND_NONCE_ACTION ) ),
-			esc_js( __( 'Something went wrong; please login and try again.', 'wp-auth0' ) ),
-			esc_js( __( 'Email successfully re-sent to ' . $userinfo->email . '!', 'wp-auth0' ) ),
-			'//code.jquery.com/jquery-1.12.4.js',
-			WPA0_PLUGIN_URL . 'assets/js/die-with-verify-email.js?ver=' . WPA0_VERSION
-		);
+				__( 'Resend verification email.', 'wp-auth0' ),
+				wp_login_url(),
+				time(),
+				__( '← Login', 'wp-auth0' ),
+				esc_url( admin_url( 'admin-ajax.php' ) ),
+				esc_js( $user_id ),
+				esc_js( wp_create_nonce( self::RESEND_NONCE_ACTION ) ),
+				esc_js( __( 'Something went wrong; please login and try again.', 'wp-auth0' ) ),
+				esc_js( sprintf(
+					__( 'Email successfully re-sent to %s!', 'wp-auth0' ),
+					$userinfo->email
+				) ),
+				'//code.jquery.com/jquery-1.12.4.js',
+				WPA0_PLUGIN_URL . 'assets/js/die-with-verify-email.js?ver=' . WPA0_VERSION
+			);
+		}
 
 		$html = apply_filters( 'auth0_verify_email_page', $html, $userinfo, '' );
-
 		wp_die( $html );
 	}
 
@@ -52,18 +58,11 @@ class WP_Auth0_Email_Verification {
 	 * Triggered in $this->render_die
 	 */
 	public static function ajax_resend_email() {
-
 		check_ajax_referer( self::RESEND_NONCE_ACTION, 'nonce' );
-
-		if ( empty( $_POST['sub'] ) ) {
-			die();
+		if ( ! empty( $_POST['sub'] ) ) {
+			echo WP_Auth0_Api_Client::resend_verification_email( sanitize_text_field( $_POST['sub'] ) ) ? 'success' : 'fail';
 		}
-
-		echo WP_Auth0_Api_Client::resend_verification_email(
-			sanitize_text_field( $_POST['sub'] )
-		) ? 'success' : 'fail';
-
-		die();
+		exit;
 	}
 }
 


### PR DESCRIPTION
Looks for `auth0` strategy on the user ID and only shows the "Resend verification email" link if there. 

Fixes #345