### PR TITLE
Fix logout process

### DIFF
--- a/lib/WP_Auth0_LoginManager.php
+++ b/lib/WP_Auth0_LoginManager.php
@@ -409,11 +409,13 @@ class WP_Auth0_LoginManager {
 					}
 				}
 
-				wp_update_user( array(
-					'ID'          => $user->data->ID,
-					'user_email'  => $userinfo->email,
-					'description' => $description,
-				) );
+				wp_update_user(
+					array(
+						'ID'          => $user->data->ID,
+						'user_email'  => $userinfo->email,
+						'description' => $description,
+					)
+				);
 			}
 
 			$this->users_repo->update_auth0_object( $user->data->ID, $userinfo );
@@ -498,8 +500,8 @@ class WP_Auth0_LoginManager {
 	 * @link https://codex.wordpress.org/Plugin_API/Action_Reference/wp_logout
 	 */
 	public function logout() {
-		$is_sso = (bool) $this->a0_options->get( 'sso' );
-		$is_slo = (bool) $this->a0_options->get( 'singlelogout' );
+		$is_sso        = (bool) $this->a0_options->get( 'sso' );
+		$is_slo        = (bool) $this->a0_options->get( 'singlelogout' );
 		$is_auto_login = (bool) $this->a0_options->get( 'auto_login' );
 
 		// Redirected here after checkSession in the footer (templates/auth0-singlelogout-handler.php).
@@ -516,18 +518,18 @@ class WP_Auth0_LoginManager {
 		// If SSO is in use, redirect to Auth0 to logout there as well.
 		if ( $is_sso ) {
 			$telemetry_headers = WP_Auth0_Api_Client::get_info_headers();
-			$redirect_url = sprintf(
+			$redirect_url      = sprintf(
 				'https://%s/v2/logout?returnTo=%s&client_id=%s&auth0Client=%s',
 				$this->a0_options->get( 'domain' ),
 				rawurlencode( home_url() ),
 				$this->a0_options->get( 'client_id' ),
-				$telemetry_headers[ 'Auth0-Client' ]
+				$telemetry_headers['Auth0-Client']
 			);
 			wp_redirect( $redirect_url );
 			exit;
 		}
 
-		// If auto-login is in use, cannot redirect back to login page
+		// If auto-login is in use, cannot redirect back to login page.
 		if ( $is_auto_login ) {
 			wp_redirect( home_url() );
 			exit;
@@ -550,7 +552,7 @@ class WP_Auth0_LoginManager {
 
 		// No need to checkSession if already logged in.
 		// URL parameter `no_sso` is set to skip checkSession.
-		if ( is_user_logged_in() || ! empty( $_GET[ 'no_sso' ] ) || ! $this->a0_options->get( 'sso' ) ) {
+		if ( is_user_logged_in() || ! empty( $_GET['no_sso'] ) || ! $this->a0_options->get( 'sso' ) ) {
 			return $previous_html;
 		}
 

--- a/lib/WP_Auth0_LoginManager.php
+++ b/lib/WP_Auth0_LoginManager.php
@@ -551,8 +551,8 @@ class WP_Auth0_LoginManager {
 	public function auth0_sso_footer( $previous_html ) {
 
 		// No need to checkSession if already logged in.
-		// URL parameter `no_sso` is set to skip checkSession.
-		if ( is_user_logged_in() || ! empty( $_GET['no_sso'] ) || ! $this->a0_options->get( 'sso' ) ) {
+		// URL parameter `skip_sso` is set to skip checkSession.
+		if ( is_user_logged_in() || isset( $_GET['skip_sso'] ) || ! $this->a0_options->get( 'sso' ) ) {
 			return $previous_html;
 		}
 
@@ -725,7 +725,7 @@ class WP_Auth0_LoginManager {
 					: __( 'Please see the site administrator', 'wp-auth0' ),
 				__( 'error code', 'wp-auth0' ),
 				$code ? sanitize_text_field( $code ) : __( 'unknown', 'wp-auth0' ),
-				$login_link ? add_query_arg( 'no_sso', 1, wp_login_url() ) : wp_logout_url(),
+				$login_link ? add_query_arg( 'skip_sso', '', wp_login_url() ) : wp_logout_url(),
 				$login_link
 					? __( '← Login', 'wp-auth0' )
 					: __( '← Logout', 'wp-auth0' )

--- a/lib/WP_Auth0_LoginManager.php
+++ b/lib/WP_Auth0_LoginManager.php
@@ -577,6 +577,8 @@ class WP_Auth0_LoginManager {
 
 	/**
 	 * End the PHP session.
+   *
+   * TODO: Deprecate
 	 */
 	public function end_session() {
 		if ( session_id() ) {

--- a/templates/auth0-sso-handler-lock10.php
+++ b/templates/auth0-sso-handler-lock10.php
@@ -1,3 +1,8 @@
+<?php
+$lock_options = new WP_Auth0_Lock10_Options();
+$client_id = $lock_options->get_client_id();
+$domain    = $lock_options->get_domain();
+?>
 <script type="text/javascript">
 document.addEventListener("DOMContentLoaded", function() {
   if (typeof(ignore_sso) !== 'undefined' && ignore_sso) {


### PR DESCRIPTION
- Remove federated logout for SSO (heavy-handed and was causing [issues](https://community.auth0.com/t/linkedin-logout-not-working-in-wordpress/10997/10) with some users) 
- Remove `end_session` method call (we're not setting any sessions so we should not be deleting any either)
- Fix telemetry header issues (fixes #448)
- Fix SLO link empty issue (`get_permalink()` is empty on non-`post` pages)
- Fix improper filter handling in `auth0_sso_footer` (cannot `echo` in filters, must return modified data)
- Add `no_sso` check for SSO footer on wp-login.php to skip SSO processing if there was a login error (can cause redirect loops)
- Minor code quality fixes (calling out internal methods