### PR TITLE
Fix install and DB update errors

### DIFF
--- a/lib/WP_Auth0_DBManager.php
+++ b/lib/WP_Auth0_DBManager.php
@@ -43,7 +43,6 @@ class WP_Auth0_DBManager {
 		$client_secret = $options->get( 'client_secret' );
 		$domain = $options->get( 'domain' );
 		$sso = $options->get( 'sso' );
-
 		$cdn_url = $options->get( 'cdn_url' );
 
 		if ( $this->current_db_version <= 7 ) {
@@ -69,17 +68,6 @@ class WP_Auth0_DBManager {
 		}
 
 		if ( $this->current_db_version < 10 ) {
-
-			if ($options->get('use_lock_10') === null) {
-
-				if ( strpos( $cdn_url, '10.' ) === false ) {
-					$options->set('use_lock_10', false);
-				} else {
-					$options->set('use_lock_10', true);
-				}
-
-			}
-
 			$dict = $options->get('dict');
 
 			if (!empty($dict))
@@ -94,16 +82,6 @@ class WP_Auth0_DBManager {
 					$options->set('language_dictionary', $dict);
 				}
 
-			}
-
-		}
-
-		if ( $this->current_db_version < 12 ) {
-
-			if ( strpos( $cdn_url, '10.' ) === false ) {
-				$options->set('use_lock_10', false);
-			} else {
-				$options->set('use_lock_10', true);
 			}
 
 		}
@@ -130,8 +108,6 @@ class WP_Auth0_DBManager {
 		// 3.4.0
 
 		if ( $this->current_db_version < 15 || 15 === $version_to_install  ) {
-
-			$options->set('use_lock_10', true);
 			$options->set('cdn_url', '//cdn.auth0.com/js/lock/11.1/lock.min.js');
 			$options->set('auth0js-cdn', '//cdn.auth0.com/js/auth0/9.1/auth0.min.js');
 			$options->set('cache_expiration', 1440);

--- a/lib/WP_Auth0_DBManager.php
+++ b/lib/WP_Auth0_DBManager.php
@@ -22,7 +22,7 @@ class WP_Auth0_DBManager {
 	}
 
 	public function check_update() {
-		if ( $this->current_db_version !== AUTH0_DB_VERSION ) {
+		if ( $this->current_db_version && $this->current_db_version !== AUTH0_DB_VERSION ) {
 			$this->install_db();
 		}
 	}
@@ -43,12 +43,6 @@ class WP_Auth0_DBManager {
 		$client_secret = $options->get( 'client_secret' );
 		$domain = $options->get( 'domain' );
 		$sso = $options->get( 'sso' );
-
-		if ($this->current_db_version === 0) {
-			$options->set('auth0_table', false);
-		} elseif($options->get('auth0_table') === null) {
-			$options->set('auth0_table', true);
-		}
 
 		$cdn_url = $options->get( 'cdn_url' );
 
@@ -218,13 +212,12 @@ class WP_Auth0_DBManager {
 				delete_option( 'wp_auth0_client_grant_failed' );
 				update_option( 'wp_auth0_client_grant_success', 1 );
 
-				if ( 409 !== $client_grant_created[ 'statusCode' ] ) {
+				if ( 409 !== $client_grant_created->statusCode ) {
 					WP_Auth0_ErrorManager::insert_auth0_error(
 						__METHOD__,
 						'Client Grant has been successfully created!'
 					);
 				}
-
 			} else {
 				WP_Auth0_ErrorManager::insert_auth0_error( __METHOD__, sprintf(
 					__( 'Unable to automatically create Client Grant. Please go to your Auth0 Dashboard '

--- a/lib/WP_Auth0_DBManager.php
+++ b/lib/WP_Auth0_DBManager.php
@@ -108,8 +108,8 @@ class WP_Auth0_DBManager {
 		// 3.4.0
 
 		if ( $this->current_db_version < 15 || 15 === $version_to_install  ) {
-			$options->set('cdn_url', '//cdn.auth0.com/js/lock/11.1/lock.min.js');
-			$options->set('auth0js-cdn', '//cdn.auth0.com/js/auth0/9.1/auth0.min.js');
+			$options->set('cdn_url', WPA0_LOCK_CDN_URL);
+			$options->set('auth0js-cdn', WPA0_AUTH0_JS_CDN_URL);
 			$options->set('cache_expiration', 1440);
 
 			// Update Client
@@ -150,11 +150,11 @@ class WP_Auth0_DBManager {
 			// Update Lock and Auth versions
 
 			if ( '//cdn.auth0.com/js/lock/11.0.0/lock.min.js' === $options->get( 'cdn_url' ) ) {
-				$options->set( 'cdn_url', '//cdn.auth0.com/js/lock/11.1/lock.min.js' );
+				$options->set( 'cdn_url', WPA0_LOCK_CDN_URL );
 			}
 
 			if ( '//cdn.auth0.com/js/auth0/9.0.0/auth0.min.js' === $options->get( 'auth0js-cdn' ) ) {
-				$options->set( 'auth0js-cdn', '//cdn.auth0.com/js/auth0/9.1/auth0.min.js' );
+				$options->set( 'auth0js-cdn', WPA0_AUTH0_JS_CDN_URL );
 			}
 
 			// Update app type and client grant

--- a/lib/WP_Auth0_Options.php
+++ b/lib/WP_Auth0_Options.php
@@ -166,7 +166,6 @@ class WP_Auth0_Options extends WP_Auth0_Options_Generic {
 			'version' => 1,
 			'last_step' => 1,
 			'migration_token_id' => null,
-			'use_lock_10' => true,
 			'jwt_auth_integration' => false,
 			'amplificator_title' => '',
 			'amplificator_subtitle' => '',

--- a/lib/WP_Auth0_Options.php
+++ b/lib/WP_Auth0_Options.php
@@ -171,7 +171,6 @@ class WP_Auth0_Options extends WP_Auth0_Options_Generic {
 			'amplificator_subtitle' => '',
 			'connections' => array(),
 			'auth0js-cdn' => WPA0_AUTH0_JS_CDN_URL,
-			'auth0_table' => false,
 
 			// Basic
 			'domain' => '',

--- a/lib/WP_Auth0_Options.php
+++ b/lib/WP_Auth0_Options.php
@@ -172,6 +172,7 @@ class WP_Auth0_Options extends WP_Auth0_Options_Generic {
 			'amplificator_subtitle' => '',
 			'connections' => array(),
 			'auth0js-cdn' => WPA0_AUTH0_JS_CDN_URL,
+			'auth0_table' => false,
 
 			// Basic
 			'domain' => '',


### PR DESCRIPTION
- Fix an error with the returned data type being the wrong error (fixes #464)
- Fix DB update running on new installs
- Fix DB table missing error in install
- Remove references to `use_lock_10` setting in DB update process and defaults
- Change update process to use same Lock version as installation