### PR TITLE
Fix user profile saving

### DIFF
--- a/WP_Auth0.php
+++ b/WP_Auth0.php
@@ -590,44 +590,26 @@ $a0_plugin->init();
 
 if ( ! function_exists( 'get_auth0userinfo' ) ) {
 	function get_auth0userinfo( $user_id ) {
-
 		$profile = WP_Auth0_UsersRepo::get_meta( $user_id, 'auth0_obj' );
-
-		if ( $profile ) {
-			return WP_Auth0_Serializer::unserialize( $profile );
-		}
-
-		return false;
+		return $profile ? WP_Auth0_Serializer::unserialize( $profile ) : false;
 	}
 }
 
 if ( ! function_exists( 'get_currentauth0userinfo' ) ) {
 	function get_currentauth0userinfo() {
-
 		global $currentauth0_user;
-
-		$current_user = wp_get_current_user();
-
-		$currentauth0_user = get_auth0userinfo( $current_user->ID );
-
+		$currentauth0_user = get_auth0userinfo( get_current_user_id() );
 		return $currentauth0_user;
 	}
 }
 
 if ( ! function_exists( 'get_currentauth0user' ) ) {
 	function get_currentauth0user() {
-
-		$current_user = wp_get_current_user();
-
-		$serialized_profile = WP_Auth0_UsersRepo::get_meta( $current_user->ID, 'auth0_obj' );
-
-		$data = new stdClass;
-
-		$data->auth0_obj   = empty( $serialized_profile ) ? false : WP_Auth0_Serializer::unserialize( $serialized_profile );
-		$data->last_update = WP_Auth0_UsersRepo::get_meta( $current_user->ID, 'last_update' );
-		$data->auth0_id    = WP_Auth0_UsersRepo::get_meta( $current_user->ID, 'auth0_id' );
-
-		return $data;
+		return (object) array(
+			'auth0_obj'   => get_auth0userinfo( get_current_user_id() ),
+			'last_update' => WP_Auth0_UsersRepo::get_meta( get_current_user_id(), 'last_update' ),
+			'auth0_id'    => WP_Auth0_UsersRepo::get_meta( get_current_user_id(), 'auth0_id' ),
+		);
 	}
 }
 

--- a/lib/WP_Auth0_UsersRepo.php
+++ b/lib/WP_Auth0_UsersRepo.php
@@ -193,13 +193,30 @@ class WP_Auth0_UsersRepo {
 		return ! empty( $users[0] ) ? $users[0] : null;
 	}
 
+	/**
+	 * Update all Auth0 meta fields for a WordPress user.
+	 *
+	 * @param int      $user_id - WordPress user ID.
+	 * @param stdClass $userinfo - User profile object from Auth0.
+	 */
 	public function update_auth0_object( $user_id, $userinfo ) {
 		global $wpdb;
-		update_user_meta( $user_id, $wpdb->prefix . 'auth0_id', ( isset( $userinfo->user_id ) ? $userinfo->user_id : $userinfo->sub ) );
-		update_user_meta( $user_id, $wpdb->prefix . 'auth0_obj', WP_Auth0_Serializer::serialize( $userinfo ) );
+
+		$auth0_user_id = isset( $userinfo->user_id ) ? $userinfo->user_id : $userinfo->sub;
+		update_user_meta( $user_id, $wpdb->prefix . 'auth0_id', $auth0_user_id );
+
+		$userinfo_encoded = WP_Auth0_Serializer::serialize( $userinfo );
+		$userinfo_encoded = wp_slash( $userinfo_encoded );
+		update_user_meta( $user_id, $wpdb->prefix . 'auth0_obj', $userinfo_encoded );
+
 		update_user_meta( $user_id, $wpdb->prefix . 'last_update', date( 'c' ) );
 	}
 
+	/**
+	 * Delete all Auth0 meta fields for a WordPress user.
+	 *
+	 * @param int $user_id - WordPress user ID.
+	 */
 	public function delete_auth0_object( $user_id ) {
 		global $wpdb;
 		delete_user_meta( $user_id, $wpdb->prefix . 'auth0_id' );

--- a/tests/suiteTemplate.php
+++ b/tests/suiteTemplate.php
@@ -1,0 +1,87 @@
+<?php
+/**
+ * Contains Class SuiteTemplate.
+ *
+ * @package WP-Auth0
+ *
+ * @since 3.8.0
+ */
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Class SuiteTemplate.
+ * Sample tests that can be copied and modified.
+ */
+class SuiteTemplate extends TestCase {
+
+
+	use AjaxHelpers;
+
+	use DomDocumentHelpers;
+
+	use HookHelpers;
+
+	use HttpHelpers;
+
+	use RedirectHelpers;
+
+	use SetUpTestDb;
+
+	use UsersHelper;
+
+	/**
+	 * Instance of WP_Auth0_Options.
+	 *
+	 * @var WP_Auth0_Options
+	 */
+	public static $opts;
+
+	/**
+	 * WP_Auth0_ErrorLog instance.
+	 *
+	 * @var WP_Auth0_ErrorLog
+	 */
+	protected static $error_log;
+
+	/**
+	 * Setup for entire test class.
+	 */
+	public static function setUpBeforeClass() {
+		parent::setUpBeforeClass();
+		self::$opts      = WP_Auth0_Options::Instance();
+		self::$error_log = new WP_Auth0_ErrorLog();
+	}
+
+	/**
+	 * Runs after each test method.
+	 */
+	public function setUp() {
+		parent::setUp();
+
+		$this->startAjaxHalting();
+		$this->startAjaxReturn();
+
+		$this->startHttpHalting();
+		$this->startHttpMocking();
+
+		$this->startRedirectHalting();
+	}
+
+	/**
+	 * Runs after each test method.
+	 */
+	public function tearDown() {
+		parent::tearDown();
+
+		$this->stopAjaxHalting();
+		$this->stopAjaxReturn();
+
+		$this->stopHttpHalting();
+		$this->stopHttpMocking();
+
+		$this->stopRedirectHalting();
+
+		self::$error_log->clear();
+	}
+}

--- a/tests/testRenderForm.php
+++ b/tests/testRenderForm.php
@@ -49,14 +49,14 @@ class TestRenderForm extends TestCase {
 		parent::setUpBeforeClass();
 		self::$opts     = WP_Auth0_Options::Instance();
 		self::$wp_auth0 = new WP_Auth0( self::$opts );
-
-		self::auth0Ready( false );
 	}
 
 	/**
 	 * Test that a specific region and domain return the correct number of IP addresses.
 	 */
 	public function testThatRenderFormPassesThrough() {
+		self::auth0Ready( false );
+		
 		$this->assertArrayNotHasKey( 'action', $_GET );
 
 		// Should pass through initially because WP-Auth0 is not configured.

--- a/tests/testRenderForm.php
+++ b/tests/testRenderForm.php
@@ -56,7 +56,7 @@ class TestRenderForm extends TestCase {
 	 */
 	public function testThatRenderFormPassesThrough() {
 		self::auth0Ready( false );
-		
+
 		$this->assertArrayNotHasKey( 'action', $_GET );
 
 		// Should pass through initially because WP-Auth0 is not configured.

--- a/tests/testUserRepoMeta.php
+++ b/tests/testUserRepoMeta.php
@@ -1,0 +1,130 @@
+<?php
+/**
+ * Contains Class TestUserRepoMeta.
+ *
+ * @package WP-Auth0
+ *
+ * @since 3.8.0
+ */
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Class TestUserRepoMeta.
+ * Tests that user meta is added, retrieved, and deleted properly.
+ */
+class TestUserRepoMeta extends TestCase {
+
+	use setUpTestDb;
+
+	use UsersHelper;
+
+	/**
+	 * Instance of WP_Auth0_Options.
+	 *
+	 * @var WP_Auth0_Options
+	 */
+	public static $opts;
+
+	/**
+	 * Setup for entire test class.
+	 */
+	public static function setUpBeforeClass() {
+		parent::setUpBeforeClass();
+		self::$opts       = WP_Auth0_Options::Instance();
+		self::$users_repo = new WP_Auth0_UsersRepo( self::$opts );
+	}
+
+	/**
+	 * Update and get user meta.
+	 */
+	public function testThatUpdateMetaIsReturnedProperly() {
+		$this->assertEmpty( self::$users_repo::get_meta( 1, 'auth0_id' ) );
+		$this->assertEmpty( self::$users_repo::get_meta( 1, 'auth0_obj' ) );
+		$this->assertEmpty( self::$users_repo::get_meta( 1, 'last_update' ) );
+
+		$userinfo = $this->getUserinfo();
+		self::$users_repo->update_auth0_object( 1, $userinfo );
+
+		$this->assertEquals( $userinfo->sub, self::$users_repo::get_meta( 1, 'auth0_id' ) );
+
+		$saved_update = self::$users_repo::get_meta( 1, 'last_update' );
+		$saved_update = explode( 'T', $saved_update );
+
+		$this->assertCount( 2, $saved_update );
+		$this->assertEquals( explode( 'T', date( 'c' ) )[0], $saved_update[0] );
+
+		// Make sure all the various ways we can get the user profile come back correctly.
+		$saved_userinfo = self::$users_repo::get_meta( 1, 'auth0_obj' );
+		$this->assertEquals( WP_Auth0_Serializer::serialize( $userinfo ), $saved_userinfo );
+
+		$saved_userinfo = WP_Auth0_Serializer::unserialize( $saved_userinfo );
+		$this->assertEquals( $userinfo, $saved_userinfo );
+
+		$saved_userinfo = get_auth0userinfo( 1 );
+		$this->assertEquals( $userinfo, $saved_userinfo );
+
+		$this->setGlobalUser( 1 );
+
+		$saved_userinfo = get_currentauth0user();
+		$this->assertEquals( $userinfo, $saved_userinfo->auth0_obj );
+		$this->assertEquals( $userinfo->sub, $saved_userinfo->auth0_id );
+	}
+
+	/**
+	 * Test that unique data cases are handled.
+	 */
+	public function testThatSpecialCharactersAreStoredProperly() {
+		$userinfo = $this->getUserinfo();
+
+		// Specially-encoded characters: ¥ £ € ¢ ₡ ₢ ₣ ₤ ₥ ₦ ₪ ₯.
+		$userinfo->encodedValue1 = '\u00a5 \u00a3 \u20ac \u00a2 \u20a1 \u20a2 \u20a3 \u20a4 \u20a5 \u20a6 \u20aa \u20af';
+
+		// MySQL-escaped characters.
+		$userinfo->encodedValue2 = '\\0 \\\' \\" \\b \\n \\r \\t \\Z \\ \\%  \\_';
+
+		// Special characters.
+		$userinfo->encodedValue3 = 'ⓝẸ𝐕ｅя 𝐂𝓞мⓟ𝕣σｍＩs𝔢 ό𝐍 ιĐᵉ𝓷т𝐢𝓣Ƴ 🔥🎉❓☝️✗→←';
+
+		// "Never Compromise on Identity" in Chinese.
+		$userinfo->encodedValue4 = '绝不妥协于身份';
+
+		self::$users_repo->update_auth0_object( 1, $userinfo );
+
+		$saved_userinfo = self::$users_repo::get_meta( 1, 'auth0_obj' );
+		$saved_userinfo = WP_Auth0_Serializer::unserialize( $saved_userinfo );
+		$this->assertEquals( $userinfo, $saved_userinfo );
+
+		$saved_userinfo = get_auth0userinfo( 1 );
+		$this->assertEquals( $userinfo, $saved_userinfo );
+	}
+
+	/**
+	 * Make sure meta values are deleted properly.
+	 */
+	public function testThatDeleteMetaDeletesData() {
+		$this->assertEmpty( self::$users_repo::get_meta( 1, 'auth0_id' ) );
+		$this->assertEmpty( self::$users_repo::get_meta( 1, 'auth0_obj' ) );
+		$this->assertEmpty( self::$users_repo::get_meta( 1, 'last_update' ) );
+
+		$this->storeAuth0Data( 1 );
+
+		$this->assertNotEmpty( self::$users_repo::get_meta( 1, 'auth0_id' ) );
+		$this->assertNotEmpty( self::$users_repo::get_meta( 1, 'auth0_obj' ) );
+		$this->assertNotEmpty( self::$users_repo::get_meta( 1, 'last_update' ) );
+
+		self::$users_repo->delete_auth0_object( 1 );
+
+		$this->assertEmpty( self::$users_repo::get_meta( 1, 'auth0_id' ) );
+		$this->assertEmpty( self::$users_repo::get_meta( 1, 'auth0_obj' ) );
+		$this->assertEmpty( self::$users_repo::get_meta( 1, 'last_update' ) );
+	}
+
+	/**
+	 * Run after every test.
+	 */
+	public function tearDown() {
+		parent::tearDown();
+		self::$users_repo->delete_auth0_object( 1 );
+	}
+}


### PR DESCRIPTION
### Changes

- Add `wp_slash()` processing before saving the user profile from Auth0
- Simplified get user profile functions in `WP_Auth0.php`
- Add tests to confirm broken behavior and fix
- Add sample test suite `tests/suiteTemplate.php`

### References

- [Reported in the WP support forums](https://wordpress.org/support/topic/get-user_metadata/)
- [StackOverflow fix applied](https://wordpress.stackexchange.com/questions/53336/wordpress-is-stripping-escape-backslashes-from-json-strings-in-post-meta)

### Testing

Tests were added before changes to confirm all current behavior as well as broken behavior. 

* [x] This change adds unit test coverage
* [x] This change has been tested on the latest version of the platform

### Checklist

* [x] All existing and new tests complete without errors
* [x] All code quality tools/guidelines in the [Contribution guide](CONTRIBUTION.md) have been run/followed
* [x] All active GitHub CI checks have passed
