### PR TITLE
Remove signup disabling

### DIFF
--- a/WP_Auth0.php
+++ b/WP_Auth0.php
@@ -124,8 +124,6 @@ class WP_Auth0 {
 		$edit_profile = new WP_Auth0_EditProfile( $this->db_manager, $users_repo, $this->a0_options );
 		$edit_profile->init();
 
-		$this->check_signup_status();
-
 		WP_Auth0_Email_Verification::init();
 	}
 
@@ -143,6 +141,8 @@ class WP_Auth0 {
 	}
 
 	/**
+	 * TODO: Deprecate, no longer used
+	 *
 	 * Checks it it should update the database connection no enable or disable signups and create or delete
 	 * the rule that will disable social signups.
 	 */

--- a/lib/WP_Auth0_Api_Operations.php
+++ b/lib/WP_Auth0_Api_Operations.php
@@ -7,6 +7,9 @@ class WP_Auth0_Api_Operations {
 		$this->a0_options = $a0_options;
 	}
 
+	/**
+	 * TODO: Deprecate, no longer used
+	 */
 	public function disable_signup_wordpress_connection( $app_token, $disable_signup ) {
 		$domain    = $this->a0_options->get( 'domain' );
 		$client_id = $this->a0_options->get( 'client_id' );

--- a/lib/WP_Auth0_RulesLib.php
+++ b/lib/WP_Auth0_RulesLib.php
@@ -2,6 +2,9 @@
 
 class WP_Auth0_RulesLib {
 
+	/**
+	 * TODO: Deprecate, no longer used
+	 */
 	public static $disable_social_signup = array(
 
 		'name'   => 'Disable-Social-Signup-Do-Not-Rename',


### PR DESCRIPTION
The WordPress plugin is both disabling signups on the Connection (via API) and social signups (via Rules) based on the WordPress registration setting. This is not good for anyone with multiple Applications using the same connections. Need to remove this functionality and deprecate the functions involved.

- Remove `$this->check_signup_status();` call on initialize
- TODOs for deprecation