### PR TITLE
Deprecate methods in WP_Auth0_Api_Operations and related ones in WP_Auth0

### DIFF
--- a/WP_Auth0.php
+++ b/WP_Auth0.php
@@ -186,44 +186,6 @@ class WP_Auth0 {
 	}
 
 	/**
-	 * TODO: Deprecate, no longer used
-	 *
-	 * Checks it it should update the database connection no enable or disable signups and create or delete
-	 * the rule that will disable social signups.
-	 */
-	function check_signup_status() {
-		$app_token = $this->a0_options->get( 'auth0_app_token' );
-
-		if ( $app_token ) {
-			$disable_signup_rule        = $this->a0_options->get( 'disable_signup_rule' );
-			$is_wp_registration_enabled = $this->a0_options->is_wp_registration_enabled();
-
-			if ( $is_wp_registration_enabled != $this->a0_options->get( 'registration_enabled' ) ) {
-					$this->a0_options->set( 'registration_enabled', $is_wp_registration_enabled );
-
-					$operations = new WP_Auth0_Api_Operations( $this->a0_options );
-
-					$operations->disable_signup_wordpress_connection( $app_token, ! $is_wp_registration_enabled );
-
-					$rule_name = WP_Auth0_RulesLib::$disable_social_signup['name'] . '-' . get_bloginfo( 'name' );
-
-					$rule_script = WP_Auth0_RulesLib::$disable_social_signup['script'];
-					$rule_script = str_replace( 'REPLACE_WITH_YOUR_CLIENT_ID', $this->a0_options->get( 'client_id' ), $rule_script );
-
-				try {
-					if ( $is_wp_registration_enabled && $disable_signup_rule === null ) {
-						return;
-					}
-					$disable_signup_rule = $operations->toggle_rule( $app_token, ( $is_wp_registration_enabled ? $disable_signup_rule : null ), $rule_name, $rule_script );
-					$this->a0_options->set( 'disable_signup_rule', $disable_signup_rule );
-				} catch ( Exception $e ) {
-
-				}
-			}
-		}
-	}
-
-	/**
 	 * Filter the avatar to use the Auth0 profile image
 	 *
 	 * @param string                                $avatar - avatar HTML
@@ -298,18 +260,6 @@ class WP_Auth0 {
 		}
 	}
 
-	/**
-	 *
-	 * @deprecated 3.6.0 - Use WPA0_PLUGIN_URL constant
-	 *
-	 * @return string
-	 */
-	public static function get_plugin_dir_url() {
-		// phpcs:ignore
-		trigger_error( sprintf( __( 'Method %s is deprecated.', 'wp-auth0' ), __METHOD__ ), E_USER_DEPRECATED );
-		return WPA0_PLUGIN_URL;
-	}
-
 	public function a0_register_query_vars( $qvars ) {
 		$qvars[] = 'error';
 		$qvars[] = 'error_description';
@@ -321,6 +271,7 @@ class WP_Auth0 {
 		return $qvars;
 	}
 
+	// TODO: Deprecate, not used
 	public function a0_render_message() {
 		$message = null;
 
@@ -452,7 +403,6 @@ class WP_Auth0 {
 		$this->router->setup_rewrites();
 	}
 
-
 	public function install() {
 		$this->db_manager->install_db();
 		$this->router->setup_rewrites();
@@ -536,6 +486,68 @@ class WP_Auth0 {
 		}
 
 		return false;
+	}
+
+	/*
+	 *
+	 * DEPRECATED
+	 *
+	 */
+
+	/**
+	 * @deprecated - 3.8.0, not used and no replacement provided.
+	 *
+	 * Checks it it should update the database connection no enable or disable signups and create or delete
+	 * the rule that will disable social signups.
+	 *
+	 * @codeCoverageIgnore - Deprecated
+	 */
+	public function check_signup_status() {
+		// phpcs:ignore
+		trigger_error( sprintf( __( 'Method %s is deprecated.', 'wp-auth0' ), __METHOD__ ), E_USER_DEPRECATED );
+
+		$app_token = $this->a0_options->get( 'auth0_app_token' );
+
+		if ( $app_token ) {
+			$disable_signup_rule        = $this->a0_options->get( 'disable_signup_rule' );
+			$is_wp_registration_enabled = $this->a0_options->is_wp_registration_enabled();
+
+			if ( $is_wp_registration_enabled != $this->a0_options->get( 'registration_enabled' ) ) {
+				$this->a0_options->set( 'registration_enabled', $is_wp_registration_enabled );
+
+				$operations = new WP_Auth0_Api_Operations( $this->a0_options );
+
+				$operations->disable_signup_wordpress_connection( $app_token, ! $is_wp_registration_enabled );
+
+				$rule_name = WP_Auth0_RulesLib::$disable_social_signup['name'] . '-' . get_bloginfo( 'name' );
+
+				$rule_script = WP_Auth0_RulesLib::$disable_social_signup['script'];
+				$rule_script = str_replace( 'REPLACE_WITH_YOUR_CLIENT_ID', $this->a0_options->get( 'client_id' ), $rule_script );
+
+				try {
+					if ( $is_wp_registration_enabled && $disable_signup_rule === null ) {
+						return;
+					}
+					$disable_signup_rule = $operations->toggle_rule( $app_token, ( $is_wp_registration_enabled ? $disable_signup_rule : null ), $rule_name, $rule_script );
+					$this->a0_options->set( 'disable_signup_rule', $disable_signup_rule );
+				} catch ( Exception $e ) {
+
+				}
+			}
+		}
+	}
+
+	/**
+	 * @deprecated 3.6.0 - Use WPA0_PLUGIN_URL constant
+	 *
+	 * @return string
+	 *
+	 * @codeCoverageIgnore - Deprecated
+	 */
+	public static function get_plugin_dir_url() {
+		// phpcs:ignore
+		trigger_error( sprintf( __( 'Method %s is deprecated.', 'wp-auth0' ), __METHOD__ ), E_USER_DEPRECATED );
+		return WPA0_PLUGIN_URL;
 	}
 }
 

--- a/lib/WP_Auth0_Api_Operations.php
+++ b/lib/WP_Auth0_Api_Operations.php
@@ -7,35 +7,6 @@ class WP_Auth0_Api_Operations {
 		$this->a0_options = $a0_options;
 	}
 
-	/**
-	 * TODO: Deprecate, no longer used
-	 */
-	public function disable_signup_wordpress_connection( $app_token, $disable_signup ) {
-		$domain    = $this->a0_options->get( 'domain' );
-		$client_id = $this->a0_options->get( 'client_id' );
-
-		$connections = WP_Auth0_Api_Client::search_connection( $domain, $app_token, 'auth0' );
-
-		if ( $connections === false ) {
-			return;
-		}
-
-		foreach ( $connections as $connection ) {
-
-			if ( in_array( $client_id, $connection->enabled_clients ) ) {
-				$connection->options->disable_signup = $disable_signup;
-				$connection_id                       = $connection->id;
-
-				unset( $connection->name );
-				unset( $connection->strategy );
-				unset( $connection->id );
-
-				WP_Auth0_Api_Client::update_connection( $domain, $app_token, $connection_id, $connection );
-			}
-		}
-
-	}
-
 	public function update_wordpress_connection( $app_token, $connection_id, $password_policy, $migration_token ) {
 
 		$domain = $this->a0_options->get( 'domain' );
@@ -155,8 +126,72 @@ class WP_Auth0_Api_Operations {
 		return $migration_connection_id;
 	}
 
+	// $input['geo_rule'] = ( isset( $input['geo_rule'] ) ? $input['geo_rule'] : 0 );
+	// $enable = ($old_options['geo_rule'] == null && 1 == $input['geo_rule'])
+	public function toggle_rule( $app_token, $rule_id, $rule_name, $rule_script ) {
+
+		$domain = $this->a0_options->get( 'domain' );
+
+		if ( is_null( $rule_id ) ) {
+			$rule = WP_Auth0_Api_Client::create_rule( $domain, $app_token, $rule_name, $rule_script );
+
+			if ( $rule === false ) {
+				$error = __( 'There was an error creating the Auth0 rule. You can do it manually from your Auth0 dashboard.', 'wp-auth0' );
+				throw new Exception( $error );
+			} else {
+				return $rule->id;
+			}
+		} else {
+			if ( false === WP_Auth0_Api_Client::delete_rule( $domain, $app_token, $rule_id ) ) {
+				$error = __( 'There was an error deleting the Auth0 rule. You can do it manually from your Auth0 dashboard.', 'wp-auth0' );
+				throw new Exception( $error );
+			}
+			return null;
+		}
+	}
+
+	/*
+	 *
+	 * DEPRECATED
+	 *
+	 */
+
 	/**
-	 * TODO: Deprecate when WP_Auth0_InitialSetup_Connections::toggle_social() is deprecated
+	 * @deprecated - 3.8.0, not used and no replacement provided.
+	 *
+	 * @codeCoverageIgnore - Deprecated
+	 */
+	public function disable_signup_wordpress_connection( $app_token, $disable_signup ) {
+		// phpcs:ignore
+		trigger_error( sprintf( __( 'Method %s is deprecated.', 'wp-auth0' ), __METHOD__ ), E_USER_DEPRECATED );
+
+		$domain    = $this->a0_options->get( 'domain' );
+		$client_id = $this->a0_options->get( 'client_id' );
+
+		$connections = WP_Auth0_Api_Client::search_connection( $domain, $app_token, 'auth0' );
+
+		if ( $connections === false ) {
+			return;
+		}
+
+		foreach ( $connections as $connection ) {
+
+			if ( in_array( $client_id, $connection->enabled_clients ) ) {
+				$connection->options->disable_signup = $disable_signup;
+				$connection_id                       = $connection->id;
+
+				unset( $connection->name );
+				unset( $connection->strategy );
+				unset( $connection->id );
+
+				WP_Auth0_Api_Client::update_connection( $domain, $app_token, $connection_id, $connection );
+			}
+		}
+
+	}
+
+	/**
+	 * @deprecated - 3.8.0, not used and no replacement provided.
 	 *
 	 * This function will sync and update the connection setting with auth0
 	 * First it checks if there is any connection with this strategy enabled for the app.
@@ -167,8 +202,13 @@ class WP_Auth0_Api_Operations {
 	 *
 	 * In the case that the user disable the connection on WP, it check if there is an active connection with the client_id.
 	 * - If exists, it will remove the client_id and if there is no other client_id it will delete the connection.
+	 *
+	 * @codeCoverageIgnore - Deprecated
 	 */
 	public function social_validation( $app_token, $old_options, $input, $strategy, $connection_options ) {
+		// phpcs:ignore
+		trigger_error( sprintf( __( 'Method %s is deprecated.', 'wp-auth0' ), __METHOD__ ), E_USER_DEPRECATED );
+
 		$domain    = $this->a0_options->get( 'domain' );
 		$client_id = $this->a0_options->get( 'client_id' );
 
@@ -220,8 +260,8 @@ class WP_Auth0_Api_Operations {
 			if ( $input[ $main_key ] ) {
 
 				if ( $selected_connection &&
-					( empty( $selected_connection->options->client_id ) || ( empty( $input[ "{$main_key}_key" ] ) && empty( $old_input[ "{$main_key}_key" ] ) ) || $selected_connection->options->client_id === $input[ "{$main_key}_key" ] ) &&
-					( empty( $selected_connection->options->client_secret ) || ( empty( $input[ "{$main_key}_secret" ] ) && empty( $old_input[ "{$main_key}_secret" ] ) ) || $selected_connection->options->client_secret === $input[ "{$main_key}_secret" ] ) ) {
+					 ( empty( $selected_connection->options->client_id ) || ( empty( $input[ "{$main_key}_key" ] ) && empty( $old_input[ "{$main_key}_key" ] ) ) || $selected_connection->options->client_id === $input[ "{$main_key}_key" ] ) &&
+					 ( empty( $selected_connection->options->client_secret ) || ( empty( $input[ "{$main_key}_secret" ] ) && empty( $old_input[ "{$main_key}_secret" ] ) ) || $selected_connection->options->client_secret === $input[ "{$main_key}_secret" ] ) ) {
 
 					$data = array(
 						'options'         => $connection_options,
@@ -244,14 +284,14 @@ class WP_Auth0_Api_Operations {
 						return $input;
 					}
 				} elseif ( $selected_connection && ! empty( $selected_connection->options->client_id ) && ! empty( $selected_connection->options->client_secret )
-					&& ! empty( $input[ "{$main_key}_key" ] ) && ! empty( $input[ "{$main_key}_secret" ] ) ) {
+						   && ! empty( $input[ "{$main_key}_key" ] ) && ! empty( $input[ "{$main_key}_secret" ] ) ) {
 
 					$input[ "{$main_key}_key" ]    = $selected_connection->options->client_id;
 					$input[ "{$main_key}_secret" ] = $selected_connection->options->client_secret;
 
 					$error  = __( 'The connection has already set an API key and secret and can not be overridden. ', 'wp-auth0' );
 					$error .= '<a href="https://manage.auth0.com/#/connections/social">' .
-						__( 'Please update them in the Auth0 dashboard. ', 'wp-auth0' ) . '</a>';
+							  __( 'Please update them in the Auth0 dashboard. ', 'wp-auth0' ) . '</a>';
 
 					throw new Exception( $error );
 
@@ -318,30 +358,5 @@ class WP_Auth0_Api_Operations {
 
 		return $input;
 	}
-
-	// $input['geo_rule'] = ( isset( $input['geo_rule'] ) ? $input['geo_rule'] : 0 );
-	// $enable = ($old_options['geo_rule'] == null && 1 == $input['geo_rule'])
-	public function toggle_rule( $app_token, $rule_id, $rule_name, $rule_script ) {
-
-		$domain = $this->a0_options->get( 'domain' );
-
-		if ( is_null( $rule_id ) ) {
-			$rule = WP_Auth0_Api_Client::create_rule( $domain, $app_token, $rule_name, $rule_script );
-
-			if ( $rule === false ) {
-				$error = __( 'There was an error creating the Auth0 rule. You can do it manually from your Auth0 dashboard.', 'wp-auth0' );
-				throw new Exception( $error );
-			} else {
-				return $rule->id;
-			}
-		} else {
-			if ( false === WP_Auth0_Api_Client::delete_rule( $domain, $app_token, $rule_id ) ) {
-				$error = __( 'There was an error deleting the Auth0 rule. You can do it manually from your Auth0 dashboard.', 'wp-auth0' );
-				throw new Exception( $error );
-			}
-			return null;
-		}
-	}
-
 
 }

--- a/lib/initial-setup/WP_Auth0_InitialSetup_Rules.php
+++ b/lib/initial-setup/WP_Auth0_InitialSetup_Rules.php
@@ -10,6 +10,8 @@ class WP_Auth0_InitialSetup_Rules {
 
 	/**
 	 * @deprecated - 3.8.0, not used and no replacement provided.
+	 *
+	 * @codeCoverageIgnore - Deprecated
 	 */
 	public function __construct( WP_Auth0_Options $a0_options ) {
 		// phpcs:ignore


### PR DESCRIPTION
Deprecation docblocks and error triggering for unused methods in the `WP_Auth0_Api_Operations` and `WP_Auth0` classes. Also moved all deprecated methods to the bottom of the class.

**No functional changes 👍**