### PR TITLE
Add custom domain support with tests; add compat test to Circle CI

### DIFF
--- a/WP_Auth0.php
+++ b/WP_Auth0.php
@@ -149,18 +149,8 @@ class WP_Auth0 {
 	 * @return string
 	 */
 	public static function get_tenant_region( $domain ) {
-
-		if ( empty( $domain ) ) {
-			$options = WP_Auth0_Options::Instance();
-			$domain  = $options->get( 'domain' );
-		}
-
-		if ( false !== strpos( $domain, 'au.auth0.com' ) ) {
-			return 'au';
-		} elseif ( false !== strpos( $domain, 'eu.auth0.com' ) ) {
-			return 'eu';
-		}
-		return 'us';
+		preg_match( '/^[\w\d\-_0-9]+\.([\w\d\-_0-9]*)[\.]*auth0\.com$/', $domain, $matches );
+		return !empty($matches[1]) ? $matches[1] : 'us';
 	}
 
 	/**

--- a/WP_Auth0.php
+++ b/WP_Auth0.php
@@ -142,6 +142,46 @@ class WP_Auth0 {
 	}
 
 	/**
+	 * Get the tenant region based on a domain.
+	 *
+	 * @param string $domain Tenant domain.
+	 *
+	 * @return string
+	 */
+	public static function get_tenant_region( $domain ) {
+
+		if ( empty( $domain ) ) {
+			$options = WP_Auth0_Options::Instance();
+			$domain  = $options->get( 'domain' );
+		}
+
+		if ( false !== strpos( $domain, 'au.auth0.com' ) ) {
+			return 'au';
+		} elseif ( false !== strpos( $domain, 'eu.auth0.com' ) ) {
+			return 'eu';
+		}
+		return 'us';
+	}
+
+	/**
+	 * Get the full tenant name with region.
+	 *
+	 * @param null|string $domain Tenant domain.
+	 *
+	 * @return string
+	 */
+	public static function get_tenant( $domain = null ) {
+
+		if ( empty( $domain ) ) {
+			$options = WP_Auth0_Options::Instance();
+			$domain  = $options->get( 'domain' );
+		}
+
+		$parts = explode( '.', $domain );
+		return $parts[0] . '@' . self::get_tenant_region( $domain );
+	}
+
+	/**
 	 * TODO: Deprecate, no longer used
 	 *
 	 * Checks it it should update the database connection no enable or disable signups and create or delete

--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -39,7 +39,7 @@ jQuery(document).ready(function($) {
     });
 
     // Show/hide field for specific switches
-    $('[data-expand!=""]').each( function() {
+    $('[data-expand][data-expand!=""]').each( function() {
         var $thisSwitch = $( this );
         var $showFieldRow = $( '#' + $thisSwitch.attr( 'data-expand' ).trim() ).closest( 'tr' );
 

--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -41,7 +41,7 @@ jQuery(document).ready(function($) {
     // Show/hide field for specific switches
     $('[data-expand!=""]').each( function() {
         var $thisSwitch = $( this );
-        var $showFieldRow = $( '#' + $thisSwitch.attr( 'data-expand' ) ).closest( 'tr' );
+        var $showFieldRow = $( '#' + $thisSwitch.attr( 'data-expand' ).trim() ).closest( 'tr' );
 
         if ( $showFieldRow.length ) {
             if ( ! $thisSwitch.prop( 'checked' ) ) {
@@ -94,7 +94,7 @@ jQuery(document).ready(function($) {
     // Set the tab showing on the form and persist the tab
     $( '.js-a0-settings-tabs' ).click( function () {
         window.location.hash = '';
-        var tabHref = $( this ).attr( 'aria-controls' );
+        var tabHref = $( this ).attr( 'aria-controls' ).trim();
         $settingsForm.attr( 'data-tab-showing', tabHref );
         if ( localStorageAvailable() ) {
             window.localStorage.setItem( 'Auth0WPSettingsTab', tabHref );

--- a/assets/js/lock-init.js
+++ b/assets/js/lock-init.js
@@ -31,9 +31,9 @@ jQuery(document).ready(function ($) {
     }
 
     // Set Lock to standard or Passwordless
-    var Lock = opts.usePasswordless
-        ? new Auth0LockPasswordless( opts.clientId, opts.domain, opts.settings )
-        : new Auth0Lock( opts.clientId, opts.domain, opts.settings );
+    var Lock = opts.usePasswordless ?
+        new Auth0LockPasswordless( opts.clientId, opts.domain, opts.settings ) :
+        new Auth0Lock( opts.clientId, opts.domain, opts.settings );
 
     // Check if we're showing as a modal, can be used in shortcodes and widgets
     if ( opts.showAsModal ) {

--- a/circle.yml
+++ b/circle.yml
@@ -19,6 +19,7 @@ test:
       phpcs --config-set installed_paths $HOME/.composer/vendor/wp-coding-standards/wpcs,$HOME/.composer/vendor/wimg/php-compatibility
   override:
     - phpcs --standard=$HOME/wp-auth0/phpcs-compat-ruleset.xml $HOME/wp-auth0 -pn -d memory_limit=-1
+    - phpcs --standard=$HOME/wp-auth0/phpcs-test-ruleset.xml $HOME/wp-auth0/tests -pn -d memory_limit=-1
     - phpcbf --standard=$HOME/wp-auth0/phpcs-compat-ruleset.xml $HOME/wp-auth0 -p -d memory_limit=-1
     - |
       rm -rf $WP_TESTS_DIR $WP_CORE_DIR

--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
         "phpcbf": "./vendor/bin/phpcbf --standard=phpcs-ruleset.xml .",
         "phpcbf-path": "SHELL_INTERACTIVE=1 ./vendor/bin/phpcbf --standard=phpcs-ruleset.xml",
         "sniffs": "./vendor/bin/phpcs --standard=phpcs-ruleset.xml -e",
-        "test": "./vendor/bin/phpunit --coverage-text --colors",
-        "test-path": "SHELL_INTERACTIVE=1 ./vendor/bin/phpunit --coverage-text --colors"
+        "test": "./vendor/bin/phpunit --coverage-text",
+        "test-path": "SHELL_INTERACTIVE=1 ./vendor/bin/phpunit"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -32,10 +32,12 @@
     "scripts": {
         "compat": "./vendor/bin/phpcs --standard=phpcs-compat-ruleset.xml .",
         "phpcs": "./vendor/bin/phpcs --standard=phpcs-ruleset.xml -s .",
+        "phpcs-tests": "./vendor/bin/phpcs --standard=phpcs-test-ruleset.xml -s ./tests/",
         "phpcs-path": "SHELL_INTERACTIVE=1 ./vendor/bin/phpcs --standard=phpcs-ruleset.xml -s",
         "phpcbf": "./vendor/bin/phpcbf --standard=phpcs-ruleset.xml .",
         "phpcbf-path": "SHELL_INTERACTIVE=1 ./vendor/bin/phpcbf --standard=phpcs-ruleset.xml",
         "sniffs": "./vendor/bin/phpcs --standard=phpcs-ruleset.xml -e",
-        "test": "./vendor/bin/phpunit --coverage-text"
+        "test": "./vendor/bin/phpunit --coverage-text --colors",
+        "test-path": "SHELL_INTERACTIVE=1 ./vendor/bin/phpunit --coverage-text --colors"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,21 +4,1232 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "c1c47e19078997dc6b95c058c6ceab66",
+    "content-hash": "84d90d2591e228b28d00357d97bb87cd",
     "packages": [],
     "packages-dev": [
         {
-            "name": "squizlabs/php_codesniffer",
-            "version": "3.2.3",
+            "name": "doctrine/instantiator",
+            "version": "1.0.5",
             "source": {
                 "type": "git",
-                "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "4842476c434e375f9d3182ff7b89059583aa8b27"
+                "url": "https://github.com/doctrine/instantiator.git",
+                "reference": "8e884e78f9f0eb1329e445619e04456e64d8051d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/4842476c434e375f9d3182ff7b89059583aa8b27",
-                "reference": "4842476c434e375f9d3182ff7b89059583aa8b27",
+                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/8e884e78f9f0eb1329e445619e04456e64d8051d",
+                "reference": "8e884e78f9f0eb1329e445619e04456e64d8051d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3,<8.0-DEV"
+            },
+            "require-dev": {
+                "athletic/athletic": "~0.1.8",
+                "ext-pdo": "*",
+                "ext-phar": "*",
+                "phpunit/phpunit": "~4.0",
+                "squizlabs/php_codesniffer": "~2.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Instantiator\\": "src/Doctrine/Instantiator/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Marco Pivetta",
+                    "email": "ocramius@gmail.com",
+                    "homepage": "http://ocramius.github.com/"
+                }
+            ],
+            "description": "A small, lightweight utility to instantiate objects in PHP without invoking their constructors",
+            "homepage": "https://github.com/doctrine/instantiator",
+            "keywords": [
+                "constructor",
+                "instantiate"
+            ],
+            "time": "2015-06-14T21:17:01+00:00"
+        },
+        {
+            "name": "myclabs/deep-copy",
+            "version": "1.7.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/myclabs/DeepCopy.git",
+                "reference": "3b8a3a99ba1f6a3952ac2747d989303cbd6b7a3e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/3b8a3a99ba1f6a3952ac2747d989303cbd6b7a3e",
+                "reference": "3b8a3a99ba1f6a3952ac2747d989303cbd6b7a3e",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.6 || ^7.0"
+            },
+            "require-dev": {
+                "doctrine/collections": "^1.0",
+                "doctrine/common": "^2.6",
+                "phpunit/phpunit": "^4.1"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "DeepCopy\\": "src/DeepCopy/"
+                },
+                "files": [
+                    "src/DeepCopy/deep_copy.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Create deep copies (clones) of your objects",
+            "keywords": [
+                "clone",
+                "copy",
+                "duplicate",
+                "object",
+                "object graph"
+            ],
+            "time": "2017-10-19T19:58:43+00:00"
+        },
+        {
+            "name": "phpdocumentor/reflection-common",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpDocumentor/ReflectionCommon.git",
+                "reference": "21bdeb5f65d7ebf9f43b1b25d404f87deab5bfb6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionCommon/zipball/21bdeb5f65d7ebf9f43b1b25d404f87deab5bfb6",
+                "reference": "21bdeb5f65d7ebf9f43b1b25d404f87deab5bfb6",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.6"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "phpDocumentor\\Reflection\\": [
+                        "src"
+                    ]
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jaap van Otterdijk",
+                    "email": "opensource@ijaap.nl"
+                }
+            ],
+            "description": "Common reflection classes used by phpdocumentor to reflect the code structure",
+            "homepage": "http://www.phpdoc.org",
+            "keywords": [
+                "FQSEN",
+                "phpDocumentor",
+                "phpdoc",
+                "reflection",
+                "static analysis"
+            ],
+            "time": "2017-09-11T18:02:19+00:00"
+        },
+        {
+            "name": "phpdocumentor/reflection-docblock",
+            "version": "3.3.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
+                "reference": "bf329f6c1aadea3299f08ee804682b7c45b326a2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/bf329f6c1aadea3299f08ee804682b7c45b326a2",
+                "reference": "bf329f6c1aadea3299f08ee804682b7c45b326a2",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.6 || ^7.0",
+                "phpdocumentor/reflection-common": "^1.0.0",
+                "phpdocumentor/type-resolver": "^0.4.0",
+                "webmozart/assert": "^1.0"
+            },
+            "require-dev": {
+                "mockery/mockery": "^0.9.4",
+                "phpunit/phpunit": "^4.4"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "phpDocumentor\\Reflection\\": [
+                        "src/"
+                    ]
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Mike van Riel",
+                    "email": "me@mikevanriel.com"
+                }
+            ],
+            "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
+            "time": "2017-11-10T14:09:06+00:00"
+        },
+        {
+            "name": "phpdocumentor/type-resolver",
+            "version": "0.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpDocumentor/TypeResolver.git",
+                "reference": "9c977708995954784726e25d0cd1dddf4e65b0f7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/9c977708995954784726e25d0cd1dddf4e65b0f7",
+                "reference": "9c977708995954784726e25d0cd1dddf4e65b0f7",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.5 || ^7.0",
+                "phpdocumentor/reflection-common": "^1.0"
+            },
+            "require-dev": {
+                "mockery/mockery": "^0.9.4",
+                "phpunit/phpunit": "^5.2||^4.8.24"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "phpDocumentor\\Reflection\\": [
+                        "src/"
+                    ]
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Mike van Riel",
+                    "email": "me@mikevanriel.com"
+                }
+            ],
+            "time": "2017-07-14T14:27:02+00:00"
+        },
+        {
+            "name": "phpspec/prophecy",
+            "version": "1.7.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpspec/prophecy.git",
+                "reference": "33a7e3c4fda54e912ff6338c48823bd5c0f0b712"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/33a7e3c4fda54e912ff6338c48823bd5c0f0b712",
+                "reference": "33a7e3c4fda54e912ff6338c48823bd5c0f0b712",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/instantiator": "^1.0.2",
+                "php": "^5.3|^7.0",
+                "phpdocumentor/reflection-docblock": "^2.0|^3.0.2|^4.0",
+                "sebastian/comparator": "^1.1|^2.0|^3.0",
+                "sebastian/recursion-context": "^1.0|^2.0|^3.0"
+            },
+            "require-dev": {
+                "phpspec/phpspec": "^2.5|^3.2",
+                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.7.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Prophecy\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Konstantin Kudryashov",
+                    "email": "ever.zet@gmail.com",
+                    "homepage": "http://everzet.com"
+                },
+                {
+                    "name": "Marcello Duarte",
+                    "email": "marcello.duarte@gmail.com"
+                }
+            ],
+            "description": "Highly opinionated mocking framework for PHP 5.3+",
+            "homepage": "https://github.com/phpspec/prophecy",
+            "keywords": [
+                "Double",
+                "Dummy",
+                "fake",
+                "mock",
+                "spy",
+                "stub"
+            ],
+            "time": "2018-04-18T13:57:24+00:00"
+        },
+        {
+            "name": "phpunit/php-code-coverage",
+            "version": "4.0.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
+                "reference": "ef7b2f56815df854e66ceaee8ebe9393ae36a40d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/ef7b2f56815df854e66ceaee8ebe9393ae36a40d",
+                "reference": "ef7b2f56815df854e66ceaee8ebe9393ae36a40d",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-xmlwriter": "*",
+                "php": "^5.6 || ^7.0",
+                "phpunit/php-file-iterator": "^1.3",
+                "phpunit/php-text-template": "^1.2",
+                "phpunit/php-token-stream": "^1.4.2 || ^2.0",
+                "sebastian/code-unit-reverse-lookup": "^1.0",
+                "sebastian/environment": "^1.3.2 || ^2.0",
+                "sebastian/version": "^1.0 || ^2.0"
+            },
+            "require-dev": {
+                "ext-xdebug": "^2.1.4",
+                "phpunit/phpunit": "^5.7"
+            },
+            "suggest": {
+                "ext-xdebug": "^2.5.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sb@sebastian-bergmann.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library that provides collection, processing, and rendering functionality for PHP code coverage information.",
+            "homepage": "https://github.com/sebastianbergmann/php-code-coverage",
+            "keywords": [
+                "coverage",
+                "testing",
+                "xunit"
+            ],
+            "time": "2017-04-02T07:44:40+00:00"
+        },
+        {
+            "name": "phpunit/php-file-iterator",
+            "version": "1.4.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
+                "reference": "730b01bc3e867237eaac355e06a36b85dd93a8b4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/730b01bc3e867237eaac355e06a36b85dd93a8b4",
+                "reference": "730b01bc3e867237eaac355e06a36b85dd93a8b4",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.4.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sb@sebastian-bergmann.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "FilterIterator implementation that filters files based on a list of suffixes.",
+            "homepage": "https://github.com/sebastianbergmann/php-file-iterator/",
+            "keywords": [
+                "filesystem",
+                "iterator"
+            ],
+            "time": "2017-11-27T13:52:08+00:00"
+        },
+        {
+            "name": "phpunit/php-text-template",
+            "version": "1.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-text-template.git",
+                "reference": "31f8b717e51d9a2afca6c9f046f5d69fc27c8686"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/31f8b717e51d9a2afca6c9f046f5d69fc27c8686",
+                "reference": "31f8b717e51d9a2afca6c9f046f5d69fc27c8686",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Simple template engine.",
+            "homepage": "https://github.com/sebastianbergmann/php-text-template/",
+            "keywords": [
+                "template"
+            ],
+            "time": "2015-06-21T13:50:34+00:00"
+        },
+        {
+            "name": "phpunit/php-timer",
+            "version": "1.0.9",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-timer.git",
+                "reference": "3dcf38ca72b158baf0bc245e9184d3fdffa9c46f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/3dcf38ca72b158baf0bc245e9184d3fdffa9c46f",
+                "reference": "3dcf38ca72b158baf0bc245e9184d3fdffa9c46f",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3.3 || ^7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sb@sebastian-bergmann.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Utility class for timing",
+            "homepage": "https://github.com/sebastianbergmann/php-timer/",
+            "keywords": [
+                "timer"
+            ],
+            "time": "2017-02-26T11:10:40+00:00"
+        },
+        {
+            "name": "phpunit/php-token-stream",
+            "version": "1.4.12",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-token-stream.git",
+                "reference": "1ce90ba27c42e4e44e6d8458241466380b51fa16"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/1ce90ba27c42e4e44e6d8458241466380b51fa16",
+                "reference": "1ce90ba27c42e4e44e6d8458241466380b51fa16",
+                "shasum": ""
+            },
+            "require": {
+                "ext-tokenizer": "*",
+                "php": ">=5.3.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.4-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Wrapper around PHP's tokenizer extension.",
+            "homepage": "https://github.com/sebastianbergmann/php-token-stream/",
+            "keywords": [
+                "tokenizer"
+            ],
+            "time": "2017-12-04T08:55:13+00:00"
+        },
+        {
+            "name": "phpunit/phpunit",
+            "version": "5.7.27",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/phpunit.git",
+                "reference": "b7803aeca3ccb99ad0a506fa80b64cd6a56bbc0c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/b7803aeca3ccb99ad0a506fa80b64cd6a56bbc0c",
+                "reference": "b7803aeca3ccb99ad0a506fa80b64cd6a56bbc0c",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-json": "*",
+                "ext-libxml": "*",
+                "ext-mbstring": "*",
+                "ext-xml": "*",
+                "myclabs/deep-copy": "~1.3",
+                "php": "^5.6 || ^7.0",
+                "phpspec/prophecy": "^1.6.2",
+                "phpunit/php-code-coverage": "^4.0.4",
+                "phpunit/php-file-iterator": "~1.4",
+                "phpunit/php-text-template": "~1.2",
+                "phpunit/php-timer": "^1.0.6",
+                "phpunit/phpunit-mock-objects": "^3.2",
+                "sebastian/comparator": "^1.2.4",
+                "sebastian/diff": "^1.4.3",
+                "sebastian/environment": "^1.3.4 || ^2.0",
+                "sebastian/exporter": "~2.0",
+                "sebastian/global-state": "^1.1",
+                "sebastian/object-enumerator": "~2.0",
+                "sebastian/resource-operations": "~1.0",
+                "sebastian/version": "^1.0.6|^2.0.1",
+                "symfony/yaml": "~2.1|~3.0|~4.0"
+            },
+            "conflict": {
+                "phpdocumentor/reflection-docblock": "3.0.2"
+            },
+            "require-dev": {
+                "ext-pdo": "*"
+            },
+            "suggest": {
+                "ext-xdebug": "*",
+                "phpunit/php-invoker": "~1.1"
+            },
+            "bin": [
+                "phpunit"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.7.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "The PHP Unit Testing framework.",
+            "homepage": "https://phpunit.de/",
+            "keywords": [
+                "phpunit",
+                "testing",
+                "xunit"
+            ],
+            "time": "2018-02-01T05:50:59+00:00"
+        },
+        {
+            "name": "phpunit/phpunit-mock-objects",
+            "version": "3.4.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/phpunit-mock-objects.git",
+                "reference": "a23b761686d50a560cc56233b9ecf49597cc9118"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/a23b761686d50a560cc56233b9ecf49597cc9118",
+                "reference": "a23b761686d50a560cc56233b9ecf49597cc9118",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/instantiator": "^1.0.2",
+                "php": "^5.6 || ^7.0",
+                "phpunit/php-text-template": "^1.2",
+                "sebastian/exporter": "^1.2 || ^2.0"
+            },
+            "conflict": {
+                "phpunit/phpunit": "<5.4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^5.4"
+            },
+            "suggest": {
+                "ext-soap": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.2.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sb@sebastian-bergmann.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Mock Object library for PHPUnit",
+            "homepage": "https://github.com/sebastianbergmann/phpunit-mock-objects/",
+            "keywords": [
+                "mock",
+                "xunit"
+            ],
+            "time": "2017-06-30T09:13:00+00:00"
+        },
+        {
+            "name": "sebastian/code-unit-reverse-lookup",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/code-unit-reverse-lookup.git",
+                "reference": "4419fcdb5eabb9caa61a27c7a1db532a6b55dd18"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/4419fcdb5eabb9caa61a27c7a1db532a6b55dd18",
+                "reference": "4419fcdb5eabb9caa61a27c7a1db532a6b55dd18",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.6 || ^7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^5.7 || ^6.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Looks up which function or method a line of code belongs to",
+            "homepage": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/",
+            "time": "2017-03-04T06:30:41+00:00"
+        },
+        {
+            "name": "sebastian/comparator",
+            "version": "1.2.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/comparator.git",
+                "reference": "2b7424b55f5047b47ac6e5ccb20b2aea4011d9be"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/2b7424b55f5047b47ac6e5ccb20b2aea4011d9be",
+                "reference": "2b7424b55f5047b47ac6e5ccb20b2aea4011d9be",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3",
+                "sebastian/diff": "~1.2",
+                "sebastian/exporter": "~1.2 || ~2.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.4"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.2.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Volker Dusch",
+                    "email": "github@wallbash.com"
+                },
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@2bepublished.at"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Provides the functionality to compare PHP values for equality",
+            "homepage": "http://www.github.com/sebastianbergmann/comparator",
+            "keywords": [
+                "comparator",
+                "compare",
+                "equality"
+            ],
+            "time": "2017-01-29T09:50:25+00:00"
+        },
+        {
+            "name": "sebastian/diff",
+            "version": "1.4.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/diff.git",
+                "reference": "7f066a26a962dbe58ddea9f72a4e82874a3975a4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/7f066a26a962dbe58ddea9f72a4e82874a3975a4",
+                "reference": "7f066a26a962dbe58ddea9f72a4e82874a3975a4",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3.3 || ^7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.4-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Kore Nordmann",
+                    "email": "mail@kore-nordmann.de"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Diff implementation",
+            "homepage": "https://github.com/sebastianbergmann/diff",
+            "keywords": [
+                "diff"
+            ],
+            "time": "2017-05-22T07:24:03+00:00"
+        },
+        {
+            "name": "sebastian/environment",
+            "version": "2.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/environment.git",
+                "reference": "5795ffe5dc5b02460c3e34222fee8cbe245d8fac"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/5795ffe5dc5b02460c3e34222fee8cbe245d8fac",
+                "reference": "5795ffe5dc5b02460c3e34222fee8cbe245d8fac",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.6 || ^7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^5.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Provides functionality to handle HHVM/PHP environments",
+            "homepage": "http://www.github.com/sebastianbergmann/environment",
+            "keywords": [
+                "Xdebug",
+                "environment",
+                "hhvm"
+            ],
+            "time": "2016-11-26T07:53:53+00:00"
+        },
+        {
+            "name": "sebastian/exporter",
+            "version": "2.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/exporter.git",
+                "reference": "ce474bdd1a34744d7ac5d6aad3a46d48d9bac4c4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/ce474bdd1a34744d7ac5d6aad3a46d48d9bac4c4",
+                "reference": "ce474bdd1a34744d7ac5d6aad3a46d48d9bac4c4",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3",
+                "sebastian/recursion-context": "~2.0"
+            },
+            "require-dev": {
+                "ext-mbstring": "*",
+                "phpunit/phpunit": "~4.4"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Volker Dusch",
+                    "email": "github@wallbash.com"
+                },
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@2bepublished.at"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Adam Harvey",
+                    "email": "aharvey@php.net"
+                }
+            ],
+            "description": "Provides the functionality to export PHP variables for visualization",
+            "homepage": "http://www.github.com/sebastianbergmann/exporter",
+            "keywords": [
+                "export",
+                "exporter"
+            ],
+            "time": "2016-11-19T08:54:04+00:00"
+        },
+        {
+            "name": "sebastian/global-state",
+            "version": "1.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/global-state.git",
+                "reference": "bc37d50fea7d017d3d340f230811c9f1d7280af4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/bc37d50fea7d017d3d340f230811c9f1d7280af4",
+                "reference": "bc37d50fea7d017d3d340f230811c9f1d7280af4",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.2"
+            },
+            "suggest": {
+                "ext-uopz": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Snapshotting of global state",
+            "homepage": "http://www.github.com/sebastianbergmann/global-state",
+            "keywords": [
+                "global state"
+            ],
+            "time": "2015-10-12T03:26:01+00:00"
+        },
+        {
+            "name": "sebastian/object-enumerator",
+            "version": "2.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/object-enumerator.git",
+                "reference": "1311872ac850040a79c3c058bea3e22d0f09cbb7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/1311872ac850040a79c3c058bea3e22d0f09cbb7",
+                "reference": "1311872ac850040a79c3c058bea3e22d0f09cbb7",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.6",
+                "sebastian/recursion-context": "~2.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Traverses array structures and object graphs to enumerate all referenced objects",
+            "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
+            "time": "2017-02-18T15:18:39+00:00"
+        },
+        {
+            "name": "sebastian/recursion-context",
+            "version": "2.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/recursion-context.git",
+                "reference": "2c3ba150cbec723aa057506e73a8d33bdb286c9a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/2c3ba150cbec723aa057506e73a8d33bdb286c9a",
+                "reference": "2c3ba150cbec723aa057506e73a8d33bdb286c9a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.4"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Adam Harvey",
+                    "email": "aharvey@php.net"
+                }
+            ],
+            "description": "Provides functionality to recursively process PHP variables",
+            "homepage": "http://www.github.com/sebastianbergmann/recursion-context",
+            "time": "2016-11-19T07:33:16+00:00"
+        },
+        {
+            "name": "sebastian/resource-operations",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/resource-operations.git",
+                "reference": "ce990bb21759f94aeafd30209e8cfcdfa8bc3f52"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/resource-operations/zipball/ce990bb21759f94aeafd30209e8cfcdfa8bc3f52",
+                "reference": "ce990bb21759f94aeafd30209e8cfcdfa8bc3f52",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.6.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Provides a list of PHP built-in functions that operate on resources",
+            "homepage": "https://www.github.com/sebastianbergmann/resource-operations",
+            "time": "2015-07-28T20:34:47+00:00"
+        },
+        {
+            "name": "sebastian/version",
+            "version": "2.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/version.git",
+                "reference": "99732be0ddb3361e16ad77b68ba41efc8e979019"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/99732be0ddb3361e16ad77b68ba41efc8e979019",
+                "reference": "99732be0ddb3361e16ad77b68ba41efc8e979019",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.6"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library that helps with managing the version number of Git-hosted PHP projects",
+            "homepage": "https://github.com/sebastianbergmann/version",
+            "time": "2016-10-03T07:35:21+00:00"
+        },
+        {
+            "name": "squizlabs/php_codesniffer",
+            "version": "3.3.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
+                "reference": "628a481780561150481a9ec74709092b9759b3ec"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/628a481780561150481a9ec74709092b9759b3ec",
+                "reference": "628a481780561150481a9ec74709092b9759b3ec",
                 "shasum": ""
             },
             "require": {
@@ -56,34 +1267,199 @@
                 "phpcs",
                 "standards"
             ],
-            "time": "2018-02-20T21:35:23+00:00"
+            "time": "2018-07-26T23:47:18+00:00"
         },
         {
-            "name": "wimg/php-compatibility",
-            "version": "8.1.0",
+            "name": "symfony/polyfill-ctype",
+            "version": "v1.8.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/wimg/PHPCompatibility.git",
-                "reference": "4ac01e4fe8faaa4f8d3b3cd06ea92e5418ce472e"
+                "url": "https://github.com/symfony/polyfill-ctype.git",
+                "reference": "7cc359f1b7b80fc25ed7796be7d96adc9b354bae"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wimg/PHPCompatibility/zipball/4ac01e4fe8faaa4f8d3b3cd06ea92e5418ce472e",
-                "reference": "4ac01e4fe8faaa4f8d3b3cd06ea92e5418ce472e",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/7cc359f1b7b80fc25ed7796be7d96adc9b354bae",
+                "reference": "7cc359f1b7b80fc25ed7796be7d96adc9b354bae",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.8-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Ctype\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                },
+                {
+                    "name": "Gert de Pagter",
+                    "email": "BackEndTea@gmail.com"
+                }
+            ],
+            "description": "Symfony polyfill for ctype functions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "ctype",
+                "polyfill",
+                "portable"
+            ],
+            "time": "2018-04-30T19:57:29+00:00"
+        },
+        {
+            "name": "symfony/yaml",
+            "version": "v3.4.13",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/yaml.git",
+                "reference": "c5010cc1692ce1fa328b1fb666961eb3d4a85bb0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/c5010cc1692ce1fa328b1fb666961eb3d4a85bb0",
+                "reference": "c5010cc1692ce1fa328b1fb666961eb3d4a85bb0",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.5.9|>=7.0.8",
+                "symfony/polyfill-ctype": "~1.8"
+            },
+            "conflict": {
+                "symfony/console": "<3.4"
+            },
+            "require-dev": {
+                "symfony/console": "~3.4|~4.0"
+            },
+            "suggest": {
+                "symfony/console": "For validating YAML files using the lint command"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.4-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Yaml\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Yaml Component",
+            "homepage": "https://symfony.com",
+            "time": "2018-05-03T23:18:14+00:00"
+        },
+        {
+            "name": "webmozart/assert",
+            "version": "1.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/webmozart/assert.git",
+                "reference": "0df1908962e7a3071564e857d86874dad1ef204a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/webmozart/assert/zipball/0df1908962e7a3071564e857d86874dad1ef204a",
+                "reference": "0df1908962e7a3071564e857d86874dad1ef204a",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3.3 || ^7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.6",
+                "sebastian/version": "^1.0.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.3-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Webmozart\\Assert\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@gmail.com"
+                }
+            ],
+            "description": "Assertions to validate method input/output with nice error messages.",
+            "keywords": [
+                "assert",
+                "check",
+                "validate"
+            ],
+            "time": "2018-01-29T19:49:41+00:00"
+        },
+        {
+            "name": "wimg/php-compatibility",
+            "version": "8.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPCompatibility/PHPCompatibility.git",
+                "reference": "eaf613c1a8265bcfd7b0ab690783f2aef519f78a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibility/zipball/eaf613c1a8265bcfd7b0ab690783f2aef519f78a",
+                "reference": "eaf613c1a8265bcfd7b0ab690783f2aef519f78a",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3",
-                "squizlabs/php_codesniffer": "^2.2 || ^3.0.2"
+                "squizlabs/php_codesniffer": "^2.3 || ^3.0.2"
             },
             "conflict": {
                 "squizlabs/php_codesniffer": "2.6.2"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0"
+                "phpunit/phpunit": "~4.5 || ^5.0 || ^6.0 || ^7.0"
             },
             "suggest": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.3"
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.3 || This Composer plugin will sort out the PHPCS 'installed_paths' automatically.",
+                "roave/security-advisories": "dev-master || Helps prevent installing dependencies with known security issues."
             },
             "type": "phpcodesniffer-standard",
             "autoload": {
@@ -93,7 +1469,7 @@
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
-                "LGPL-3.0"
+                "LGPL-3.0-or-later"
             ],
             "authors": [
                 {
@@ -108,7 +1484,7 @@
                 "phpcs",
                 "standards"
             ],
-            "time": "2017-12-27T21:58:38+00:00"
+            "time": "2018-07-17T13:42:26+00:00"
         },
         {
             "name": "wp-coding-standards/wpcs",
@@ -156,6 +1532,8 @@
     "stability-flags": [],
     "prefer-stable": false,
     "prefer-lowest": false,
-    "platform": [],
+    "platform": {
+        "php": "^5.3 || ^7.0"
+    },
     "platform-dev": []
 }

--- a/lib/WP_Auth0_Lock10_Options.php
+++ b/lib/WP_Auth0_Lock10_Options.php
@@ -11,10 +11,11 @@ class WP_Auth0_Lock10_Options {
 	/**
 	 * WP_Auth0_Lock10_Options constructor.
 	 *
-	 * @param array $extended_settings - argument in renderAuth0Form(), used by shortcode and widget
+	 * @param array                 $extended_settings Argument in renderAuth0Form(), used by shortcode and widget.
+	 * @param null|WP_Auth0_Options $opts WP_Auth0_Options instance.
 	 */
-	public function __construct( $extended_settings = array() ) {
-		$this->wp_options        = WP_Auth0_Options::Instance();
+	public function __construct( $extended_settings = array(), $opts = null ) {
+		$this->wp_options        = ! empty( $opts ) ? $opts : WP_Auth0_Options::Instance();
 		$this->extended_settings = $extended_settings;
 	}
 
@@ -36,7 +37,7 @@ class WP_Auth0_Lock10_Options {
 	}
 
 	public function get_domain() {
-		return $this->wp_options->get( 'domain' );
+		return $this->wp_options->get_auth_domain();
 	}
 
 	public function get_auth0_implicit_workflow() {
@@ -188,6 +189,14 @@ class WP_Auth0_Lock10_Options {
 		} else {
 			$extraOptions['auth']['responseType'] = 'code';
 			$extraOptions['auth']['redirectUrl']  = $this->get_code_callback_url();
+		}
+
+		if ( $this->wp_options->get( 'custom_domain' ) ) {
+			$tenant_region                        = WP_Auth0::get_tenant_region( $this->wp_options->get( 'domain' ) );
+			$extraOptions['configurationBaseUrl'] = sprintf(
+				'https://cdn%s.auth0.com',
+				( 'us' === $tenant_region ? '' : '.' . $tenant_region )
+			);
 		}
 
 		$options_obj       = $this->build_settings( $this->wp_options->get_options() );

--- a/lib/WP_Auth0_LoginManager.php
+++ b/lib/WP_Auth0_LoginManager.php
@@ -110,7 +110,7 @@ class WP_Auth0_LoginManager {
 		$connection  = apply_filters( 'auth0_get_auto_login_connection', $this->a0_options->get( 'auto_login_method' ) );
 		$auth_params = self::get_authorize_params( $connection );
 
-		$auth_url = 'https://' . $this->a0_options->get( 'domain' ) . '/authorize';
+		$auth_url = 'https://' . $this->a0_options->get_auth_domain() . '/authorize';
 		$auth_url = add_query_arg( array_map( 'rawurlencode', $auth_params ), $auth_url );
 
 		WP_Auth0_State_Handler::get_instance()->set_cookie( $auth_params['state'] );
@@ -198,6 +198,7 @@ class WP_Auth0_LoginManager {
 	 */
 	public function redirect_login() {
 		$domain             = $this->a0_options->get( 'domain' );
+		$auth_domain        = $this->a0_options->get_auth_domain();
 		$client_id          = $this->a0_options->get( 'client_id' );
 		$client_secret      = $this->a0_options->get( 'client_secret' );
 		$userinfo_resp_code = null;
@@ -205,7 +206,7 @@ class WP_Auth0_LoginManager {
 
 		// Exchange authorization code for an access token.
 		$exchange_resp = WP_Auth0_Api_Client::get_token(
-			$domain, $client_id, $client_secret, 'authorization_code', array(
+			$auth_domain, $client_id, $client_secret, 'authorization_code', array(
 				'redirect_uri' => $this->a0_options->get_wp_auth0_url(),
 				'code'         => $this->query_vars( 'code' ),
 			)
@@ -266,7 +267,7 @@ class WP_Auth0_LoginManager {
 		// Management API call failed, fallback to userinfo.
 		if ( 200 !== $userinfo_resp_code || empty( $userinfo_resp_body ) ) {
 
-			$userinfo_resp      = WP_Auth0_Api_Client::get_user_info( $domain, $access_token );
+			$userinfo_resp      = WP_Auth0_Api_Client::get_user_info( $auth_domain, $access_token );
 			$userinfo_resp_code = (int) wp_remote_retrieve_response_code( $userinfo_resp );
 			$userinfo_resp_body = wp_remote_retrieve_body( $userinfo_resp );
 
@@ -436,7 +437,7 @@ class WP_Auth0_LoginManager {
 				}
 
 				wp_update_user(
-					array(
+					(object) array(
 						'ID'          => $user->data->ID,
 						'user_email'  => $userinfo->email,
 						'description' => $description,
@@ -547,7 +548,7 @@ class WP_Auth0_LoginManager {
 			$telemetry_headers = WP_Auth0_Api_Client::get_info_headers();
 			$redirect_url      = sprintf(
 				'https://%s/v2/logout?returnTo=%s&client_id=%s&auth0Client=%s',
-				$this->a0_options->get( 'domain' ),
+				$this->a0_options->get_auth_domain(),
 				rawurlencode( home_url() ),
 				$this->a0_options->get( 'client_id' ),
 				$telemetry_headers['Auth0-Client']

--- a/lib/WP_Auth0_Metrics.php
+++ b/lib/WP_Auth0_Metrics.php
@@ -22,18 +22,7 @@ class WP_Auth0_Metrics {
 			return;
 		}
 
-		$domain = $this->a0_options->get( 'domain' );
-		$parts  = explode( '.', $domain );
-
-		$tenant = $parts[0];
-
-		if ( strpos( $domain, 'au.auth0.com' ) !== false ) {
-			$tenant .= '@au';
-		} elseif ( strpos( $domain, 'eu.auth0.com' ) !== false ) {
-			$tenant .= '@eu';
-		} elseif ( strpos( $domain, 'auth0.com' ) !== false ) {
-			$tenant .= '@us';
-		}
+		$tenant = WP_Auth0::get_tenant();
 
 		if ( $this->a0_options->get( 'metrics' ) == 1 ) {
 			?>

--- a/lib/WP_Auth0_Options.php
+++ b/lib/WP_Auth0_Options.php
@@ -139,6 +139,19 @@ class WP_Auth0_Options extends WP_Auth0_Options_Generic {
 	}
 
 	/**
+	 * Get the authentication domain.
+	 *
+	 * @return string
+	 */
+	public function get_auth_domain() {
+		$domain = $this->get( 'custom_domain' );
+		if ( empty( $domain ) ) {
+			$domain = $this->get( 'domain' );
+		}
+		return $domain;
+	}
+
+	/**
 	 * Get lock_connections as an array of strings
 	 *
 	 * @return array
@@ -182,6 +195,7 @@ class WP_Auth0_Options extends WP_Auth0_Options_Generic {
 
 			// Basic
 			'domain'                    => '',
+			'custom_domain'             => '',
 			'client_id'                 => '',
 			'client_secret'             => '',
 			'client_secret_b64_encoded' => null,

--- a/lib/WP_Auth0_Routes.php
+++ b/lib/WP_Auth0_Routes.php
@@ -65,7 +65,7 @@ class WP_Auth0_Routes {
 	protected function coo_fallback() {
 		$cdn          = $this->a0_options->get( 'auth0js-cdn' );
 		$client_id    = $this->a0_options->get( 'client_id' );
-		$domain       = $this->a0_options->get( 'domain' );
+		$domain       = $this->a0_options->get_auth_domain();
 		$protocol     = $this->a0_options->get( 'force_https_callback', false ) ? 'https' : null;
 		$redirect_uri = $this->a0_options->get_wp_auth0_url( $protocol );
 		echo <<<EOT

--- a/lib/admin/WP_Auth0_Admin.php
+++ b/lib/admin/WP_Auth0_Admin.php
@@ -125,22 +125,6 @@ class WP_Auth0_Admin {
 	}
 
 	public function render_settings_page() {
-
-		$domain = $this->a0_options->get( 'domain' );
-		$parts  = explode( '.', $domain );
-
-		$tenant = $parts[0];
-
-		if ( strpos( $domain, 'au.auth0.com' ) !== false ) {
-			$tenant .= '@au';
-		} elseif ( strpos( $domain, 'eu.auth0.com' ) !== false ) {
-			$tenant .= '@eu';
-		} elseif ( strpos( $domain, 'auth0.com' ) !== false ) {
-			$tenant .= '@us';
-		}
-
-		$options = $this->a0_options;
-
 		include WPA0_PLUGIN_DIR . 'templates/settings.php';
 	}
 }

--- a/lib/admin/WP_Auth0_Admin_Basic.php
+++ b/lib/admin/WP_Auth0_Admin_Basic.php
@@ -41,6 +41,12 @@ class WP_Auth0_Admin_Basic extends WP_Auth0_Admin_Generic {
 				'function' => 'render_domain',
 			),
 			array(
+				'name'     => __( 'Custom Domain', 'wp-auth0' ),
+				'opt'      => 'custom_domain',
+				'id'       => 'wpa0_custom_domain',
+				'function' => 'render_custom_domain',
+			),
+			array(
 				'name'     => __( 'Client ID', 'wp-auth0' ),
 				'opt'      => 'client_id',
 				'id'       => 'wpa0_client_id',
@@ -105,6 +111,23 @@ class WP_Auth0_Admin_Basic extends WP_Auth0_Admin_Generic {
 		$this->render_field_description(
 			__( 'Auth0 Domain, found in your Application settings in the ', 'wp-auth0' ) .
 			$this->get_dashboard_link( 'applications' )
+		);
+	}
+
+	/**
+	 * Render form field and description for the `custom_domain` option.
+	 * IMPORTANT: Internal callback use only, do not call this function directly!
+	 *
+	 * @param array $args - callback args passed in from add_settings_field().
+	 *
+	 * @see WP_Auth0_Admin_Generic::init_option_section()
+	 * @see add_settings_field()
+	 */
+	public function render_custom_domain( $args = array() ) {
+		$this->render_text_field( $args['label_for'], $args['opt_name'], 'text', 'login.yourdomain.com' );
+		$this->render_field_description(
+			__( 'Custom login domain. ', 'wp-auth0' ) .
+			$this->get_docs_link( 'custom-domains', __( 'More information here', 'wp-auth0' ) )
 		);
 	}
 
@@ -318,7 +341,7 @@ class WP_Auth0_Admin_Basic extends WP_Auth0_Admin_Generic {
 		}
 
 		if ( empty( $input['domain'] ) ) {
-			$this->add_validation_error( __( 'You need to specify domain', 'wp-auth0' ) );
+			$this->add_validation_error( __( 'You need to specify a domain', 'wp-auth0' ) );
 		}
 
 		if ( empty( $input['client_id'] ) ) {

--- a/lib/initial-setup/WP_Auth0_InitialSetup_AdminUser.php
+++ b/lib/initial-setup/WP_Auth0_InitialSetup_AdminUser.php
@@ -9,10 +9,6 @@ class WP_Auth0_InitialSetup_AdminUser {
 	}
 
 	public function render( $step ) {
-		$client_id    = $this->a0_options->get( 'client_id' );
-		$domain       = $this->a0_options->get( 'domain' );
-		$current_user = wp_get_current_user();
-		$error        = isset( $_REQUEST['result'] ) && $_REQUEST['result'] === 'error';
 		include WPA0_PLUGIN_DIR . 'templates/initial-setup/admin-creation.php';
 	}
 
@@ -27,7 +23,7 @@ class WP_Auth0_InitialSetup_AdminUser {
 			'connection' => $this->a0_options->get( 'db_connection_name' ),
 		);
 
-		$admin_user = WP_Auth0_Api_Client::signup_user( $this->a0_options->get( 'domain' ), $data );
+		$admin_user = WP_Auth0_Api_Client::signup_user( $this->a0_options->get_auth_domain(), $data );
 
 		if ( $admin_user === false ) {
 			wp_redirect( admin_url( 'admin.php?page=wpa0-setup&step=3&profile=social&result=error' ) );

--- a/phpcs-compat-ruleset.xml
+++ b/phpcs-compat-ruleset.xml
@@ -2,18 +2,20 @@
 <ruleset name="WP-Auth0" namespace="WPAuth0\CS\Standard">
     <description>A custom compatibility standard for WP-Auth0</description>
 
-    <!-- Internal tool, will be removed -->
+    <!-- Internal tool, will be removed-->
     <exclude-pattern>/account_cleanup/*</exclude-pattern>
 
-    <!-- No PHP files -->
+    <!-- Not currently checking JS or CSS -->
     <exclude-pattern>/assets/*</exclude-pattern>
-    <exclude-pattern>/webtask/*</exclude-pattern>
+
+    <!-- Tests have their own ruleset (different PHP version) -->
+    <exclude-pattern>/tests/*</exclude-pattern>
 
     <!-- Dev tools only, currently -->
     <exclude-pattern>/vendor/*</exclude-pattern>
 
-    <!-- No need to compat-test tests -->
-    <exclude-pattern>/tests/*</exclude-pattern>
+    <!-- Not currently checking JS -->
+    <exclude-pattern>/webtask/*</exclude-pattern>
 
     <!-- Deprecated so no changes needed -->
     <exclude-pattern>/lib/admin/WP_Auth0_Admin_Dashboard.php</exclude-pattern>

--- a/phpcs-ruleset.xml
+++ b/phpcs-ruleset.xml
@@ -8,6 +8,9 @@
     <!-- Not currently checking JS or CSS -->
     <exclude-pattern>/assets/*</exclude-pattern>
 
+    <!-- Tests have their own ruleset (different PHP version) -->
+    <exclude-pattern>/tests/*</exclude-pattern>
+
     <!-- Dev tools only, currently -->
     <exclude-pattern>/vendor/*</exclude-pattern>
 

--- a/phpcs-test-ruleset.xml
+++ b/phpcs-test-ruleset.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0"?>
+<ruleset name="WP-Auth0" namespace="WPAuth0\CS\Standard">
+    <description>A custom coding standard for WP-Auth0 tests</description>
+
+    <!-- Tests only -->
+    <include-pattern>/tests/*</include-pattern>
+
+    <config name="testVersion" value="5.6-"/>
+    <config name="showProgress" value="1"/>
+    <config name="extensions" value="php"/>
+
+    <arg name="colors"/>
+
+    <rule ref="Generic.CodeAnalysis"/>
+    <rule ref="Generic.Commenting.Todo"/>
+    <rule ref="PHPCompatibility"/>
+    <rule ref="WordPress-Docs"/>
+    <rule ref="WordPress-Core">
+        <exclude name="WordPress.Files.FileName"/>
+        <exclude name="WordPress.NamingConventions.ValidVariableName.NotSnakeCase"/>
+        <exclude name="WordPress.NamingConventions.ValidFunctionName.MethodNameInvalid"/>
+        <exclude name="Squiz.Commenting.FileComment.Missing"/>
+    </rule>
+</ruleset>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -10,7 +10,7 @@
 	>
 	<filter>
 		<whitelist>
-			<directory>./lib</directory>
+			<directory suffix=".php">./lib</directory>
 		</whitelist>
 	</filter>
 	<testsuites>

--- a/templates/auth0-singlelogout-handler.php
+++ b/templates/auth0-singlelogout-handler.php
@@ -20,7 +20,7 @@ $logout_url = add_query_arg( 'SLO', 1, $logout_url );
 
 	var webAuth = new auth0.WebAuth({
 	  clientID:'<?php echo sanitize_text_field( $this->a0_options->get( 'client_id' ) ); ?>',
-	  domain:'<?php echo sanitize_text_field( $this->a0_options->get( 'domain' ) ); ?>'
+	  domain:'<?php echo sanitize_text_field( $this->a0_options->get_auth_domain() ); ?>'
 	});
 
 	var sloOptions = {

--- a/templates/auth0-sso-handler-lock10.php
+++ b/templates/auth0-sso-handler-lock10.php
@@ -4,42 +4,44 @@ $client_id    = $lock_options->get_client_id();
 $domain       = $lock_options->get_domain();
 ?>
 <script type="text/javascript">
-document.addEventListener("DOMContentLoaded", function() {
-  if (typeof(ignore_sso) !== 'undefined' && ignore_sso) {
-	return;
-  }
-  if (typeof(auth0) === 'undefined') {
-	return;
-  }
+	document.addEventListener("DOMContentLoaded", function() {
+		if (typeof(ignore_sso) !== 'undefined' && ignore_sso) {
+			return;
+		}
+		if (typeof(auth0) === 'undefined') {
+			return;
+		}
 
-  var webAuth = new auth0.WebAuth({
-	clientID:'<?php echo $client_id; ?>',
-	domain:'<?php echo $domain; ?>'
-  });
-
-  var options = <?php echo json_encode( $lock_options->get_sso_options() ); ?>;
-  webAuth.checkSession(options, function (err, authResult) {
-	  if (typeof(authResult) === 'undefined') {
-		return;
-	  }
-
-	  if (authResult.idToken) {
-		jQuery(document).ready(function($){
-		  var $form=$(document.createElement('form')).css({display:'none'}).attr("method","POST").attr("action","
-			<?php
-			echo add_query_arg( 'auth0', 'implicit', site_url( 'index.php' ) );
-			?>
-			");
-		  var $input=$(document.createElement('input')).attr('name','token').val(authResult.idToken);
-		  var $input2=$(document.createElement('input')).attr('name','state').val(authResult.state);
-		  $form.append($input).append($input2);
-		  $("body").append($form);
-		  Cookies.set( '<?php echo WP_Auth0_State_Handler::get_storage_cookie_name(); ?>', authResult.state );
-		  Cookies.set( '<?php echo WP_Auth0_Nonce_Handler::get_storage_cookie_name(); ?>', authResult.idTokenPayload.nonce );
-		  $form.submit();
+		var webAuth = new auth0.WebAuth({
+			clientID:'<?php echo $client_id; ?>',
+			domain:'<?php echo $domain; ?>'
 		});
-	  }
-	});
+		var postAction = '<?php echo add_query_arg( 'auth0', 'implicit', site_url( 'index.php' ) ); ?>';
+		var stateCookieName = '<?php echo WP_Auth0_State_Handler::get_storage_cookie_name(); ?>';
+		var nonceCookieName = '<?php echo WP_Auth0_Nonce_Handler::get_storage_cookie_name(); ?>';
 
-});
+		var options = <?php echo json_encode( $lock_options->get_sso_options() ); ?>;
+		webAuth.checkSession(options, function (err, authResult) {
+			if (typeof(authResult) === 'undefined') {
+				return;
+			}
+
+			if (authResult.idToken) {
+				jQuery(document).ready(function($){
+					var $form=$(document.createElement('form'))
+						.css({display: 'none'})
+						.attr("method", "POST")
+						.attr("action", postAction);
+					var $input=$(document.createElement('input')).attr('name','token').val(authResult.idToken);
+					var $input2=$(document.createElement('input')).attr('name','state').val(authResult.state);
+					$form.append($input).append($input2);
+					$("body").append($form);
+					Cookies.set( stateCookieName, authResult.state );
+					Cookies.set( nonceCookieName, authResult.idTokenPayload.nonce );
+					$form.submit();
+				});
+			}
+		});
+
+	});
 </script>

--- a/templates/initial-setup/admin-creation.php
+++ b/templates/initial-setup/admin-creation.php
@@ -1,3 +1,7 @@
+<?php
+$error        = isset( $_REQUEST['result'] ) && $_REQUEST['result'] === 'error';
+$current_user = wp_get_current_user();
+?>
 <div class="a0-wrap">
 
 	<?php require WPA0_PLUGIN_DIR . 'templates/initial-setup/partials/header.php'; ?>

--- a/templates/login-form.php
+++ b/templates/login-form.php
@@ -19,7 +19,7 @@ function renderAuth0Form( $canShowLegacyLogin = true, $specialSettings = array()
 			array(
 				'settings'        => $lock_options->get_lock_options(),
 				'ready'           => WP_Auth0::ready(),
-				'domain'          => $options->get( 'domain' ),
+				'domain'          => $lock_options->get_domain(),
 				'clientId'        => $options->get( 'client_id' ),
 				'stateCookieName' => WP_Auth0_State_Handler::get_storage_cookie_name(),
 				'nonceCookieName' => WP_Auth0_Nonce_Handler::get_storage_cookie_name(),

--- a/templates/settings.php
+++ b/templates/settings.php
@@ -177,7 +177,7 @@
 		var url = 'https://sandbox.it.auth0.com/api/run/wptest/wp-auth0-slack?webtask_no_cache=1';
 		var data = {
 			"score": jQuery('.feedback_calification:checked').val(),
-			"account": '<?php echo $tenant; ?>',
+			"account": '<?php echo WP_Auth0::get_tenant(); ?>',
 			"feedback": jQuery('#feedback_text').val()
 		};
 		var successMsg = "<?php _e( 'Done! Thank you for your feedback.', 'wp-auth0' ); ?>";

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -29,3 +29,12 @@ tests_add_filter( 'muplugins_loaded', '_manually_load_plugin' );
 
 // Start up the WP testing environment.
 require $_tests_dir . '/includes/bootstrap.php';
+
+spl_autoload_register(
+	function( $className ) {
+			$fileName = stream_resolve_include_path( 'traits/' . $className . '.php' );
+		if ( false !== $fileName ) {
+			include $fileName;
+		}
+	}
+);

--- a/tests/testCustomDomains.php
+++ b/tests/testCustomDomains.php
@@ -1,0 +1,69 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Class TestCustomDomains.
+ * Test custom domain functionality.
+ */
+class TestCustomDomains extends TestCase {
+
+	use setUpTestDb;
+
+	use domDocumentHelpers;
+
+	/**
+	 * Test the input HTML for the custom domain setting.
+	 */
+	public function testCustomDomainsFieldOutput() {
+		$field_args  = [
+			'label_for' => 'wpa0_custom_domain',
+			'opt_name'  => 'custom_domain',
+		];
+		$opts        = new WP_Auth0_Options();
+		$admin_basic = new WP_Auth0_Admin_Basic( $opts );
+
+		// Get the field HTML.
+		ob_start();
+		$admin_basic->render_custom_domain( $field_args );
+		$field_html = ob_get_clean();
+
+		// Check field HTML for required attributes.
+		$input = $this->getDomListFromTagName( $field_html, 'input' );
+		$this->assertEquals( 1, $input->length );
+		$this->assertEquals( $field_args['label_for'], $input->item( 0 )->getAttribute( 'id' ) );
+		$this->assertEquals(
+			testWPAuth0Options::OPTIONS_NAME . '[' . $field_args['opt_name'] . ']',
+			$input->item( 0 )->getAttribute( 'name' )
+		);
+		$this->assertEquals( 'text', $input->item( 0 )->getAttribute( 'type' ) );
+
+		// Check that saving a custom domain appears in the field value.
+		$expected_value = 'example.org';
+		$opts->set( $field_args['opt_name'], $expected_value );
+		$this->assertEquals( $expected_value, $opts->get( $field_args['opt_name'] ) );
+
+		// Get the field HTML.
+		ob_start();
+		$admin_basic->render_custom_domain( $field_args );
+		$field_html = ob_get_clean();
+
+		$input = $this->getDomListFromTagName( $field_html, 'input' );
+		$this->assertEquals( $expected_value, $input->item( 0 )->getAttribute( 'value' ) );
+	}
+
+	/**
+	 * Test that a custom domain is output for the auth domain setting.
+	 */
+	public function testAuthDomain() {
+		$auth0_domain  = 'test.auth0.com';
+		$custom_domain = 'login.example.com';
+		$opts          = WP_Auth0_Options::Instance();
+
+		$opts->set( 'domain', $auth0_domain );
+		$this->assertEquals( $auth0_domain, $opts->get_auth_domain() );
+		$opts->set( 'custom_domain', $custom_domain );
+		$this->assertEquals( $custom_domain, $opts->get_auth_domain() );
+		$opts->set( 'custom_domain', '' );
+		$this->assertEquals( $auth0_domain, $opts->get_auth_domain() );
+	}
+}

--- a/tests/testLockOptions.php
+++ b/tests/testLockOptions.php
@@ -1,0 +1,32 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Class TestLockOptions.
+ * Tests that Lock options output expected values based on given conditions.
+ */
+class TestLockOptions extends TestCase {
+
+	use setUpTestDb;
+
+	/**
+	 * Test that a custom domain adds a correct key for CDN configuration to Lock options.
+	 */
+	public function testLockConfigBaseUrl() {
+		$opts = WP_Auth0_Options::Instance();
+
+		$opts->set( 'domain', 'test.auth0.com' );
+		$lock_options     = new WP_Auth0_Lock10_Options( [], $opts );
+		$lock_options_arr = $lock_options->get_lock_options();
+		$this->assertArrayNotHasKey( 'configurationBaseUrl', $lock_options_arr );
+
+		$opts->set( 'custom_domain', 'login.example.com' );
+		$this->assertEquals( 'https://cdn.auth0.com', $lock_options->get_lock_options()['configurationBaseUrl'] );
+
+		$opts->set( 'domain', 'test.eu.auth0.com' );
+		$this->assertEquals( 'https://cdn.eu.auth0.com', $lock_options->get_lock_options()['configurationBaseUrl'] );
+
+		$opts->set( 'domain', 'test.au.auth0.com' );
+		$this->assertEquals( 'https://cdn.au.auth0.com', $lock_options->get_lock_options()['configurationBaseUrl'] );
+	}
+}

--- a/tests/testWPAuth0DbMigrations.php
+++ b/tests/testWPAuth0DbMigrations.php
@@ -2,24 +2,17 @@
 use PHPUnit\Framework\TestCase;
 
 /**
- * Class testWPAuth0Options
+ * Class TestWPAuth0DbMigrations.
+ * Tests for database upgrade processes.
  */
-class testWPAuth0DbMigrations extends TestCase {
+class TestWPAuth0DbMigrations extends TestCase {
 
-	const FILTER_TEST_STRING = '__filter_test__';
-
-	public function setUp() {
-		global $wpdb;
-		$wpdb->suppress_errors = false;
-		$wpdb->show_errors     = true;
-		$wpdb->db_connect();
-		ini_set( 'display_errors', 1 );
-	}
+	use setUpTestDb;
 
 	/**
 	 * Test the basic options functionality.
 	 */
-	public function testDefaultOptionsBehavior() {
+	public function testV19Update() {
 		$opts = new WP_Auth0_Options();
 
 		$initial_connections = [
@@ -36,7 +29,7 @@ class testWPAuth0DbMigrations extends TestCase {
 		$saved_connections = $opts->get( 'connections' );
 		$this->assertEquals( $initial_connections, $saved_connections );
 
-		// Run the migration for v19
+		// Run the migration for v19.
 		update_option( 'auth0_db_version', 18 );
 		$db_manager = new WP_Auth0_DBManager( $opts );
 		$db_manager->init();
@@ -50,5 +43,4 @@ class testWPAuth0DbMigrations extends TestCase {
 			$this->assertEquals( $initial_connections[ $key ], $opts->get( $key ) );
 		}
 	}
-
 }

--- a/tests/testWPAuth0Helpers.php
+++ b/tests/testWPAuth0Helpers.php
@@ -14,13 +14,17 @@ class TestWPAuth0Helpers extends TestCase {
 		// Test the default.
 		$this->assertEquals( 'us', WP_Auth0::get_tenant_region( 'banana' ) );
 		$this->assertEquals( 'us', WP_Auth0::get_tenant_region( 'banana.auth0.com' ) );
+		$this->assertEquals( 'us', WP_Auth0::get_tenant_region( 'banana.us.auth0.com' ) );
 		$this->assertEquals( 'eu', WP_Auth0::get_tenant_region( 'apple.eu.auth0.com' ) );
 		$this->assertEquals( 'au', WP_Auth0::get_tenant_region( 'orange.au.auth0.com' ) );
+		$this->assertEquals( 'xx', WP_Auth0::get_tenant_region( 'mango.xx.auth0.com' ) );
 
 		// Test full tenant name getting.
 		$this->assertEquals( 'banana@us', WP_Auth0::get_tenant( 'banana' ) );
 		$this->assertEquals( 'banana@us', WP_Auth0::get_tenant( 'banana.auth0.com' ) );
+		$this->assertEquals( 'banana@us', WP_Auth0::get_tenant( 'banana.us.auth0.com' ) );
 		$this->assertEquals( 'apple@eu', WP_Auth0::get_tenant( 'apple.eu.auth0.com' ) );
 		$this->assertEquals( 'orange@au', WP_Auth0::get_tenant( 'orange.au.auth0.com' ) );
+		$this->assertEquals( 'mango@xx', WP_Auth0::get_tenant( 'mango.xx.auth0.com' ) );
 	}
 }

--- a/tests/testWPAuth0Helpers.php
+++ b/tests/testWPAuth0Helpers.php
@@ -1,0 +1,26 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Class TestWPAuth0Helpers
+ */
+class TestWPAuth0Helpers extends TestCase {
+
+	/**
+	 * Test the basic options functionality.
+	 */
+	public function testGetTenantInfo() {
+
+		// Test the default.
+		$this->assertEquals( 'us', WP_Auth0::get_tenant_region( 'banana' ) );
+		$this->assertEquals( 'us', WP_Auth0::get_tenant_region( 'banana.auth0.com' ) );
+		$this->assertEquals( 'eu', WP_Auth0::get_tenant_region( 'apple.eu.auth0.com' ) );
+		$this->assertEquals( 'au', WP_Auth0::get_tenant_region( 'orange.au.auth0.com' ) );
+
+		// Test full tenant name getting.
+		$this->assertEquals( 'banana@us', WP_Auth0::get_tenant( 'banana' ) );
+		$this->assertEquals( 'banana@us', WP_Auth0::get_tenant( 'banana.auth0.com' ) );
+		$this->assertEquals( 'apple@eu', WP_Auth0::get_tenant( 'apple.eu.auth0.com' ) );
+		$this->assertEquals( 'orange@au', WP_Auth0::get_tenant( 'orange.au.auth0.com' ) );
+	}
+}

--- a/tests/testWPAuth0Options.php
+++ b/tests/testWPAuth0Options.php
@@ -2,19 +2,21 @@
 use PHPUnit\Framework\TestCase;
 
 /**
- * Class testWPAuth0Options
+ * Class TestWPAuth0Options
  */
-class testWPAuth0Options extends TestCase {
+class TestWPAuth0Options extends TestCase {
 
+	use SetUpTestDb;
+
+	/**
+	 * Test string to use.
+	 */
 	const FILTER_TEST_STRING = '__filter_test__';
 
-	public function setUp() {
-		global $wpdb;
-		$wpdb->suppress_errors = false;
-		$wpdb->show_errors     = true;
-		$wpdb->db_connect();
-		ini_set( 'display_errors', 1 );
-	}
+	/**
+	 * DB settings name.
+	 */
+	const OPTIONS_NAME = 'wp_auth0_settings';
 
 	/**
 	 * Test the basic options functionality.
@@ -23,10 +25,10 @@ class testWPAuth0Options extends TestCase {
 		$opts = new WP_Auth0_Options();
 
 		// Make sure the settings name did not change.
-		$this->assertEquals( 'wp_auth0_settings', $opts->get_options_name() );
+		$this->assertEquals( self::OPTIONS_NAME, $opts->get_options_name() );
 
 		// Make sure the number of options has not changed unintentionally.
-		$this->assertEquals( 66, count( $opts->get_options() ) );
+		$this->assertEquals( 67, count( $opts->get_options() ) );
 	}
 
 	/**
@@ -47,6 +49,7 @@ class testWPAuth0Options extends TestCase {
 		$opts = new WP_Auth0_Options();
 
 		add_filter(
+			// phpcs:ignore
 			'wp_auth0_get_option', function( $value, $key ) {
 				return $key . self::FILTER_TEST_STRING;
 			}, 10, 2

--- a/tests/traits/domDocumentHelpers.php
+++ b/tests/traits/domDocumentHelpers.php
@@ -1,0 +1,21 @@
+<?php
+
+/**
+ * Trait DomDocumentHelpers.
+ */
+trait DomDocumentHelpers {
+
+	/**
+	 * Get a DOMNodeList from a tag name.
+	 *
+	 * @param string $html HTML to load and query.
+	 * @param string $tag HTML tag to retrieve.
+	 *
+	 * @return DOMNodeList
+	 */
+	public function getDomListFromTagName( $html, $tag ) {
+		$dom = new DOMDocument;
+		$dom->loadHTML( $html );
+		return $dom->getElementsByTagName( $tag );
+	}
+}

--- a/tests/traits/setUpTestDb.php
+++ b/tests/traits/setUpTestDb.php
@@ -1,0 +1,18 @@
+<?php
+
+/**
+ * Trait SetUpTestDb.
+ */
+trait SetUpTestDb {
+
+	/**
+	 * Setup the database to be used for testing.
+	 */
+	public function setUp() {
+		global $wpdb;
+		$wpdb->suppress_errors = false;
+		$wpdb->show_errors     = true;
+		$wpdb->db_connect();
+		ini_set( 'display_errors', 1 );
+	}
+}


### PR DESCRIPTION
Main purpose of this PR is to add a field for custom domains and application code to use the custom domain properly. 

![screenshot 2018-07-23 13 27 13](https://user-images.githubusercontent.com/855223/43101053-22a6313e-8e7c-11e8-8bdb-43783e142789.png)

Follows guidance from the [Auth0 docs on custom domains](https://auth0.com/docs/custom-domains) and the [additional configuration docs](https://auth0.com/docs/custom-domains/additional-configuration). In summary: all auth-level domains were changed to the custom domain but management API calls remain pointing to the tenant domain (would appreciate a review of how this is being used as well). 

Also: 
- Add `WP_Auth0::get_tenant_region()` to get the tenant region from a domain
- Add `WP_Auth0::get_tenant()` to get the full tenant name from a domain
- Add `WP_Auth0_Options::get_auth_domain()` to get a custom domain, if saved, falling back to main domain
- Tests!
- Add test-specific code quality checks
- Fix 2 whitespace-caused issues