### PR TITLE
Standardize hook name

### DIFF
--- a/lib/WP_Auth0_Options_Generic.php
+++ b/lib/WP_Auth0_Options_Generic.php
@@ -52,7 +52,8 @@ class WP_Auth0_Options_Generic {
 	 * @return string
 	 */
 	public function get_constant_name( $key ) {
-		$constant_prefix = apply_filters( 'wp_auth0_settings_constant_prefix', 'AUTH0_ENV_' );
+		// NOTE: the add_filter call must load before WP_Auth0::init() so it cannot be used in a theme.
+		$constant_prefix = apply_filters( 'auth0_settings_constant_prefix', 'AUTH0_ENV_' );
 		return $constant_prefix . strtoupper( $key );
 	}
 

--- a/tests/testConstantSettings.php
+++ b/tests/testConstantSettings.php
@@ -65,7 +65,7 @@ class TestConstantSettings extends TestCase {
 		$this->assertEquals( self::DEFAULT_CONSTANT_PREFIX . 'DOMAIN', $opts->get_constant_name( $opt_name ) );
 
 		add_filter(
-			'wp_auth0_settings_constant_prefix', function( $prefix ) {
+			'auth0_settings_constant_prefix', function( $prefix ) {
 				return '__TEST_PREFIX_' . $prefix;
 			}, 10, 2
 		);


### PR DESCRIPTION
Removing the `wp_` prefix for the added hook. This has not been released yet so OK to change the name. 