### PR TITLE
Add skip strategies setting and tests

### DIFF
--- a/WP_Auth0.php
+++ b/WP_Auth0.php
@@ -530,9 +530,7 @@ $a0_plugin->init();
 if ( ! function_exists( 'get_auth0userinfo' ) ) {
 	function get_auth0userinfo( $user_id ) {
 
-		global $wpdb;
-
-		$profile = get_user_meta( $user_id, $wpdb->prefix . 'auth0_obj', true );
+		$profile = WP_Auth0_UsersRepo::get_meta( $user_id, 'auth0_obj' );
 
 		if ( $profile ) {
 			return WP_Auth0_Serializer::unserialize( $profile );
@@ -558,17 +556,15 @@ if ( ! function_exists( 'get_currentauth0userinfo' ) ) {
 if ( ! function_exists( 'get_currentauth0user' ) ) {
 	function get_currentauth0user() {
 
-		global $wpdb;
-
 		$current_user = wp_get_current_user();
 
-		$serialized_profile = get_user_meta( $current_user->ID, $wpdb->prefix . 'auth0_obj', true );
+		$serialized_profile = WP_Auth0_UsersRepo::get_meta( $current_user->ID, 'auth0_obj' );
 
 		$data = new stdClass;
 
 		$data->auth0_obj   = empty( $serialized_profile ) ? false : WP_Auth0_Serializer::unserialize( $serialized_profile );
-		$data->last_update = get_user_meta( $current_user->ID, $wpdb->prefix . 'last_update', true );
-		$data->auth0_id    = get_user_meta( $current_user->ID, $wpdb->prefix . 'auth0_id', true );
+		$data->last_update = WP_Auth0_UsersRepo::get_meta( $current_user->ID, 'last_update' );
+		$data->auth0_id    = WP_Auth0_UsersRepo::get_meta( $current_user->ID, 'auth0_id' );
 
 		return $data;
 	}

--- a/lib/WP_Auth0_DBManager.php
+++ b/lib/WP_Auth0_DBManager.php
@@ -431,7 +431,7 @@ class WP_Auth0_DBManager {
 		$repo = new WP_Auth0_UsersRepo( $this->a0_options );
 
 		foreach ( $userRows as $row ) {
-			$auth0_id = get_user_meta( $row->wp_id, $wpdb->prefix . 'auth0_id', true );
+			$auth0_id = WP_Auth0_UsersRepo::get_meta( $row->wp_id, 'auth0_id' );
 
 			if ( ! $auth0_id ) {
 				$repo->update_auth0_object( $row->wp_id, WP_Auth0_Serializer::unserialize( $row->auth0_obj ) );

--- a/lib/WP_Auth0_Export_Users.php
+++ b/lib/WP_Auth0_Export_Users.php
@@ -69,7 +69,8 @@ class WP_Auth0_Export_Users {
 		global $wpdb;
 
 		foreach ( $users as $user ) {
-			$profile = new WP_Auth0_UserProfile( get_user_meta( $user->ID, $wpdb->prefix . 'auth0_obj', true ) );
+			$auth0_obj = WP_Auth0_UsersRepo::get_meta( $user->ID, 'auth0_obj' );
+			$profile   = new WP_Auth0_UserProfile( $auth0_obj );
 
 			echo $this->process_str( $profile->get_email(), true );
 			echo $this->process_str( $profile->get_nickname(), true );

--- a/lib/WP_Auth0_Options.php
+++ b/lib/WP_Auth0_Options.php
@@ -179,6 +179,29 @@ class WP_Auth0_Options extends WP_Auth0_Options_Generic {
 	}
 
 	/**
+	 * Check if provided strategy is allowed to skip email verification.
+	 * Useful for Enterprise strategies that do not provide a email_verified profile value.
+	 *
+	 * @param string $strategy - Strategy to check against saved setting.
+	 *
+	 * @return bool
+	 *
+	 * @since 3.8.0
+	 */
+	public function strategy_skips_verified_email( $strategy ) {
+		$skip_strategies = trim( $this->get( 'skip_strategies' ) );
+
+		// No strategies to skip.
+		if ( empty( $skip_strategies ) ) {
+			return false;
+		}
+
+		$skip_strategies = explode( ',', $skip_strategies );
+		$skip_strategies = array_map( 'trim', $skip_strategies );
+		return in_array( $strategy, $skip_strategies );
+	}
+
+	/**
 	 * Default settings when plugin is installed or reset
 	 *
 	 * @return array
@@ -229,6 +252,7 @@ class WP_Auth0_Options extends WP_Auth0_Options_Generic {
 
 			// Advanced
 			'requires_verified_email'   => true,
+			'skip_strategies'           => '',
 			'remember_users_session'    => false,
 			'default_login_redirection' => home_url(),
 			'passwordless_enabled'      => false,

--- a/lib/admin/WP_Auth0_Admin_Advanced.php
+++ b/lib/admin/WP_Auth0_Admin_Advanced.php
@@ -233,9 +233,10 @@ class WP_Auth0_Admin_Advanced extends WP_Auth0_Admin_Generic {
 	 * @since 3.8.0
 	 */
 	public function render_skip_strategies( $args = array() ) {
-		$this->render_text_field( $args['label_for'], $args['opt_name'] );
+		$this->render_text_field( $args['label_for'], $args['opt_name'], 'text', 'e.g. "twitter,ldap"' );
 		$this->render_field_description(
 			__( 'Enter one or more strategies, separated by commas, to skip email verification. ', 'wp-auth0' ) .
+			__( 'You can find the strategy under the "Connection Name" field in the Auth0 dashboard. ', 'wp-auth0' ) .
 			__( 'Leave this field blank to require email for all strategies. ', 'wp-auth0' ) .
 			__( 'This could introduce a security risk and should be used sparingly, if at all', 'wp-auth0' )
 		);

--- a/lib/admin/WP_Auth0_Admin_Basic.php
+++ b/lib/admin/WP_Auth0_Admin_Basic.php
@@ -122,6 +122,8 @@ class WP_Auth0_Admin_Basic extends WP_Auth0_Admin_Generic {
 	 *
 	 * @see WP_Auth0_Admin_Generic::init_option_section()
 	 * @see add_settings_field()
+	 *
+	 * @since 3.7.0
 	 */
 	public function render_custom_domain( $args = array() ) {
 		$this->render_text_field( $args['label_for'], $args['opt_name'], 'text', 'login.yourdomain.com' );

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -41,3 +41,4 @@ require dirname( __FILE__ ) . '/../vendor/autoload.php';
 
 require dirname( __FILE__ ) . '/traits/domDocumentHelpers.php';
 require dirname( __FILE__ ) . '/traits/setUpTestDb.php';
+require dirname( __FILE__ ) . '/traits/users.php';

--- a/tests/testCustomDomains.php
+++ b/tests/testCustomDomains.php
@@ -19,6 +19,11 @@ class TestCustomDomains extends TestCase {
 	use domDocumentHelpers;
 
 	/**
+	 * DB settings name.
+	 */
+	const OPTIONS_NAME = 'wp_auth0_settings';
+
+	/**
 	 * Test the input HTML for the custom domain setting.
 	 */
 	public function testCustomDomainsFieldOutput() {
@@ -39,7 +44,7 @@ class TestCustomDomains extends TestCase {
 		$this->assertEquals( 1, $input->length );
 		$this->assertEquals( $field_args['label_for'], $input->item( 0 )->getAttribute( 'id' ) );
 		$this->assertEquals(
-			testWPAuth0Options::OPTIONS_NAME . '[' . $field_args['opt_name'] . ']',
+			self::OPTIONS_NAME . '[' . $field_args['opt_name'] . ']',
 			$input->item( 0 )->getAttribute( 'name' )
 		);
 		$this->assertEquals( 'text', $input->item( 0 )->getAttribute( 'type' ) );

--- a/tests/testRequiredEmail.php
+++ b/tests/testRequiredEmail.php
@@ -1,0 +1,197 @@
+<?php
+/**
+ * Contains Class TestRequiredEmail.
+ *
+ * @package WP-Auth0
+ * @since 3.8.0
+ */
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Class TestRequiredEmail.
+ * Tests that required email settings function properly.
+ */
+class TestRequiredEmail extends TestCase {
+
+	use setUpTestDb;
+
+	use domDocumentHelpers;
+
+	/**
+	 * Instance of WP_Auth0_Options.
+	 *
+	 * @var WP_Auth0_Options
+	 */
+	public static $opts;
+
+	/**
+	 * Instance of WP_Auth0_Admin_Advanced.
+	 *
+	 * @var WP_Auth0_Admin_Advanced
+	 */
+	public static $admin;
+
+	/**
+	 * DB settings name.
+	 */
+	const OPTIONS_NAME = 'wp_auth0_settings';
+
+	/**
+	 * Setup for entire test class.
+	 */
+	public static function setUpBeforeClass() {
+		parent::setUpBeforeClass();
+		self::$opts  = new WP_Auth0_Options();
+		$router      = new WP_Auth0_Routes( self::$opts );
+		self::$admin = new WP_Auth0_Admin_Advanced( self::$opts, $router );
+	}
+
+	/**
+	 * Test the input HTML for the custom domain setting.
+	 */
+	public function testRequiredEmailFieldOutput() {
+		$field_args = [
+			'label_for' => 'wpa0_verified_email',
+			'opt_name'  => 'requires_verified_email',
+		];
+
+		// Get the field HTML.
+		ob_start();
+		self::$admin->render_verified_email( $field_args );
+		$field_html = ob_get_clean();
+
+		// Check field HTML for required attributes.
+		$input = $this->getDomListFromTagName( $field_html, 'input' );
+		$this->assertEquals( 1, $input->length );
+		$this->assertEquals( $field_args['label_for'], $input->item( 0 )->getAttribute( 'id' ) );
+		$this->assertEquals(
+			self::OPTIONS_NAME . '[' . $field_args['opt_name'] . ']',
+			$input->item( 0 )->getAttribute( 'name' )
+		);
+		$this->assertEquals( 'checkbox', $input->item( 0 )->getAttribute( 'type' ) );
+
+		// Check that saving a custom domain appears in the field value.
+		$expected_value = 1;
+		self::$opts->set( $field_args['opt_name'], $expected_value );
+		$this->assertEquals( $expected_value, self::$opts->get( $field_args['opt_name'] ) );
+
+		// Get the field HTML.
+		ob_start();
+		self::$admin->render_verified_email( $field_args );
+		$field_html = ob_get_clean();
+
+		$input = $this->getDomListFromTagName( $field_html, 'input' );
+		$this->assertEquals( $expected_value, $input->item( 0 )->getAttribute( 'value' ) );
+	}
+
+	/**
+	 * Test that the required email field is properly validated.
+	 */
+	public function testRequiredEmailValidation() {
+		$opt_name = 'requires_verified_email';
+
+		$validated_opts = self::$admin->basic_validation( [], [ $opt_name => 1 ] );
+		$this->assertEquals( 1, $validated_opts[ $opt_name ] );
+
+		$validated_opts = self::$admin->basic_validation( [], [ $opt_name => true ] );
+		$this->assertEquals( 1, $validated_opts[ $opt_name ] );
+
+		$validated_opts = self::$admin->basic_validation( [], [] );
+		$this->assertEquals( 0, $validated_opts[ $opt_name ] );
+
+		$validated_opts = self::$admin->basic_validation( [], [ $opt_name => 0 ] );
+		$this->assertEquals( 0, $validated_opts[ $opt_name ] );
+
+		$validated_opts = self::$admin->basic_validation( [], [ $opt_name => '' ] );
+		$this->assertEquals( 0, $validated_opts[ $opt_name ] );
+	}
+
+	/**
+	 * Test the input HTML for the custom domain setting.
+	 */
+	public function testSkipStrategiesFieldOutput() {
+		$field_args = [
+			'label_for' => 'wpa0_skip_strategies',
+			'opt_name'  => 'skip_strategies',
+		];
+
+		// Get the field HTML.
+		ob_start();
+		self::$admin->render_skip_strategies( $field_args );
+		$field_html = ob_get_clean();
+
+		// Check field HTML for required attributes.
+		$input = $this->getDomListFromTagName( $field_html, 'input' );
+		$this->assertEquals( 1, $input->length );
+		$this->assertEquals( $field_args['label_for'], $input->item( 0 )->getAttribute( 'id' ) );
+		$this->assertEquals(
+			self::OPTIONS_NAME . '[' . $field_args['opt_name'] . ']',
+			$input->item( 0 )->getAttribute( 'name' )
+		);
+		$this->assertEquals( 'text', $input->item( 0 )->getAttribute( 'type' ) );
+
+		// Check that saving a custom domain appears in the field value.
+		$expected_value = 'auth0,twitter';
+		self::$opts->set( $field_args['opt_name'], $expected_value );
+		$this->assertEquals( $expected_value, self::$opts->get( $field_args['opt_name'] ) );
+
+		// Get the field HTML.
+		ob_start();
+		self::$admin->render_skip_strategies( $field_args );
+		$field_html = ob_get_clean();
+
+		$input = $this->getDomListFromTagName( $field_html, 'input' );
+		$this->assertEquals( $expected_value, $input->item( 0 )->getAttribute( 'value' ) );
+	}
+
+	/**
+	 * Test that the skip required email field is properly validated.
+	 */
+	public function testSkipRequiredEmailValidation() {
+		$opt_name = 'skip_strategies';
+
+		$validated_opts = self::$admin->basic_validation( [], [ $opt_name => '' ] );
+		$this->assertEquals( '', $validated_opts[ $opt_name ] );
+
+		$validated_opts = self::$admin->basic_validation( [], [ $opt_name => '  ' ] );
+		$this->assertEquals( '', $validated_opts[ $opt_name ] );
+
+		$validated_opts = self::$admin->basic_validation( [], [ $opt_name => 'auth0' ] );
+		$this->assertEquals( 'auth0', $validated_opts[ $opt_name ] );
+
+		$validated_opts = self::$admin->basic_validation( [], [ $opt_name => ' auth0 ' ] );
+		$this->assertEquals( 'auth0', $validated_opts[ $opt_name ] );
+
+		$validated_opts = self::$admin->basic_validation( [], [ $opt_name => 'auth0,twitter' ] );
+		$this->assertEquals( 'auth0,twitter', $validated_opts[ $opt_name ] );
+	}
+
+	/**
+	 * Test that the skip required email field is properly used.
+	 */
+	public function testSkipRequiredEmailOption() {
+		$opt_name = 'skip_strategies';
+
+		$this->assertFalse( self::$opts->strategy_skips_verified_email( null ) );
+		$this->assertFalse( self::$opts->strategy_skips_verified_email( '' ) );
+
+		self::$opts->set( $opt_name, '' );
+		$this->assertFalse( self::$opts->strategy_skips_verified_email( 'auth0' ) );
+		$this->assertFalse( self::$opts->strategy_skips_verified_email( 'twitter' ) );
+
+		self::$opts->set( $opt_name, 'auth0' );
+		$this->assertTrue( self::$opts->strategy_skips_verified_email( 'auth0' ) );
+		$this->assertFalse( self::$opts->strategy_skips_verified_email( 'twitter' ) );
+
+		self::$opts->set( $opt_name, 'auth0,twitter' );
+		$this->assertTrue( self::$opts->strategy_skips_verified_email( 'auth0' ) );
+		$this->assertTrue( self::$opts->strategy_skips_verified_email( 'twitter' ) );
+		$this->assertFalse( self::$opts->strategy_skips_verified_email( 'github' ) );
+
+		self::$opts->set( $opt_name, ' auth0, github ' );
+		$this->assertTrue( self::$opts->strategy_skips_verified_email( 'auth0' ) );
+		$this->assertFalse( self::$opts->strategy_skips_verified_email( 'twitter' ) );
+		$this->assertTrue( self::$opts->strategy_skips_verified_email( 'github' ) );
+	}
+}

--- a/tests/testUserMeta.php
+++ b/tests/testUserMeta.php
@@ -1,0 +1,124 @@
+<?php
+/**
+ * Contains Class TestUserMeta.
+ *
+ * @package WP-Auth0
+ * @since 3.8.0
+ */
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Class TestUserMeta.
+ * Tests that user meta is saved, retrieved, and deleted properly.
+ */
+class TestUserMeta extends TestCase {
+
+	use setUpTestDb;
+
+	use users;
+
+	/**
+	 * Instance of WP_Auth0_Options.
+	 *
+	 * @var WP_Auth0_Options
+	 */
+	public static $opts;
+
+	/**
+	 * Setup for entire test class.
+	 */
+	public static function setUpBeforeClass() {
+		parent::setUpBeforeClass();
+		self::$opts = WP_Auth0_Options::Instance();
+	}
+
+	/**
+	 * Test that Auth0 meta data is created and updated properly.
+	 */
+	public function testUpdateAuth0Meta() {
+		global $wpdb;
+
+		$user      = $this->createUser();
+		$uid       = $user->ID;
+		$user_repo = new WP_Auth0_UsersRepo( self::$opts );
+
+		$userinfo = $this->getUserinfo();
+		$user_repo->update_auth0_object( $uid, $userinfo );
+
+		$this->assertNotEmpty( get_user_meta( $uid, $wpdb->prefix . 'last_update', true ) );
+		$this->assertEquals( $userinfo->sub, get_user_meta( $uid, $wpdb->prefix . 'auth0_id', true ) );
+
+		// JSON-encoded object for complete Auth0 profile.
+		$saved_userinfo = get_user_meta( $uid, $wpdb->prefix . 'auth0_obj', true );
+		$saved_userinfo = json_decode( $saved_userinfo );
+
+		$this->assertInstanceOf( 'stdClass', $saved_userinfo );
+		$this->assertEquals( $userinfo->sub, $saved_userinfo->sub );
+		$this->assertEquals( $userinfo->name, $saved_userinfo->name );
+		$this->assertEquals( $userinfo->email, $saved_userinfo->email );
+
+		// Run through the process again to make sure we update with new data.
+		$userinfo_2 = $this->getUserinfo();
+		$user_repo->update_auth0_object( $uid, $userinfo_2 );
+
+		$this->assertEquals( $userinfo_2->sub, get_user_meta( $uid, $wpdb->prefix . 'auth0_id', true ) );
+
+		$saved_userinfo_2 = get_user_meta( $uid, $wpdb->prefix . 'auth0_obj', true );
+		$saved_userinfo_2 = json_decode( $saved_userinfo_2 );
+
+		$this->assertInstanceOf( 'stdClass', $saved_userinfo_2 );
+		$this->assertEquals( $userinfo_2->sub, $saved_userinfo_2->sub );
+		$this->assertEquals( $userinfo_2->name, $saved_userinfo_2->name );
+		$this->assertEquals( $userinfo_2->email, $saved_userinfo_2->email );
+	}
+
+	/**
+	 * Test that Auth0 meta data is created and updated properly.
+	 */
+	public function testGetAuth0Meta() {
+		global $wpdb;
+
+		$user      = $this->createUser();
+		$uid       = $user->ID;
+		$user_repo = new WP_Auth0_UsersRepo( self::$opts );
+		$user_repo->update_auth0_object( $uid, $this->getUserinfo() );
+
+		$this->assertEquals(
+			get_user_meta( $uid, $wpdb->prefix . 'auth0_id', true ),
+			WP_Auth0_UsersRepo::get_meta( $uid, 'auth0_id' )
+		);
+		$this->assertEquals(
+			get_user_meta( $uid, $wpdb->prefix . 'auth0_obj', true ),
+			WP_Auth0_UsersRepo::get_meta( $uid, 'auth0_obj' )
+		);
+		$this->assertEquals(
+			get_user_meta( $uid, $wpdb->prefix . 'last_update', true ),
+			WP_Auth0_UsersRepo::get_meta( $uid, 'last_update' )
+		);
+	}
+
+	/**
+	 * Test that Auth0 meta data is created and updated properly.
+	 */
+	public function testDeleteAuth0Meta() {
+		global $wpdb;
+
+		$user      = $this->createUser();
+		$uid       = $user->ID;
+		$user_repo = new WP_Auth0_UsersRepo( self::$opts );
+
+		$userinfo = $this->getUserinfo();
+		$user_repo->update_auth0_object( $uid, $userinfo );
+
+		$this->assertNotEmpty( get_user_meta( $uid, $wpdb->prefix . 'last_update', true ) );
+		$this->assertNotEmpty( get_user_meta( $uid, $wpdb->prefix . 'auth0_id', true ) );
+		$this->assertNotEmpty( get_user_meta( $uid, $wpdb->prefix . 'auth0_obj', true ) );
+
+		$user_repo->delete_auth0_object( $uid );
+
+		$this->assertEmpty( get_user_meta( $uid, $wpdb->prefix . 'last_update', true ) );
+		$this->assertEmpty( get_user_meta( $uid, $wpdb->prefix . 'auth0_id', true ) );
+		$this->assertEmpty( get_user_meta( $uid, $wpdb->prefix . 'auth0_obj', true ) );
+	}
+}

--- a/tests/testUserRepoCreate.php
+++ b/tests/testUserRepoCreate.php
@@ -1,0 +1,208 @@
+<?php
+/**
+ * Contains Class TestUserRepoCreate.
+ *
+ * @package WP-Auth0
+ * @since 3.8.0
+ */
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Class TestUserRepoCreate.
+ * Tests that users are created and joined properly.
+ */
+class TestUserRepoCreate extends TestCase {
+
+	use setUpTestDb;
+
+	use users;
+
+	/**
+	 * Instance of WP_Auth0_Options.
+	 *
+	 * @var WP_Auth0_Options
+	 */
+	public static $opts;
+
+	/**
+	 * Instance of WP_Auth0_UsersRepo.
+	 *
+	 * @var WP_Auth0_UsersRepo
+	 */
+	public static $repo;
+
+	/**
+	 * Dummy ID token to use during user creation.
+	 *
+	 * @var string
+	 */
+	const TOKEN = '__test_ID_token__';
+
+	/**
+	 * Setup for entire test class.
+	 */
+	public static function setUpBeforeClass() {
+		parent::setUpBeforeClass();
+		self::$opts = WP_Auth0_Options::Instance();
+		self::$repo = new WP_Auth0_UsersRepo( self::$opts );
+	}
+
+	/**
+	 * Test that a user without a verified email is rejected.
+	 *
+	 * @throws WP_Auth0_CouldNotCreateUserException - WP registration rejected.
+	 * @throws WP_Auth0_EmailNotVerifiedException - Verified email is required.
+	 * @throws WP_Auth0_RegistrationNotEnabledException - User registration is turned off in WP.
+	 */
+	public function testRequiredEmailRejected() {
+		$userinfo = $this->getUserinfo( 'auth0' );
+		$this->createUser( $userinfo->email );
+
+		// Require a verified email.
+		self::$opts->set( 'requires_verified_email', 1 );
+
+		$this->expectException( WP_Auth0_EmailNotVerifiedException::class );
+		self::$repo->create( $userinfo, self::TOKEN );
+	}
+
+	/**
+	 * Test that an existing user with a different Auth0 sub is rejected.
+	 *
+	 * @throws WP_Auth0_CouldNotCreateUserException - WP registration rejected.
+	 * @throws WP_Auth0_EmailNotVerifiedException - Verified email is required.
+	 * @throws WP_Auth0_RegistrationNotEnabledException - User registration is turned off in WP.
+	 */
+	public function testUserAlreadyExistsRejected() {
+		$userinfo = $this->getUserinfo();
+		$user     = $this->createUser( $userinfo->email );
+		self::$repo->update_auth0_object( $user->ID, $userinfo );
+
+		// Require a verified email.
+		self::$opts->set( 'requires_verified_email', 1 );
+
+		// Modify the Auth0 sub so we get a mis-match.
+		$userinfo->sub .= uniqid();
+
+		// Make the email verified to pass the check.
+		$userinfo->email_verified = 1;
+
+		$this->expectException( WP_Auth0_CouldNotCreateUserException::class );
+		self::$repo->create( $userinfo, self::TOKEN );
+	}
+
+	/**
+	 * Test that signup is rejected if user registration is turned off (default).
+	 *
+	 * @throws WP_Auth0_CouldNotCreateUserException - WP registration rejected.
+	 * @throws WP_Auth0_EmailNotVerifiedException - Verified email is required.
+	 * @throws WP_Auth0_RegistrationNotEnabledException - User registration is turned off in WP.
+	 */
+	public function testSignupNotAllowedRejected() {
+		$this->expectException( WP_Auth0_RegistrationNotEnabledException::class );
+		self::$repo->create( $this->getUserinfo(), self::TOKEN );
+	}
+
+	/**
+	 * Test that a core WP rejection happens with invalid new user data.
+	 *
+	 * @throws WP_Auth0_CouldNotCreateUserException - WP registration rejected.
+	 * @throws WP_Auth0_EmailNotVerifiedException - Verified email is required.
+	 * @throws WP_Auth0_RegistrationNotEnabledException - User registration is turned off in WP.
+	 */
+	public function testUserCouldNotBeCreatedRejected() {
+		$userinfo = $this->getUserinfo();
+
+		// Crate a username that's too long (> 60 characters).
+		$userinfo->username = uniqid() . uniqid() . uniqid() . uniqid() . uniqid();
+
+		// Turn on user registration.
+		update_option( 'users_can_register', 1 );
+
+		$this->expectException( WP_Auth0_CouldNotCreateUserException::class );
+		self::$repo->create( $userinfo, self::TOKEN );
+	}
+
+	/**
+	 * Test that the wpa0_should_create_user can prevent user signups.
+	 *
+	 * @throws WP_Auth0_CouldNotCreateUserException - WP registration rejected.
+	 * @throws WP_Auth0_EmailNotVerifiedException - Verified email is required.
+	 * @throws WP_Auth0_RegistrationNotEnabledException - User registration is turned off in WP.
+	 */
+	public function testShouldCreateUserFilterRejected() {
+		$userinfo = $this->getUserinfo();
+
+		// Turn on user registration.
+		update_option( 'users_can_register', 1 );
+
+		add_filter(
+			'wpa0_should_create_user', function() {
+				return false;
+			}, 10
+		);
+
+		$this->expectException( WP_Auth0_CouldNotCreateUserException::class );
+		self::$repo->create( $userinfo, self::TOKEN );
+	}
+
+	/**
+	 * Test that an Auth0 user can be joined with an existing WP one is email verification is turned off.
+	 *
+	 * @throws WP_Auth0_CouldNotCreateUserException - WP registration rejected.
+	 * @throws WP_Auth0_EmailNotVerifiedException - Verified email is required.
+	 * @throws WP_Auth0_RegistrationNotEnabledException - User registration is turned off in WP.
+	 */
+	public function testJoinUserEmailVerificationOff() {
+		$userinfo = $this->getUserinfo();
+		$user     = $this->createUser( $userinfo->email );
+
+		// Require a verified email.
+		self::$opts->set( 'requires_verified_email', 0 );
+
+		$expected_uid = self::$repo->create( $userinfo, self::TOKEN );
+		$this->assertEquals( $expected_uid, $user->ID );
+	}
+
+	/**
+	 * Test that an Auth0 user can be joined with an existing WP one is email verification is turned on.
+	 *
+	 * @throws WP_Auth0_CouldNotCreateUserException - WP registration rejected.
+	 * @throws WP_Auth0_EmailNotVerifiedException - Verified email is required.
+	 * @throws WP_Auth0_RegistrationNotEnabledException - User registration is turned off in WP.
+	 */
+	public function testJoinUserEmailVerified() {
+		$userinfo = $this->getUserinfo();
+		$user     = $this->createUser( $userinfo->email );
+
+		// Require a verified email.
+		self::$opts->set( 'requires_verified_email', 1 );
+
+		// Make the email verified to pass the check.
+		$userinfo->email_verified = 1;
+
+		$expected_uid = self::$repo->create( $userinfo, self::TOKEN );
+		$this->assertEquals( $expected_uid, $user->ID );
+	}
+
+	/**
+	 * Test that a new user can be created if their strategy is skipped.
+	 *
+	 * @throws WP_Auth0_CouldNotCreateUserException - WP registration rejected.
+	 * @throws WP_Auth0_EmailNotVerifiedException - Verified email is required.
+	 * @throws WP_Auth0_RegistrationNotEnabledException - User registration is turned off in WP.
+	 */
+	public function testJoinUserSkipStrategy() {
+		$userinfo = $this->getUserinfo( 'auth0' );
+		$user     = $this->createUser( $userinfo->email );
+
+		// Require a verified email.
+		self::$opts->set( 'requires_verified_email', 1 );
+
+		// Skip the auth0 strategy.
+		self::$opts->set( 'skip_strategies', 'auth0' );
+
+		$expected_uid = self::$repo->create( $userinfo, self::TOKEN );
+		$this->assertEquals( $expected_uid, $user->ID );
+	}
+}

--- a/tests/testWPAuth0Options.php
+++ b/tests/testWPAuth0Options.php
@@ -25,7 +25,10 @@ class TestWPAuth0Options extends TestCase {
 	 */
 	const OPTIONS_NAME = 'wp_auth0_settings';
 
-	const DEFAULT_OPTIONS_COUNT = 67;
+	/**
+	 * Total number of options.
+	 */
+	const DEFAULT_OPTIONS_COUNT = 68;
 
 	/**
 	 * Test the basic options functionality.

--- a/tests/traits/users.php
+++ b/tests/traits/users.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * Contains Trait Users.
+ *
+ * @package WP-Auth0
+ * @since 3.8.0
+ */
+
+/**
+ * Trait Users.
+ */
+trait Users {
+
+	/**
+	 * Create a new User.
+	 *
+	 * @param null $email - Email to use, default is used if none provided.
+	 *
+	 * @return null|object|stdClass
+	 */
+	public function createUser( $email = null ) {
+		$username = 'test_new_user' . uniqid();
+		$user     = wp_insert_user(
+			[
+				'user_login' => $username,
+				'user_email' => $email ? $email : $username . '@example.com',
+				'user_pass'  => uniqid(),
+			]
+		);
+
+		return is_wp_error( $user ) ? null : get_user_by( 'id', $user )->data;
+	}
+
+	/**
+	 * Create a userinfo object.
+	 *
+	 * @param string $strategy - Strategy to use for the sub.
+	 *
+	 * @return stdClass
+	 */
+	public function getUserinfo( $strategy = 'test-strategy' ) {
+		$name            = 'test_new_user' . uniqid();
+		$userinfo        = new stdClass();
+		$userinfo->sub   = $strategy . '|' . uniqid();
+		$userinfo->name  = $name;
+		$userinfo->email = $name . '@example.com';
+		return $userinfo;
+	}
+}


### PR DESCRIPTION
**Summary:** Add a setting to the admin that skips email verification for specific strategies. This is being added based on Enterprise strategies that do not provide an `email_verified` flag in the userinfo object. 

**Admin Setting:**

![screenshot 2018-08-29 12 52 34](https://user-images.githubusercontent.com/855223/44811805-6b5e9f80-ab8a-11e8-8036-de4846e15b93.png)

**Specific Changes:**

- Add the `WP_Auth0_UsersRepo::get_meta()` method to abstract getting Auth0 user meta information; refactored all current uses of the core `get_user_meta()` function to use this new method.
- Refactor `WP_Auth0_LoginManager::login_user()` to use the new skip strategies field. 
- Add `WP_Auth0_Options::strategy_skips_verified_email()` method to check whether a specific strategy can be skipped. 
- Refactor `WP_Auth0_UsersRepo::create()` to use the new skip strategies field and simplify logic. 
- Add tests for all new functionality and `WP_Auth0_UsersRepo::create()`

