### PR TITLE
Fix PHP notice for Amplificator widget

### DIFF
--- a/lib/WP_Auth0_SocialAmplification_Widget.php
+++ b/lib/WP_Auth0_SocialAmplification_Widget.php
@@ -102,8 +102,10 @@ class WP_Auth0_SocialAmplification_Widget extends WP_Widget {
 			}
 
 			$providers = array();
-			foreach ( $user_profile->identities as $identity ) {
-				$providers[] = $identity->provider;
+			if ( ! empty( $user_profile->identities ) ) {
+				foreach ( $user_profile->identities as $identity ) {
+					$providers[] = $identity->provider;
+				}
 			}
 
 			$providers = array_intersect( array_unique( $providers ), $supportedProviders );


### PR DESCRIPTION
The `identities` property for the user profile can be empty but that was not checked in the widget output.