### PR TITLE
Fix migration token notice; replace domain with auth_domain

### DIFF
--- a/lib/WP_Auth0_Options.php
+++ b/lib/WP_Auth0_Options.php
@@ -64,7 +64,7 @@ class WP_Auth0_Options extends WP_Auth0_Options_Generic {
 			$this->get( 'client_secret', '' ),
 			$this->get( 'client_secret_b64_encoded', false ),
 			( $legacy ? false : $this->get_client_signing_algorithm() === 'RS256' ),
-			$this->get( 'domain' )
+			$this->get_auth_domain()
 		);
 	}
 

--- a/lib/admin/WP_Auth0_Admin_Advanced.php
+++ b/lib/admin/WP_Auth0_Admin_Advanced.php
@@ -360,7 +360,9 @@ class WP_Auth0_Admin_Advanced extends WP_Auth0_Admin_Generic {
 				$this->get_dashboard_link()
 			);
 			$this->render_field_description( 'Security token:' );
-			$this->render_const_notice( 'migration_token' );
+			if ( $this->options->has_constant_val( 'migration_token' ) ) {
+				$this->render_const_notice( 'migration_token' );
+			}
 			printf(
 				'<textarea class="code" rows="%d" disabled>%s</textarea>',
 				$this->_textarea_rows,


### PR DESCRIPTION
- Fix migration token constant notice
- Replace domain for `get_client_secret_as_key` with auth_domain (uses custom)