### PR TITLE
Update phpcs script and dependent libs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ wp-phptidy.php
 /account_cleanup/vendor/
 /vendor/
 /rules/
+.phpcs.xml
+phpcs.xml

--- a/composer.json
+++ b/composer.json
@@ -7,10 +7,10 @@
         "php": "^5.3 || ^7.0"
     },
     "require-dev": {
-        "phpcompatibility/php-compatibility": "^8.1",
         "dealerdirect/phpcodesniffer-composer-installer": "^0.4.3",
-        "wp-coding-standards/wpcs": "^0.14.1",
-        "phpunit/phpunit": "^6.5.0"
+        "wp-coding-standards/wpcs": "^1",
+        "phpunit/phpunit": "^6.5.0",
+        "phpcompatibility/phpcompatibility-wp": "*"
     },
     "authors": [
         {
@@ -30,15 +30,13 @@
     },
     "minimum-stability": "stable",
     "scripts": {
-        "compat": "./vendor/bin/phpcs --standard=phpcs-compat-ruleset.xml .",
-        "phpcs": "./vendor/bin/phpcs --standard=phpcs-ruleset.xml -s .",
+        "compat": "vendor/bin/phpcs --standard=phpcs-compat-ruleset.xml .",
+        "phpcs": "\"vendor/bin/phpcs\"",
         "phpcs-tests": "./vendor/bin/phpcs --standard=phpcs-test-ruleset.xml -s ./tests/",
-        "phpcs-path": "SHELL_INTERACTIVE=1 ./vendor/bin/phpcs --standard=phpcs-ruleset.xml -s",
-        "phpcbf": "./vendor/bin/phpcbf --standard=phpcs-ruleset.xml .",
+        "phpcbf": "\"vendor/bin/phpcbf\"",
         "phpcbf-tests": "./vendor/bin/phpcbf --standard=phpcs-test-ruleset.xml -s ./tests/",
-        "phpcbf-path": "SHELL_INTERACTIVE=1 ./vendor/bin/phpcbf --standard=phpcs-ruleset.xml",
-        "sniffs": "./vendor/bin/phpcs --standard=phpcs-ruleset.xml -e",
-        "test": "SHELL_INTERACTIVE=1 ./vendor/bin/phpunit --coverage-text --verbose",
-        "test-ci": "./vendor/bin/phpunit --debug --verbose --coverage-clover=coverage.xml"
+        "sniffs": "vendor/bin/phpcs --standard=phpcs-ruleset.xml -e",
+        "test": "\"vendor/bin/phpunit\"",
+        "test-ci": "vendor/bin/phpunit --debug --coverage-clover=coverage.xml"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
         "phpcbf": "\"vendor/bin/phpcbf\"",
         "phpcbf-tests": "./vendor/bin/phpcbf --standard=phpcs-test-ruleset.xml -s ./tests/",
         "sniffs": "vendor/bin/phpcs --standard=phpcs-ruleset.xml -e",
-        "test": "\"vendor/bin/phpunit\"",
+        "test": "\"vendor/bin/phpunit\" --coverage-text",
         "test-ci": "vendor/bin/phpunit --debug --coverage-clover=coverage.xml"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "0d253455e7fde5476cd1438868ff9968",
+    "content-hash": "3d6029204417adeeff6727ece9cf9351",
     "packages": [],
     "packages-dev": [
         {
@@ -281,16 +281,16 @@
         },
         {
             "name": "phpcompatibility/php-compatibility",
-            "version": "8.2.0",
+            "version": "9.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCompatibility/PHPCompatibility.git",
-                "reference": "eaf613c1a8265bcfd7b0ab690783f2aef519f78a"
+                "reference": "e9f4047e5edf53c88f36f1dafc0d49454ce13e25"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibility/zipball/eaf613c1a8265bcfd7b0ab690783f2aef519f78a",
-                "reference": "eaf613c1a8265bcfd7b0ab690783f2aef519f78a",
+                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibility/zipball/e9f4047e5edf53c88f36f1dafc0d49454ce13e25",
+                "reference": "e9f4047e5edf53c88f36f1dafc0d49454ce13e25",
                 "shasum": ""
             },
             "require": {
@@ -308,11 +308,60 @@
                 "roave/security-advisories": "dev-master || Helps prevent installing dependencies with known security issues."
             },
             "type": "phpcodesniffer-standard",
-            "autoload": {
-                "psr-4": {
-                    "PHPCompatibility\\": "PHPCompatibility/"
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/PHPCompatibility/PHPCompatibility/graphs/contributors"
+                },
+                {
+                    "name": "Wim Godden",
+                    "homepage": "https://github.com/wimg",
+                    "role": "lead"
+                },
+                {
+                    "name": "Juliette Reinders Folmer",
+                    "homepage": "https://github.com/jrfnl",
+                    "role": "lead"
                 }
+            ],
+            "description": "A set of sniffs for PHP_CodeSniffer that checks for PHP cross-version compatibility.",
+            "homepage": "http://techblog.wimgodden.be/tag/codesniffer/",
+            "keywords": [
+                "compatibility",
+                "phpcs",
+                "standards"
+            ],
+            "time": "2018-10-07T17:38:02+00:00"
+        },
+        {
+            "name": "phpcompatibility/phpcompatibility-paragonie",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPCompatibility/PHPCompatibilityParagonie.git",
+                "reference": "67d89dcef47f351144d24b247aa968f2269162f7"
             },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibilityParagonie/zipball/67d89dcef47f351144d24b247aa968f2269162f7",
+                "reference": "67d89dcef47f351144d24b247aa968f2269162f7",
+                "shasum": ""
+            },
+            "require": {
+                "phpcompatibility/php-compatibility": "^9.0"
+            },
+            "require-dev": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.4"
+            },
+            "suggest": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.4 || This Composer plugin will sort out the PHP_CodeSniffer 'installed_paths' automatically.",
+                "roave/security-advisories": "dev-master || Helps prevent installing dependencies with known security issues."
+            },
+            "type": "phpcodesniffer-standard",
             "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "LGPL-3.0-or-later"
@@ -321,16 +370,72 @@
                 {
                     "name": "Wim Godden",
                     "role": "lead"
+                },
+                {
+                    "name": "Juliette Reinders Folmer",
+                    "role": "lead"
                 }
             ],
-            "description": "A set of sniffs for PHP_CodeSniffer that checks for PHP version compatibility.",
-            "homepage": "http://techblog.wimgodden.be/tag/codesniffer/",
+            "description": "A set of rulesets for PHP_CodeSniffer to check for PHP cross-version compatibility issues in projects, while accounting for polyfills provided by the Paragonie polyfill libraries.",
+            "homepage": "http://phpcompatibility.com/",
+            "keywords": [
+                "compatibility",
+                "paragonie",
+                "phpcs",
+                "polyfill",
+                "standards"
+            ],
+            "time": "2018-10-07T17:59:30+00:00"
+        },
+        {
+            "name": "phpcompatibility/phpcompatibility-wp",
+            "version": "2.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPCompatibility/PHPCompatibilityWP.git",
+                "reference": "cb303f0067cd5b366a41d4fb0e254fb40ff02efd"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibilityWP/zipball/cb303f0067cd5b366a41d4fb0e254fb40ff02efd",
+                "reference": "cb303f0067cd5b366a41d4fb0e254fb40ff02efd",
+                "shasum": ""
+            },
+            "require": {
+                "phpcompatibility/php-compatibility": "^9.0",
+                "phpcompatibility/phpcompatibility-paragonie": "^1.0"
+            },
+            "require-dev": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.3"
+            },
+            "suggest": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.3 || This Composer plugin will sort out the PHP_CodeSniffer 'installed_paths' automatically.",
+                "roave/security-advisories": "dev-master || Helps prevent installing dependencies with known security issues."
+            },
+            "type": "phpcodesniffer-standard",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Wim Godden",
+                    "role": "lead"
+                },
+                {
+                    "name": "Juliette Reinders Folmer",
+                    "role": "lead"
+                }
+            ],
+            "description": "A ruleset for PHP_CodeSniffer to check for PHP cross-version compatibility issues in projects, while accounting for polyfills provided by WordPress.",
+            "homepage": "http://phpcompatibility.com/",
             "keywords": [
                 "compatibility",
                 "phpcs",
-                "standards"
+                "standards",
+                "wordpress"
             ],
-            "time": "2018-07-17T13:42:26+00:00"
+            "time": "2018-10-07T18:31:37+00:00"
         },
         {
             "name": "phpdocumentor/reflection-common",
@@ -1500,16 +1605,16 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.3.1",
+            "version": "3.3.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "628a481780561150481a9ec74709092b9759b3ec"
+                "reference": "6ad28354c04b364c3c71a34e4a18b629cc3b231e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/628a481780561150481a9ec74709092b9759b3ec",
-                "reference": "628a481780561150481a9ec74709092b9759b3ec",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/6ad28354c04b364c3c71a34e4a18b629cc3b231e",
+                "reference": "6ad28354c04b364c3c71a34e4a18b629cc3b231e",
                 "shasum": ""
             },
             "require": {
@@ -1547,7 +1652,7 @@
                 "phpcs",
                 "standards"
             ],
-            "time": "2018-07-26T23:47:18+00:00"
+            "time": "2018-09-23T23:08:17+00:00"
         },
         {
             "name": "theseer/tokenizer",
@@ -1641,24 +1746,27 @@
         },
         {
             "name": "wp-coding-standards/wpcs",
-            "version": "0.14.1",
+            "version": "1.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards.git",
-                "reference": "cf6b310caad735816caef7573295f8a534374706"
+                "reference": "46d42828ce7355d8b3776e3171f2bda892d179b4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/WordPress-Coding-Standards/WordPress-Coding-Standards/zipball/cf6b310caad735816caef7573295f8a534374706",
-                "reference": "cf6b310caad735816caef7573295f8a534374706",
+                "url": "https://api.github.com/repos/WordPress-Coding-Standards/WordPress-Coding-Standards/zipball/46d42828ce7355d8b3776e3171f2bda892d179b4",
+                "reference": "46d42828ce7355d8b3776e3171f2bda892d179b4",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3",
                 "squizlabs/php_codesniffer": "^2.9.0 || ^3.0.2"
             },
+            "require-dev": {
+                "phpcompatibility/php-compatibility": "*"
+            },
             "suggest": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.3"
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.3 || This Composer plugin will sort out the PHPCS 'installed_paths' automatically."
             },
             "type": "phpcodesniffer-standard",
             "notification-url": "https://packagist.org/downloads/",
@@ -1677,7 +1785,7 @@
                 "standards",
                 "wordpress"
             ],
-            "time": "2018-02-16T01:57:48+00:00"
+            "time": "2018-09-10T17:04:05+00:00"
         }
     ],
     "aliases": [],

--- a/lib/WP_Auth0_Api_Client.php
+++ b/lib/WP_Auth0_Api_Client.php
@@ -114,7 +114,8 @@ class WP_Auth0_Api_Client {
 		$headers['content-type'] = 'application/x-www-form-urlencoded';
 
 		$response = wp_remote_post(
-			$endpoint . 'oauth/token', array(
+			$endpoint . 'oauth/token',
+			array(
 				'headers' => $headers,
 				'body'    => $body,
 			)
@@ -140,7 +141,8 @@ class WP_Auth0_Api_Client {
 	public static function get_client_token() {
 
 		$response = wp_remote_post(
-			self::get_endpoint( 'oauth/token' ), array(
+			self::get_endpoint( 'oauth/token' ),
+			array(
 				'headers' => self::get_headers(),
 				'body'    => json_encode(
 					array(
@@ -192,7 +194,8 @@ class WP_Auth0_Api_Client {
 		$headers['Authorization'] = "Bearer $jwt";
 
 		return wp_remote_get(
-			$endpoint, array(
+			$endpoint,
+			array(
 				'headers' => $headers,
 			)
 		);
@@ -208,7 +211,8 @@ class WP_Auth0_Api_Client {
 		$headers['content-type'] = 'application/json';
 
 		$response = wp_remote_post(
-			$endpoint, array(
+			$endpoint,
+			array(
 				'headers' => $headers,
 				'body'    => json_encode( $data ),
 			)
@@ -322,7 +326,8 @@ class WP_Auth0_Api_Client {
 		);
 
 		$response = wp_remote_post(
-			self::get_endpoint( 'api/v2/clients', $domain ), array(
+			self::get_endpoint( 'api/v2/clients', $domain ),
+			array(
 				'headers' => self::get_headers( $app_token ),
 				'body'    => json_encode( $payload ),
 			)
@@ -353,7 +358,8 @@ class WP_Auth0_Api_Client {
 		$headers['content-type']  = 'application/json';
 
 		$response = wp_remote_post(
-			$endpoint, array(
+			$endpoint,
+			array(
 				'method'  => 'PATCH',
 				'headers' => $headers,
 				'body'    => json_encode( array_merge( array( 'sso' => (bool) $sso ), $payload ) ),
@@ -391,7 +397,8 @@ class WP_Auth0_Api_Client {
 		$headers['content-type']  = 'application/json';
 
 		$response = wp_remote_post(
-			$endpoint, array(
+			$endpoint,
+			array(
 				'method'  => 'POST',
 				'headers' => $headers,
 				'body'    => json_encode( $payload ),
@@ -423,7 +430,8 @@ class WP_Auth0_Api_Client {
 		$headers['content-type']  = 'application/json';
 
 		$response = wp_remote_post(
-			$endpoint, array(
+			$endpoint,
+			array(
 				'method'  => 'DELETE',
 				'headers' => $headers,
 			)
@@ -461,7 +469,8 @@ class WP_Auth0_Api_Client {
 		);
 
 		$response = wp_remote_post(
-			self::get_endpoint( 'api/v2/client-grants' ), array(
+			self::get_endpoint( 'api/v2/client-grants' ),
+			array(
 				'headers' => self::get_headers( $app_token ),
 				'body'    => json_encode( $data ),
 			)
@@ -507,7 +516,8 @@ class WP_Auth0_Api_Client {
 		$headers['content-type']  = 'application/json';
 
 		$response = wp_remote_post(
-			$endpoint, array(
+			$endpoint,
+			array(
 				'method'  => 'POST',
 				'headers' => $headers,
 				'body'    => json_encode( $payload ),
@@ -541,7 +551,8 @@ class WP_Auth0_Api_Client {
 		$headers['Authorization'] = "Bearer $app_token";
 
 		$response = wp_remote_get(
-			$endpoint, array(
+			$endpoint,
+			array(
 				'headers' => $headers,
 			)
 		);
@@ -573,7 +584,8 @@ class WP_Auth0_Api_Client {
 		$headers['Authorization'] = "Bearer $app_token";
 
 		$response = wp_remote_get(
-			$endpoint, array(
+			$endpoint,
+			array(
 				'headers' => $headers,
 			)
 		);
@@ -606,7 +618,8 @@ class WP_Auth0_Api_Client {
 		$headers['content-type']  = 'application/json';
 
 		$response = wp_remote_post(
-			$endpoint, array(
+			$endpoint,
+			array(
 				'method'  => 'PATCH',
 				'headers' => $headers,
 				'body'    => json_encode( $payload ),
@@ -641,7 +654,8 @@ class WP_Auth0_Api_Client {
 		$headers['content-type']  = 'application/json';
 
 		$response = wp_remote_post(
-			$endpoint, array(
+			$endpoint,
+			array(
 				'method'  => 'PATCH',
 				'headers' => $headers,
 				'body'    => json_encode( $payload ),
@@ -733,7 +747,8 @@ class WP_Auth0_Api_Client {
 		);
 
 		$response = wp_remote_post(
-			$endpoint, array(
+			$endpoint,
+			array(
 				'method'  => 'PUT',
 				'headers' => $headers,
 				'body'    => json_encode( $payload ),
@@ -875,7 +890,8 @@ class WP_Auth0_Api_Client {
 		);
 
 		$response = wp_remote_post(
-			$endpoint . 'oauth/ro', array(
+			$endpoint . 'oauth/ro',
+			array(
 				'headers' => $headers,
 				'body'    => $body,
 			)
@@ -956,7 +972,8 @@ class WP_Auth0_Api_Client {
 		$headers['Authorization'] = "Bearer $jwt";
 
 		$response = wp_remote_get(
-			$endpoint, array(
+			$endpoint,
+			array(
 				'headers' => $headers,
 			)
 		);
@@ -1026,7 +1043,8 @@ class WP_Auth0_Api_Client {
 		$headers['content-type']  = 'application/json';
 
 		$response = wp_remote_post(
-			$endpoint, array(
+			$endpoint,
+			array(
 				'headers' => $headers,
 				'body'    => json_encode( $data ),
 			)
@@ -1063,7 +1081,8 @@ class WP_Auth0_Api_Client {
 		$headers['Authorization'] = "Bearer $app_token";
 
 		$response = wp_remote_get(
-			$endpoint, array(
+			$endpoint,
+			array(
 				'headers' => $headers,
 			)
 		);
@@ -1119,7 +1138,8 @@ class WP_Auth0_Api_Client {
 		$headers['content-type']  = 'application/json';
 
 		$response = wp_remote_post(
-			$endpoint, array(
+			$endpoint,
+			array(
 				'method'  => 'DELETE',
 				'headers' => $headers,
 			)
@@ -1157,7 +1177,8 @@ class WP_Auth0_Api_Client {
 		$headers['content-type']  = 'application/json';
 
 		$response = wp_remote_post(
-			$endpoint, array(
+			$endpoint,
+			array(
 				'method'  => 'DELETE',
 				'headers' => $headers,
 			)
@@ -1194,7 +1215,8 @@ class WP_Auth0_Api_Client {
 		$headers['content-type'] = 'application/json';
 
 		$response = wp_remote_post(
-			$endpoint, array(
+			$endpoint,
+			array(
 				'method'  => 'POST',
 				'headers' => $headers,
 				'body'    => json_encode( $payload ),
@@ -1244,7 +1266,8 @@ class WP_Auth0_Api_Client {
 		}
 
 		$response = wp_remote_post(
-			$endpoint, array(
+			$endpoint,
+			array(
 				'headers' => $headers,
 				'body'    => json_encode( $payload ),
 			)

--- a/lib/WP_Auth0_Api_Operations.php
+++ b/lib/WP_Auth0_Api_Operations.php
@@ -116,7 +116,10 @@ class WP_Auth0_Api_Operations {
 				$enabled_clients = array_diff( $db_connection->enabled_clients, array( $client_id ) );
 
 				WP_Auth0_Api_Client::update_connection(
-					$domain, $app_token, $db_connection->id, array(
+					$domain,
+					$app_token,
+					$db_connection->id,
+					array(
 						'enabled_clients' => array_values( $enabled_clients ),
 					)
 				);
@@ -297,7 +300,8 @@ class WP_Auth0_Api_Operations {
 
 					$data = array(
 						'options'         => array_merge(
-							$connection_options, array(
+							$connection_options,
+							array(
 								'client_id'     => $input[ "{$main_key}_key" ],
 								'client_secret' => $input[ "{$main_key}_secret" ],
 							)
@@ -322,7 +326,8 @@ class WP_Auth0_Api_Operations {
 						'strategy'        => $strategy,
 						'enabled_clients' => array( $client_id ),
 						'options'         => array_merge(
-							$connection_options, array(
+							$connection_options,
+							array(
 								'client_id'     => $input[ "{$main_key}_key" ],
 								'client_secret' => $input[ "{$main_key}_secret" ],
 							)

--- a/lib/WP_Auth0_DBManager.php
+++ b/lib/WP_Auth0_DBManager.php
@@ -171,7 +171,8 @@ class WP_Auth0_DBManager {
 				}
 			} else {
 				WP_Auth0_ErrorManager::insert_auth0_error(
-					__METHOD__, sprintf(
+					__METHOD__,
+					sprintf(
 						__(
 							'Unable to automatically create Client Grant. Please go to your Auth0 Dashboard and authorize your Application %1$s for management API scopes %2$s.',
 							'wp-auth0'
@@ -226,7 +227,8 @@ class WP_Auth0_DBManager {
 				);
 			} else {
 				WP_Auth0_ErrorManager::insert_auth0_error(
-					__METHOD__, sprintf(
+					__METHOD__,
+					sprintf(
 						__(
 							'Unable to automatically update Client Grant Type. Please go to your Auth0 Dashboard and add Client Credentials to your Application settings > Advanced > Grant Types for ID %s ',
 							'wp-auth0'

--- a/lib/WP_Auth0_EditProfile.php
+++ b/lib/WP_Auth0_EditProfile.php
@@ -158,7 +158,10 @@ class WP_Auth0_EditProfile {
 			$requires_verified_email = $this->a0_options->get( 'requires_verified_email' );
 
 			$response = WP_Auth0_Api_Client::update_user(
-				$domain, $app_token, $user_id, array(
+				$domain,
+				$app_token,
+				$user_id,
+				array(
 					'connection'   => $connection,
 					'email'        => $user_email,
 					'client_id'    => $client_id,
@@ -250,14 +253,18 @@ class WP_Auth0_EditProfile {
 
 			if ( $api_token ) {
 				WP_Auth0_Api_Client::update_user(
-					$domain, $api_token, $user_profile->user_id, array(
+					$domain,
+					$api_token,
+					$user_profile->user_id,
+					array(
 						'password'   => $auth0_password,
 						'connection' => $connection,
 					)
 				);
 			} else {
 				WP_Auth0_Api_Client::change_password(
-					$domain, array(
+					$domain,
+					array(
 						'client_id'  => $client_id,
 						'email'      => $user_profile->email,
 						'connection' => $connection,

--- a/lib/WP_Auth0_LoginManager.php
+++ b/lib/WP_Auth0_LoginManager.php
@@ -221,7 +221,11 @@ class WP_Auth0_LoginManager {
 
 		// Exchange authorization code for an access token.
 		$exchange_resp = WP_Auth0_Api_Client::get_token(
-			$auth_domain, $client_id, $client_secret, 'authorization_code', array(
+			$auth_domain,
+			$client_id,
+			$client_secret,
+			'authorization_code',
+			array(
 				'redirect_uri' => $this->a0_options->get_wp_auth0_url(),
 				'code'         => $this->query_vars( 'code' ),
 			)
@@ -534,7 +538,9 @@ class WP_Auth0_LoginManager {
 
 		// See wp_signon() for documentation on this filter.
 		$secure_cookie = apply_filters(
-			'secure_signon_cookie', $secure_cookie, array(
+			'secure_signon_cookie',
+			$secure_cookie,
+			array(
 				'user_login'    => $user->user_login,
 				'user_password' => null,
 				'remember'      => $remember_users_session,
@@ -816,7 +822,11 @@ class WP_Auth0_LoginManager {
 		$client_id = $this->a0_options->get( 'client_id' );
 		$secret    = $this->a0_options->get_client_secret_as_key();
 		$response  = WP_Auth0_Api_Client::ro(
-			$domain, $client_id, $username, $password, $connection,
+			$domain,
+			$client_id,
+			$username,
+			$password,
+			$connection,
 			'openid name email nickname email_verified identities'
 		);
 		try {

--- a/lib/admin/WP_Auth0_Admin.php
+++ b/lib/admin/WP_Auth0_Admin.php
@@ -30,7 +30,9 @@ class WP_Auth0_Admin {
 		wp_register_script( 'wpa0_bootstrap', WPA0_PLUGIN_BS_URL . 'js/bootstrap.min.js', array( 'jquery' ), '3.3.6' );
 		wp_register_script( 'wpa0_admin', WPA0_PLUGIN_JS_URL . 'admin.js', array( 'wpa0_bootstrap' ), WPA0_VERSION );
 		wp_localize_script(
-			'wpa0_admin', 'wpa0', array(
+			'wpa0_admin',
+			'wpa0',
+			array(
 				'media_title'             => __( 'Choose your icon', 'wp-auth0' ),
 				'media_button'            => __( 'Choose icon', 'wp-auth0' ),
 				'clear_cache_working'     => __( 'Working ...', 'wp-auth0' ),

--- a/lib/admin/WP_Auth0_Admin_Advanced.php
+++ b/lib/admin/WP_Auth0_Admin_Advanced.php
@@ -720,7 +720,8 @@ class WP_Auth0_Admin_Advanced extends WP_Auth0_Admin_Generic {
 					array(
 						'scope' => 'migration_ws',
 						'jti'   => $token_id,
-					), $secret
+					),
+					$secret
 				);
 				$input['migration_token_id'] = $token_id;
 

--- a/lib/initial-setup/WP_Auth0_InitialSetup.php
+++ b/lib/initial-setup/WP_Auth0_InitialSetup.php
@@ -144,7 +144,8 @@ class WP_Auth0_InitialSetup {
 					<?php
 					echo __(
 						'Go to your Auth0 dashboard > APIs > Auth0 Management API > Non-Interactive Clients'
-								   . ' tab and authorize the client for this site. ', 'wp-auth0'
+								   . ' tab and authorize the client for this site. ',
+						'wp-auth0'
 					);
 					?>
 					<?php echo __( 'Make sure to add the following scopes: ', 'wp-auth0' ); ?>

--- a/lib/initial-setup/WP_Auth0_InitialSetup_Consent.php
+++ b/lib/initial-setup/WP_Auth0_InitialSetup_Consent.php
@@ -73,7 +73,11 @@ class WP_Auth0_InitialSetup_Consent {
 		$client_id = get_bloginfo( 'url' );
 
 		$response = WP_Auth0_Api_Client::get_token(
-			$this->domain, $client_id, null, 'authorization_code', array(
+			$this->domain,
+			$client_id,
+			null,
+			'authorization_code',
+			array(
 				'redirect_uri' => home_url(),
 				'code'         => $code,
 			)
@@ -152,7 +156,8 @@ class WP_Auth0_InitialSetup_Consent {
 					array(
 						'scope' => 'migration_ws',
 						'jti'   => $token_id,
-					), $secret
+					),
+					$secret
 				);
 				$migration_token_id = $token_id;
 

--- a/lib/initial-setup/WP_Auth0_InitialSetup_Migration.php
+++ b/lib/initial-setup/WP_Auth0_InitialSetup_Migration.php
@@ -27,7 +27,8 @@ class WP_Auth0_InitialSetup_Migration {
 			array(
 				'scope' => 'migration_ws',
 				'jti'   => $token_id,
-			), $secret
+			),
+			$secret
 		);
 
 		$this->a0_options->set( 'migration_token', $token );

--- a/lib/twitter-api-php/TwitterAPIExchange.php
+++ b/lib/twitter-api-php/TwitterAPIExchange.php
@@ -320,7 +320,8 @@ class TwitterAPIExchange {
 
 		foreach ( $oauth as $key => $value ) {
 			if ( in_array(
-				$key, array(
+				$key,
+				array(
 					'oauth_consumer_key',
 					'oauth_nonce',
 					'oauth_signature',

--- a/phpcs-test-ruleset.xml
+++ b/phpcs-test-ruleset.xml
@@ -2,22 +2,35 @@
 <ruleset name="WP-Auth0" namespace="WPAuth0\CS\Standard">
     <description>A custom coding standard for WP-Auth0 tests</description>
 
-    <config name="testVersion" value="5.6-"/>
-    <config name="showProgress" value="1"/>
+    <!-- Only check PHP files. -->
+    <arg name="extensions" value="php"/>
 
+    <!-- Show progress, show the error codes for each message (source). -->
+    <arg value="sp"/>
+
+    <!-- Strip the filepaths down to the relevant bit. -->
+    <arg name="basepath" value="."/>
+
+    <!-- Show coloured output, if available. -->
     <arg name="colors"/>
+
+    <!--
+    PHPCompatibility sniffs to check for PHP cross-version incompatible code.
+    https://github.com/PHPCompatibility/PHPCompatibility
+    -->
+    <config name="testVersion" value="7.1-"/>
+    <rule ref="PHPCompatibilityWP"/>
 
     <rule ref="Generic.CodeAnalysis"/>
     <rule ref="Generic.Commenting.Todo"/>
-    <rule ref="PHPCompatibility"/>
     <rule ref="WordPress-Docs"/>
     <rule ref="WordPress-Core">
         <exclude name="WordPress.Files.FileName"/>
         <exclude name="WordPress.NamingConventions.ValidFunctionName"/>
         <exclude name="WordPress.NamingConventions.ValidVariableName"/>
     </rule>
-    <rule ref="WordPress.VIP.DirectDatabaseQuery"/>
-    <rule ref="WordPress.VIP.SlowDBQuery"/>
+    <rule ref="WordPress.DB.DirectDatabaseQuery"/>
+    <rule ref="WordPress.DB.SlowDBQuery"/>
     <rule ref="WordPress.WP.I18n">
         <properties>
             <property name="text_domain" type="array" value="wp-auth0" />

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -2,6 +2,8 @@
 <ruleset name="WP-Auth0" namespace="WPAuth0\CS\Standard">
     <description>A custom coding standard for WP-Auth0</description>
 
+    <file>.</file>
+
     <!-- Internal tool, will be removed-->
     <exclude-pattern>/account_cleanup/*</exclude-pattern>
 
@@ -21,12 +23,26 @@
     <exclude-pattern>/lib/admin/WP_Auth0_Admin_Dashboard.php</exclude-pattern>
     <exclude-pattern>/lib/dashboard-widgets/*</exclude-pattern>
 
-    <config name="testVersion" value="5.3-"/>
-    <config name="showProgress" value="1"/>
-    <config name="extensions" value="php"/>
     <config name="minimum_supported_wp_version" value="3.8"/>
 
+    <!-- Only check PHP files. -->
+    <arg name="extensions" value="php"/>
+
+    <!-- Show progress, show the error codes for each message (source). -->
+    <arg value="sp"/>
+
+    <!-- Strip the filepaths down to the relevant bit. -->
+    <arg name="basepath" value="."/>
+
+    <!-- Show coloured output, if available. -->
     <arg name="colors"/>
+
+    <!--
+    PHPCompatibility sniffs to check for PHP cross-version incompatible code.
+    https://github.com/PHPCompatibility/PHPCompatibility
+    -->
+    <config name="testVersion" value="5.5-"/>
+    <rule ref="PHPCompatibilityWP"/>
 
     <rule ref="Generic.CodeAnalysis"/>
     <rule ref="Generic.Commenting.Todo"/>
@@ -36,8 +52,13 @@
         <exclude name="WordPress.Files.FileName"/>
         <exclude name="WordPress.NamingConventions.ValidVariableName.NotSnakeCaseMemberVar"/>
     </rule>
-    <rule ref="WordPress.VIP.DirectDatabaseQuery"/>
-    <rule ref="WordPress.VIP.SlowDBQuery"/>
+    <rule ref="WordPress.DB.DirectDatabaseQuery"/>
+    <rule ref="WordPress.DB.SlowDBQuery"/>
+    <rule ref="WordPress.NamingConventions.PrefixAllGlobals">
+        <properties>
+            <property name="prefixes" type="array" value="wp_auth0" />
+        </properties>
+    </rule>
     <rule ref="WordPress.WP.I18n">
         <properties>
             <property name="text_domain" type="array" value="wp-auth0" />

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -6,6 +6,7 @@
 	convertErrorsToExceptions="true"
 	convertNoticesToExceptions="true"
 	convertWarningsToExceptions="true"
+	verbose="true"
 	>
 	<filter>
 		<whitelist>
@@ -27,4 +28,7 @@
 		<ini name="display_errors" value="On" />
 		<ini name="display_startup_errors" value="On" />
 	</php>
+	<logging>
+		<log type="coverage-text" target="php://stdout" showUncoveredFiles="false"/>
+	</logging>
 </phpunit>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -28,7 +28,4 @@
 		<ini name="display_errors" value="On" />
 		<ini name="display_startup_errors" value="On" />
 	</php>
-	<logging>
-		<log type="coverage-text" target="php://stdout" showUncoveredFiles="false"/>
-	</logging>
 </phpunit>

--- a/tests/testConstantSettings.php
+++ b/tests/testConstantSettings.php
@@ -67,9 +67,12 @@ class TestConstantSettings extends TestCase {
 		$this->assertEquals( self::DEFAULT_CONSTANT_PREFIX . 'DOMAIN', $opts->get_constant_name( $opt_name ) );
 
 		add_filter(
-			'auth0_settings_constant_prefix', function( $prefix ) {
+			'auth0_settings_constant_prefix',
+			function( $prefix ) {
 				return '__TEST_PREFIX_' . $prefix;
-			}, 10, 2
+			},
+			10,
+			2
 		);
 
 		$this->assertEquals(

--- a/tests/testEmailVerification.php
+++ b/tests/testEmailVerification.php
@@ -76,9 +76,11 @@ class TestEmailVerification extends TestCase {
 	 */
 	public function testWpRenderDie() {
 		add_filter(
-			'wp_die_handler', function() {
+			'wp_die_handler',
+			function() {
 				return [ $this, 'wp_die_handler' ];
-			}, 10
+			},
+			10
 		);
 
 		$userinfo = $this->getUserinfo( 'not-auth0' );
@@ -106,9 +108,11 @@ class TestEmailVerification extends TestCase {
 		$this->assertContains( 'assets/js/die-with-verify-email.js?ver=' . WPA0_VERSION, $html );
 
 		add_filter(
-			'auth0_verify_email_page', function() {
+			'auth0_verify_email_page',
+			function() {
 				return '__test_auth0_verify_email_page__';
-			}, 10
+			},
+			10
 		);
 
 		// 3. Test that the auth0_verify_email_page returns passed-in content.

--- a/tests/testLoginManager.php
+++ b/tests/testLoginManager.php
@@ -24,10 +24,13 @@ class TestLoginManager extends TestCase {
 		$this->assertEquals( 'openid email profile', $scope );
 
 		add_filter(
-			'auth0_auth_scope', function( $default_scope, $context ) {
+			'auth0_auth_scope',
+			function( $default_scope, $context ) {
 				$default_scope[] = $context;
 				return $default_scope;
-			}, 10, 2
+			},
+			10,
+			2
 		);
 
 		$scope = WP_Auth0_LoginManager::get_userinfo_scope( 'auth0' );
@@ -65,10 +68,13 @@ class TestLoginManager extends TestCase {
 		$this->assertEquals( 'form_post', $auth_params['response_mode'] );
 
 		add_filter(
-			'auth0_authorize_url_params', function( $params, $connection, $redirect_to ) {
+			'auth0_authorize_url_params',
+			function( $params, $connection, $redirect_to ) {
 				$params[ $connection ] = $redirect_to;
 				return $params;
-			}, 10, 3
+			},
+			10,
+			3
 		);
 
 		$auth_params = WP_Auth0_LoginManager::get_authorize_params( 'auth0', 'https://auth0.com' );
@@ -111,9 +117,12 @@ class TestLoginManager extends TestCase {
 
 		// Authorize URL filter.
 		add_filter(
-			'auth0_authorize_url', function ( $auth_url, $params ) {
+			'auth0_authorize_url',
+			function ( $auth_url, $params ) {
 				return explode( '?', $auth_url )[0] . '?test=' . $params['test'];
-			}, 10, 2
+			},
+			10,
+			2
 		);
 
 		$auth_url = WP_Auth0_LoginManager::build_authorize_url(

--- a/tests/testUserRepoCreate.php
+++ b/tests/testUserRepoCreate.php
@@ -140,9 +140,11 @@ class TestUserRepoCreate extends TestCase {
 		update_option( 'users_can_register', 1 );
 
 		add_filter(
-			'wpa0_should_create_user', function() {
+			'wpa0_should_create_user',
+			function() {
 				return false;
-			}, 10
+			},
+			10
 		);
 
 		$this->expectException( WP_Auth0_CouldNotCreateUserException::class );

--- a/tests/testWPAuth0Options.php
+++ b/tests/testWPAuth0Options.php
@@ -68,7 +68,9 @@ class TestWPAuth0Options extends TestCase {
 			// phpcs:ignore
 			'wp_auth0_get_option', function( $value, $key ) {
 				return $key . self::FILTER_TEST_STRING;
-			}, 10, 2
+			},
+			10,
+			2
 		);
 
 		foreach ( array_keys( $opts->get_options() ) as $opt_name ) {

--- a/tests/traits/hookHelpers.php
+++ b/tests/traits/hookHelpers.php
@@ -24,13 +24,15 @@ trait HookHelpers {
 
 		if ( isset( $wp_filter[ $hook ]->callbacks ) ) {
 			array_walk(
-				$wp_filter[ $hook ]->callbacks, function( $callbacks, $priority ) use ( &$hooks ) {
+				$wp_filter[ $hook ]->callbacks,
+				function( $callbacks, $priority ) use ( &$hooks ) {
 					foreach ( $callbacks as $id => $callback ) {
 						$hooks[] = array_merge(
 							[
 								'id'       => $id,
 								'priority' => $priority,
-							], $callback
+							],
+							$callback
 						);
 					}
 				}


### PR DESCRIPTION
### Changes

**This PR does not change plugin functionality.**

- Rename `phpcs-ruleset.xml` → `phpcs.xml.dist` (automatically picked up by PHPCS)
- Add local PHPCS config files to `.gitignore`
- Update coding standard Composer packages
- Adjust Composer scripts

**Note:** I had to run the auto-formatter command to pass CI. I marked all the modified files with a comment if the changes were whitespace only. Non-whitespace changes in [this commit](https://github.com/auth0/wp-auth0/commit/ab381efba151886af8e477cbfd1de20aaafb776d).

### References

- [Configuration feedback](https://github.com/auth0/auth0-PHP/pull/284#issuecomment-418809388) from @jrfnl

