### PR TITLE
Deprecate unused methods and classes for initial setup

### DIFF
--- a/lib/initial-setup/WP_Auth0_InitialSetup_Connections.php
+++ b/lib/initial-setup/WP_Auth0_InitialSetup_Connections.php
@@ -12,10 +12,28 @@ class WP_Auth0_InitialSetup_Connections {
 		include WPA0_PLUGIN_DIR . 'templates/initial-setup/connections.php';
 	}
 
+	public function callback() {
+		wp_redirect( admin_url( 'admin.php?page=wpa0-setup&step=5' ) );
+	}
+
+	public function add_validation_error( $error ) {
+		wp_redirect(
+			admin_url(
+				'admin.php?page=wpa0-setup&step=5&error=' .
+				urlencode( 'There was an error setting up your connections.' )
+			)
+		);
+		exit;
+	}
+
 	/**
-	 * TODO: Deprecate, not used
+	 * @deprecated - 3.8.0, not used and no replacement provided.
+	 *
+	 * @codeCoverageIgnore - Deprecated
 	 */
 	public function update_connection() {
+		// phpcs:ignore
+		trigger_error( sprintf( __( 'Method %s is deprecated.', 'wp-auth0' ), __METHOD__ ), E_USER_DEPRECATED );
 
 		$provider_name = $_POST['connection'];
 
@@ -27,9 +45,13 @@ class WP_Auth0_InitialSetup_Connections {
 	}
 
 	/**
-	 * TODO: Deprecate when self::update_connection() is deprecated
+	 * @deprecated - 3.8.0, not used and no replacement provided.
+	 *
+	 * @codeCoverageIgnore - Deprecated
 	 */
 	protected function toggle_db() {
+		// phpcs:ignore
+		trigger_error( sprintf( __( 'Method %s is deprecated.', 'wp-auth0' ), __METHOD__ ), E_USER_DEPRECATED );
 
 		$domain        = $this->a0_options->get( 'domain' );
 		$app_token     = $this->a0_options->get( 'auth0_app_token' );
@@ -61,9 +83,13 @@ class WP_Auth0_InitialSetup_Connections {
 	}
 
 	/**
-	 * TODO: Deprecate when self::update_connection() is deprecated
+	 * @deprecated - 3.8.0, not used and no replacement provided.
+	 *
+	 * @codeCoverageIgnore - Deprecated
 	 */
 	protected function toggle_social( $provider_name ) {
+		// phpcs:ignore
+		trigger_error( sprintf( __( 'Method %s is deprecated.', 'wp-auth0' ), __METHOD__ ), E_USER_DEPRECATED );
 
 		$provider_options = array(
 			'facebook'      => array(
@@ -106,20 +132,6 @@ class WP_Auth0_InitialSetup_Connections {
 			$this->a0_options->set_connection( $key, $value );
 		}
 
-		exit;
-	}
-
-	public function callback() {
-		wp_redirect( admin_url( 'admin.php?page=wpa0-setup&step=5' ) );
-	}
-
-	public function add_validation_error( $error ) {
-		wp_redirect(
-			admin_url(
-				'admin.php?page=wpa0-setup&step=5&error=' .
-				urlencode( 'There was an error setting up your connections.' )
-			)
-		);
 		exit;
 	}
 }

--- a/lib/initial-setup/WP_Auth0_InitialSetup_Migration.php
+++ b/lib/initial-setup/WP_Auth0_InitialSetup_Migration.php
@@ -1,12 +1,20 @@
 <?php
 /**
- * TODO: Deprecate, not used
+ * @deprecated - 3.8.0, not used and no replacement provided.
+ *
+ * @codeCoverageIgnore - Deprecated
  */
 class WP_Auth0_InitialSetup_Migration {
 
 	protected $a0_options;
 
+	/**
+	 * @deprecated - 3.8.0, not used and no replacement provided.
+	 */
 	public function __construct( WP_Auth0_Options $a0_options ) {
+		// phpcs:ignore
+		trigger_error( sprintf( __( 'Method %s is deprecated.', 'wp-auth0' ), __METHOD__ ), E_USER_DEPRECATED );
+
 		$this->a0_options = $a0_options;
 	}
 

--- a/lib/initial-setup/WP_Auth0_InitialSetup_Rules.php
+++ b/lib/initial-setup/WP_Auth0_InitialSetup_Rules.php
@@ -1,12 +1,20 @@
 <?php
 /**
- * TODO: Deprecate, not used
+ * @deprecated - 3.8.0, not used and no replacement provided.
+ *
+ * @codeCoverageIgnore - Deprecated
  */
 class WP_Auth0_InitialSetup_Rules {
 
 	protected $a0_options;
 
+	/**
+	 * @deprecated - 3.8.0, not used and no replacement provided.
+	 */
 	public function __construct( WP_Auth0_Options $a0_options ) {
+		// phpcs:ignore
+		trigger_error( sprintf( __( 'Method %s is deprecated.', 'wp-auth0' ), __METHOD__ ), E_USER_DEPRECATED );
+
 		$this->a0_options = $a0_options;
 	}
 


### PR DESCRIPTION
Deprecation docblocks and error triggering for unused methods and classes related to initial setup. Also moved all deprecated methods to the bottom of the class.

**No functional changes 👍**