### PR TITLE
Fix SLO callback URL 

### DIFF
--- a/lib/WP_Auth0_LoginManager.php
+++ b/lib/WP_Auth0_LoginManager.php
@@ -80,6 +80,7 @@ class WP_Auth0_LoginManager {
 		add_filter( 'login_message', array( $this, 'auth0_sso_footer' ) );
 		add_action( 'wp_footer', array( $this, 'auth0_singlelogout_footer' ) );
 		add_action( 'admin_footer', array( $this, 'auth0_singlelogout_footer' ) );
+		add_action( 'login_footer', array( $this, 'auth0_singlelogout_footer' ) );
 		add_action( 'wp_login', array( $this, 'end_session' ) );
 	}
 

--- a/lib/WP_Auth0_LoginManager.php
+++ b/lib/WP_Auth0_LoginManager.php
@@ -79,6 +79,7 @@ class WP_Auth0_LoginManager {
 		add_action( 'wp_logout', array( $this, 'logout' ) );
 		add_filter( 'login_message', array( $this, 'auth0_sso_footer' ) );
 		add_action( 'wp_footer', array( $this, 'auth0_singlelogout_footer' ) );
+		add_action( 'admin_footer', array( $this, 'auth0_singlelogout_footer' ) );
 		add_action( 'wp_login', array( $this, 'end_session' ) );
 	}
 

--- a/templates/auth0-singlelogout-handler.php
+++ b/templates/auth0-singlelogout-handler.php
@@ -23,7 +23,10 @@ $logout_url = add_query_arg( 'SLO', 1, $logout_url );
       domain:'<?php echo sanitize_text_field( $this->a0_options->get( 'domain' ) ); ?>'
     });
 
-    var sloOptions = { 'responseType' : 'token id_token', 'redirectUri' : '<?php echo home_url() ?>' };
+    var sloOptions = {
+        'responseType' : 'token id_token',
+        'redirectUri' : '<?php echo $this->a0_options->get_wp_auth0_url( null ) ?>'
+    };
     webAuth.checkSession( sloOptions, function ( err ) {
             if ( err && err.error && 'login_required' === err.error ) {
                 window.location = '<?php echo $logout_url ?>';

--- a/templates/auth0-singlelogout-handler.php
+++ b/templates/auth0-singlelogout-handler.php
@@ -6,7 +6,7 @@ if ( empty( $current_user->auth0_obj ) ) {
 
 $logout_url = wp_logout_url();
 $logout_url = html_entity_decode( $logout_url );
-$logout_url = add_query_arg( 'redirect_to', get_permalink(), $logout_url );
+$logout_url = add_query_arg( 'redirect_to', ( get_the_ID() ? get_permalink() : wp_login_url() ), $logout_url );
 $logout_url = add_query_arg( 'SLO', 1, $logout_url );
 ?>
 <script id="auth0" src="<?php echo esc_url( $this->a0_options->get('auth0js-cdn') ) ?>"></script>


### PR DESCRIPTION
Reported here - https://wordpress.org/support/topic/sso-logout-issues/

SLO is using `home_url()`, which some sites don't have in the "Allowed Callback URLs" field for the Application. Changed to the main Auth0 callback URL which is always there. Callback is not used as a redirect so does not need to change for Implicit, just needs to be valid. 

Also adds SLO check to the admin + login pages and changes the redirect URL used after logout to point to an external page if there is one or the wp-login.php page. 