### PR TITLE
Deprecate WP_Auth0_Metrics

### DIFF
--- a/lib/WP_Auth0_Metrics.php
+++ b/lib/WP_Auth0_Metrics.php
@@ -1,10 +1,20 @@
 <?php
-// TODO: Deprecate
+/**
+ * @deprecated - 3.8.0, not used and no replacement provided.
+ *
+ * @codeCoverageIgnore - Deprecated
+ */
 class WP_Auth0_Metrics {
 
 	protected $a0_options;
 
+	/**
+	 * @deprecated - 3.8.0, not used and no replacement provided.
+	 */
 	public function __construct( WP_Auth0_Options $a0_options ) {
+		// phpcs:ignore
+		trigger_error( sprintf( __( 'Method %s is deprecated.', 'wp-auth0' ), __METHOD__ ), E_USER_DEPRECATED );
+
 		$this->a0_options = $a0_options;
 	}
 


### PR DESCRIPTION
Deprecation docblocks and error triggering for the unused `WP_Auth0_Metrics` class.

**No functional changes 👍**