### PR TITLE
Deprecate unused login methods and props

### DIFF
--- a/lib/WP_Auth0_LoginManager.php
+++ b/lib/WP_Auth0_LoginManager.php
@@ -24,7 +24,7 @@ class WP_Auth0_LoginManager {
 	/**
 	 * Should the new user have an administrator role?
 	 *
-	 * TODO: Deprecate, not used
+	 * @deprecated - 3.8.0
 	 *
 	 * @var bool|null
 	 */
@@ -33,7 +33,7 @@ class WP_Auth0_LoginManager {
 	/**
 	 * Ignore verified email requirement in Settings > Advanced.
 	 *
-	 * TODO: Deprecate, not used
+	 * @deprecated - 3.8.0
 	 *
 	 * @var bool
 	 */
@@ -51,8 +51,8 @@ class WP_Auth0_LoginManager {
 	 *
 	 * @param WP_Auth0_UsersRepo    $users_repo - see member variable doc comment.
 	 * @param WP_Auth0_Options|null $a0_options - see member variable doc comment.
-	 * @param null|bool             $admin_role - see member variable doc comment.
-	 * @param bool                  $ignore_unverified_email - see member variable doc comment.
+	 * @param null|bool             $admin_role - @deprecated - 3.8.0.
+	 * @param bool                  $ignore_unverified_email - @deprecated - 3.8.0.
 	 */
 	public function __construct(
 		WP_Auth0_UsersRepo $users_repo,
@@ -60,14 +60,23 @@ class WP_Auth0_LoginManager {
 		$admin_role = null,
 		$ignore_unverified_email = false
 	) {
-		$this->admin_role              = $admin_role;
-		$this->ignore_unverified_email = $ignore_unverified_email;
-		$this->users_repo              = $users_repo;
+		$this->users_repo = $users_repo;
 
 		if ( $a0_options instanceof WP_Auth0_Options ) {
 			$this->a0_options = $a0_options;
 		} else {
 			$this->a0_options = WP_Auth0_Options::Instance();
+		}
+
+		$this->admin_role              = $admin_role;
+		$this->ignore_unverified_email = $ignore_unverified_email;
+
+		if ( func_num_args() > 2 ) {
+			// phpcs:ignore
+			trigger_error(
+				sprintf( __( '$admin_role and $ignore_unverified_email are deprecated.', 'wp-auth0' ), __METHOD__ ),
+				E_USER_DEPRECATED
+			);
 		}
 	}
 
@@ -626,17 +635,6 @@ class WP_Auth0_LoginManager {
 	}
 
 	/**
-	 * End the PHP session.
-	 *
-	 * TODO: Deprecate
-	 */
-	public function end_session() {
-		if ( session_id() ) {
-			session_destroy();
-		}
-	}
-
-	/**
 	 * Get and filter the scope used for access and ID tokens.
 	 *
 	 * @param string $context - how the scopes are being used.
@@ -772,6 +770,28 @@ class WP_Auth0_LoginManager {
 					: __( '← Logout', 'wp-auth0' )
 			)
 		);
+	}
+
+	/*
+	 *
+	 * DEPRECATED
+	 *
+	 */
+
+	/**
+	 * End the PHP session.
+	 *
+	 * @deprecated - 3.8.0, not used and no replacement provided.
+	 *
+	 * @codeCoverageIgnore - Deprecated
+	 */
+	public function end_session() {
+		// phpcs:ignore
+		trigger_error( sprintf( __( 'Method %s is deprecated.', 'wp-auth0' ), __METHOD__ ), E_USER_DEPRECATED );
+
+		if ( session_id() ) {
+			session_destroy();
+		}
 	}
 
 	/**

--- a/lib/WP_Auth0_Settings_Section.php
+++ b/lib/WP_Auth0_Settings_Section.php
@@ -65,8 +65,5 @@ class WP_Auth0_Settings_Section {
 		}
 	}
 
-	// TODO: deprecate
-	public function redirect_to_help() {
-
-	}
+	public function redirect_to_help() {}
 }

--- a/lib/WP_Auth0_Users.php
+++ b/lib/WP_Auth0_Users.php
@@ -5,7 +5,7 @@ class WP_Auth0_Users {
 	 * Create a WordPress user with Auth0 data.
 	 *
 	 * @param object       $userinfo - User profile data from Auth0.
-	 * @param null|boolean $role - Set the sole as administrator - @deprecated - 3.8.0.
+	 * @param null|boolean $role - Set the role as administrator - @deprecated - 3.8.0.
 	 *
 	 * @return int|WP_Error
 	 */

--- a/lib/WP_Auth0_Users.php
+++ b/lib/WP_Auth0_Users.php
@@ -1,5 +1,14 @@
 <?php
 class WP_Auth0_Users {
+
+	/**
+	 * Create a WordPress user with Auth0 data.
+	 *
+	 * @param object       $userinfo - User profile data from Auth0.
+	 * @param null|boolean $role - Set the sole as administrator - @deprecated - 3.8.0.
+	 *
+	 * @return int|WP_Error
+	 */
 	public static function create_user( $userinfo, $role = null ) {
 		$email = null;
 		if ( isset( $userinfo->email ) ) {
@@ -76,6 +85,8 @@ class WP_Auth0_Users {
 		);
 
 		if ( $role ) {
+			// phpcs:ignore
+			trigger_error( sprintf( __( '$role parameter is deprecated.', 'wp-auth0' ), __METHOD__ ), E_USER_DEPRECATED );
 			$user_data['role'] = 'administrator';
 		}
 

--- a/lib/WP_Auth0_UsersRepo.php
+++ b/lib/WP_Auth0_UsersRepo.php
@@ -73,9 +73,9 @@ class WP_Auth0_UsersRepo {
 	 *
 	 * @param object      $userinfo - Profile object from Auth0.
 	 * @param string      $token - ID token from Auth0.
-	 * @param null|string $access_token - TODO: Deprecate, not used
-	 * @param null|string $role - TODO: Deprecate, not used
-	 * @param bool        $skip_email_verified - TODO: Deprecate, not used
+	 * @param null|string $access_token - @deprecated - 3.8.0.
+	 * @param null|string $role - @deprecated - 3.8.0.
+	 * @param bool        $skip_email_verified - @deprecated - 3.8.0.
 	 *
 	 * @return int|null|WP_Error
 	 *
@@ -84,6 +84,18 @@ class WP_Auth0_UsersRepo {
 	 * @throws WP_Auth0_RegistrationNotEnabledException
 	 */
 	public function create( $userinfo, $token, $access_token = null, $role = null, $skip_email_verified = false ) {
+
+		if ( func_num_args() > 2 ) {
+			// phpcs:ignore
+			trigger_error(
+				sprintf(
+					__( '$access_token, $role, and $skip_email_verified params are deprecated.', 'wp-auth0' ),
+					__METHOD__
+				),
+				E_USER_DEPRECATED
+			);
+		}
+
 		$auth0_sub      = $userinfo->sub;
 		list($strategy) = explode( '|', $auth0_sub );
 		$opts           = WP_Auth0_Options::Instance();


### PR DESCRIPTION
- Deprecated unused `$admin_role` and `$ignore_unverified_email` parameters in the `WP_Auth0_LoginManager` construct method
- Deprecated unused `end_session()` method in the `WP_Auth0_LoginManager` class
- Deprecate `$role` parameter in the `create_user` method in the `WP_Auth0_Users` class
- Deprecate `$access_token`, `$role`, and `$skip_email_verified` parameters in the `create` method of the `WP_Auth0_UsersRepo` class

**No functional changes 👍**