### PR TITLE
Fix SLO redirect, SLO on when SSO off, SSO setting not pushed to dashboard

### DIFF
--- a/lib/WP_Auth0_Lock10_Options.php
+++ b/lib/WP_Auth0_Lock10_Options.php
@@ -136,11 +136,10 @@ class WP_Auth0_Lock10_Options {
   public function get_sso_options() {
     $options["scope"] = WP_Auth0_LoginManager::get_userinfo_scope( 'sso' );
 
+    $options["responseType"] = 'token id_token';
     if ( $this->get_auth0_implicit_workflow() ) {
-      $options["responseType"] = 'id_token';
       $options["redirectUri"] = $this->get_implicit_callback_url();
     } else {
-      $options["responseType"] = 'code';
       $options["redirectUri"] = $this->get_code_callback_url();
     }
 

--- a/templates/auth0-singlelogout-handler.php
+++ b/templates/auth0-singlelogout-handler.php
@@ -3,6 +3,11 @@ $current_user = get_currentauth0user();
 if ( empty( $current_user->auth0_obj ) ) {
   return;
 }
+
+$logout_url = wp_logout_url();
+$logout_url = html_entity_decode( $logout_url );
+$logout_url = add_query_arg( 'redirect_to', get_permalink(), $logout_url );
+$logout_url = add_query_arg( 'SLO', 1, $logout_url );
 ?>
 <script id="auth0" src="<?php echo esc_url( $this->a0_options->get('auth0js-cdn') ) ?>"></script>
 <script type="text/javascript">
@@ -18,9 +23,10 @@ if ( empty( $current_user->auth0_obj ) ) {
       domain:'<?php echo sanitize_text_field( $this->a0_options->get( 'domain' ) ); ?>'
     });
 
-    webAuth.checkSession( { 'responseType' : 'token', 'redirectUri' : window.location.href }, function ( err ) {
-            if ( err && err.error ==='login_required' ) {
-                window.location = '<?php echo esc_url( wp_logout_url( get_permalink() ) . '&SLO=1' ); ?>';
+    var sloOptions = { 'responseType' : 'token id_token', 'redirectUri' : '<?php echo home_url() ?>' };
+    webAuth.checkSession( sloOptions, function ( err ) {
+            if ( err && err.error && 'login_required' === err.error ) {
+                window.location = '<?php echo $logout_url ?>';
             }
         }
     );

--- a/templates/auth0-sso-handler-lock10.php
+++ b/templates/auth0-sso-handler-lock10.php
@@ -18,17 +18,12 @@ document.addEventListener("DOMContentLoaded", function() {
   });
 
   var options = <?php echo json_encode( $lock_options->get_sso_options() ); ?>;
-  options.responseType = 'token id_token';
-  webAuth.checkSession(options
-  , function (err, authResult) {
+  webAuth.checkSession(options, function (err, authResult) {
       if (typeof(authResult) === 'undefined') {
         return;
       }
 
-      if (typeof(authResult.code) !== 'undefined') {
-        window.location = '<?php echo WP_Auth0_Options::Instance()->get_wp_auth0_url(); ?>&code='
-            + authResult.code + '&state=' + authResult.state;
-      } else if (typeof(authResult.idToken) !== 'undefined') {
+      if (authResult.idToken) {
         jQuery(document).ready(function($){
           var $form=$(document.createElement('form')).css({display:'none'}).attr("method","POST").attr("action","<?php
             echo add_query_arg( 'auth0', 'implicit', site_url( 'index.php' ) ); ?>");


### PR DESCRIPTION
The SLO functionality (loads a `checkSession` call on front-end pages if the user is logged in) was using an incorrect `redirectUri` value and also redirected to a malformed logout link (prompted the user to logout instead of doing it automatically). Also:

- Hide and turn off SLO if SSO is not on (fixes #336)
- Removed unnecessary `code` check in SSO `checkSession` call
- More clear `responseType` handling
- Use client credential grant to update Application instead of likely-expired app token