### PR TITLE
Update telemetry header

### DIFF
--- a/lib/WP_Auth0_Api_Client.php
+++ b/lib/WP_Auth0_Api_Client.php
@@ -64,9 +64,11 @@ class WP_Auth0_Api_Client {
 
 	/**
 	 * Get required telemetry header.
-	 * TODO: Refactor to use WP_Auth0_Api_Abstract::get_info_headers and deprecate.
+	 * TODO: Deprecate
 	 *
 	 * @return array
+	 *
+	 * @codeCoverageIgnore - Deprecated
 	 */
 	public static function get_info_headers() {
 		return WP_Auth0_Api_Abstract::get_info_headers();
@@ -84,7 +86,7 @@ class WP_Auth0_Api_Client {
 	 */
 	private static function get_headers( $token = '', $content_type = 'application/json' ) {
 
-		$headers = self::get_info_headers();
+		$headers = WP_Auth0_Api_Abstract::get_info_headers();
 
 		if ( ! empty( $token ) ) {
 			$headers['Authorization'] = "Bearer {$token}";
@@ -110,7 +112,7 @@ class WP_Auth0_Api_Client {
 		$body['client_secret'] = is_null( $client_secret ) ? '' : $client_secret;
 		$body['grant_type']    = $grantType;
 
-		$headers                 = self::get_info_headers();
+		$headers                 = WP_Auth0_Api_Abstract::get_info_headers();
 		$headers['content-type'] = 'application/x-www-form-urlencoded';
 
 		$response = wp_remote_post(
@@ -189,7 +191,7 @@ class WP_Auth0_Api_Client {
 	public static function get_user( $domain, $jwt, $user_id ) {
 		$endpoint = "https://$domain/api/v2/users/" . urlencode( $user_id );
 
-		$headers = self::get_info_headers();
+		$headers = WP_Auth0_Api_Abstract::get_info_headers();
 
 		$headers['Authorization'] = "Bearer $jwt";
 
@@ -206,7 +208,7 @@ class WP_Auth0_Api_Client {
 
 		$endpoint = "https://$domain/dbconnections/signup";
 
-		$headers = self::get_info_headers();
+		$headers = WP_Auth0_Api_Abstract::get_info_headers();
 
 		$headers['content-type'] = 'application/json';
 
@@ -352,7 +354,7 @@ class WP_Auth0_Api_Client {
 
 		$endpoint = "https://$domain/api/v2/clients/$client_id";
 
-		$headers = self::get_info_headers();
+		$headers = WP_Auth0_Api_Abstract::get_info_headers();
 
 		$headers['Authorization'] = "Bearer $app_token";
 		$headers['content-type']  = 'application/json';
@@ -391,7 +393,7 @@ class WP_Auth0_Api_Client {
 
 		$endpoint = "https://$domain/api/v2/rules";
 
-		$headers = self::get_info_headers();
+		$headers = WP_Auth0_Api_Abstract::get_info_headers();
 
 		$headers['Authorization'] = "Bearer $app_token";
 		$headers['content-type']  = 'application/json';
@@ -424,7 +426,7 @@ class WP_Auth0_Api_Client {
 
 		$endpoint = "https://$domain/api/v2/rules/$id";
 
-		$headers = self::get_info_headers();
+		$headers = WP_Auth0_Api_Abstract::get_info_headers();
 
 		$headers['Authorization'] = "Bearer $app_token";
 		$headers['content-type']  = 'application/json';
@@ -510,7 +512,7 @@ class WP_Auth0_Api_Client {
 	public static function create_connection( $domain, $app_token, $payload ) {
 		$endpoint = "https://$domain/api/v2/connections";
 
-		$headers = self::get_info_headers();
+		$headers = WP_Auth0_Api_Abstract::get_info_headers();
 
 		$headers['Authorization'] = "Bearer $app_token";
 		$headers['content-type']  = 'application/json';
@@ -546,7 +548,7 @@ class WP_Auth0_Api_Client {
 			$endpoint .= "?strategy=$strategy";
 		}
 
-		$headers = self::get_info_headers();
+		$headers = WP_Auth0_Api_Abstract::get_info_headers();
 
 		$headers['Authorization'] = "Bearer $app_token";
 
@@ -579,7 +581,7 @@ class WP_Auth0_Api_Client {
 	public static function get_connection( $domain, $app_token, $id ) {
 		$endpoint = "https://$domain/api/v2/connections/$id";
 
-		$headers = self::get_info_headers();
+		$headers = WP_Auth0_Api_Abstract::get_info_headers();
 
 		$headers['Authorization'] = "Bearer $app_token";
 
@@ -612,7 +614,7 @@ class WP_Auth0_Api_Client {
 	public static function update_connection( $domain, $app_token, $id, $payload ) {
 		$endpoint = "https://$domain/api/v2/connections/$id";
 
-		$headers = self::get_info_headers();
+		$headers = WP_Auth0_Api_Abstract::get_info_headers();
 
 		$headers['Authorization'] = "Bearer $app_token";
 		$headers['content-type']  = 'application/json';
@@ -648,7 +650,7 @@ class WP_Auth0_Api_Client {
 	public static function update_user( $domain, $app_token, $id, $payload ) {
 		$endpoint = "https://$domain/api/v2/users/$id";
 
-		$headers = self::get_info_headers();
+		$headers = WP_Auth0_Api_Abstract::get_info_headers();
 
 		$headers['Authorization'] = "Bearer $app_token";
 		$headers['content-type']  = 'application/json';
@@ -737,7 +739,7 @@ class WP_Auth0_Api_Client {
 	public static function update_guardian( $domain, $app_token, $factor, $enabled ) {
 		$endpoint = "https://$domain/api/v2/guardian/factors/$factor";
 
-		$headers = self::get_info_headers();
+		$headers = WP_Auth0_Api_Abstract::get_info_headers();
 
 		$headers['Authorization'] = "Bearer $app_token";
 		$headers['content-type']  = 'application/json';
@@ -876,7 +878,7 @@ class WP_Auth0_Api_Client {
 
 		$endpoint = "https://$domain/";
 
-		$headers                 = self::get_info_headers();
+		$headers                 = WP_Auth0_Api_Abstract::get_info_headers();
 		$headers['content-type'] = 'application/x-www-form-urlencoded';
 		$body                    = array(
 			'client_id'  => $client_id,
@@ -965,7 +967,7 @@ class WP_Auth0_Api_Client {
 
 		$endpoint = "https://$domain/api/v2/users?include_totals=$include_totals&per_page=$per_page&page=$page&sort=$sort&q=$q&search_engine=v2";
 
-		$headers = self::get_info_headers();
+		$headers = WP_Auth0_Api_Abstract::get_info_headers();
 
 		$headers['Authorization'] = "Bearer $jwt";
 
@@ -1035,7 +1037,7 @@ class WP_Auth0_Api_Client {
 
 		$endpoint = "https://$domain/api/v2/users";
 
-		$headers = self::get_info_headers();
+		$headers = WP_Auth0_Api_Abstract::get_info_headers();
 
 		$headers['Authorization'] = "Bearer $jwt";
 		$headers['content-type']  = 'application/json';
@@ -1074,7 +1076,7 @@ class WP_Auth0_Api_Client {
 
 		$endpoint = "https://$domain/api/v2/clients";
 
-		$headers = self::get_info_headers();
+		$headers = WP_Auth0_Api_Abstract::get_info_headers();
 
 		$headers['Authorization'] = "Bearer $app_token";
 
@@ -1130,7 +1132,7 @@ class WP_Auth0_Api_Client {
 
 		$endpoint = "https://$domain/api/v2/connections/$id";
 
-		$headers = self::get_info_headers();
+		$headers = WP_Auth0_Api_Abstract::get_info_headers();
 
 		$headers['Authorization'] = "Bearer $app_token";
 		$headers['content-type']  = 'application/json';
@@ -1169,7 +1171,7 @@ class WP_Auth0_Api_Client {
 
 		$endpoint = "https://$domain/api/v2/users/$user_id/multifactor/$provider";
 
-		$headers = self::get_info_headers();
+		$headers = WP_Auth0_Api_Abstract::get_info_headers();
 
 		$headers['Authorization'] = "Bearer $app_token";
 		$headers['content-type']  = 'application/json';
@@ -1208,7 +1210,7 @@ class WP_Auth0_Api_Client {
 
 		$endpoint = "https://$domain/dbconnections/change_password";
 
-		$headers = self::get_info_headers();
+		$headers = WP_Auth0_Api_Abstract::get_info_headers();
 
 		$headers['content-type'] = 'application/json';
 
@@ -1251,7 +1253,7 @@ class WP_Auth0_Api_Client {
 
 		$endpoint = "https://$domain/api/v2/users/$main_user_id/identities";
 
-		$headers = self::get_info_headers();
+		$headers = WP_Auth0_Api_Abstract::get_info_headers();
 
 		$headers['Authorization'] = "Bearer $app_token";
 		$headers['content-type']  = 'application/json';

--- a/lib/WP_Auth0_LoginManager.php
+++ b/lib/WP_Auth0_LoginManager.php
@@ -579,7 +579,7 @@ class WP_Auth0_LoginManager {
 
 		// If SSO is in use, redirect to Auth0 to logout there as well.
 		if ( $is_sso ) {
-			$telemetry_headers = WP_Auth0_Api_Client::get_info_headers();
+			$telemetry_headers = WP_Auth0_Api_Abstract::get_info_headers();
 			$redirect_url      = sprintf(
 				'https://%s/v2/logout?returnTo=%s&client_id=%s&auth0Client=%s',
 				$this->a0_options->get_auth_domain(),
@@ -683,7 +683,7 @@ class WP_Auth0_LoginManager {
 		}
 
 		// Get the telemetry header.
-		$telemetry             = WP_Auth0_Api_Client::get_info_headers();
+		$telemetry             = WP_Auth0_Api_Abstract::get_info_headers();
 		$params['auth0Client'] = $telemetry['Auth0-Client'];
 
 		// Where should the user be redirected after logging in?

--- a/lib/api/WP_Auth0_Api_Abstract.php
+++ b/lib/api/WP_Auth0_Api_Abstract.php
@@ -133,11 +133,11 @@ abstract class WP_Auth0_Api_Abstract {
 	 */
 	public static function get_info_headers() {
 		$header_value = array(
-			'name'        => 'wp-auth0',
-			'version'     => WPA0_VERSION,
-			'environment' => array(
-				'PHP'       => phpversion(),
-				'WordPress' => get_bloginfo( 'version' ),
+			'name'    => 'wp-auth0',
+			'version' => WPA0_VERSION,
+			'env'     => array(
+				'php' => phpversion(),
+				'wp'  => get_bloginfo( 'version' ),
 			),
 		);
 		return array( 'Auth0-Client' => base64_encode( wp_json_encode( $header_value ) ) );

--- a/tests/testApiAbstract.php
+++ b/tests/testApiAbstract.php
@@ -62,13 +62,18 @@ class TestApiAbstract extends TestCase {
 		// 2. Test that we have an analytics header being sent with the correct data.
 		$headers = $api_abstract->get_request( 'headers' );
 		$this->assertNotEmpty( $headers );
-		$this->assertNotEmpty( $headers['Auth0-Client'] );
+		$this->assertArrayHasKey( 'Auth0-Client', $headers );
 
 		$client_header = base64_decode( $headers['Auth0-Client'] );
 		$client_header = json_decode( $client_header, true );
 
 		$this->assertEquals( 'wp-auth0', $client_header['name'] );
 		$this->assertEquals( WPA0_VERSION, $client_header['version'] );
+		$this->assertArrayHasKey( 'env', $client_header );
+		$this->assertArrayHasKey( 'php', $client_header['env'] );
+		$this->assertEquals( phpversion(), $client_header['env']['php'] );
+		$this->assertArrayHasKey( 'wp', $client_header['env'] );
+		$this->assertEquals( get_bloginfo( 'version' ), $client_header['env']['wp'] );
 	}
 
 	/**


### PR DESCRIPTION
### Changes

- Update `environment` property with `env`
- Replace `WP_Auth0_Api_Client::get_info_headers()` with `WP_Auth0_Api_Abstract::get_info_headers()`

### References

See internal RFC.

### Testing

* [x] This change adds unit test coverage
* [x] This change has been tested on the latest version of the platform/language or why not

### Checklist

* [x] All existing and new tests complete without errors
* [x] All code quality tools/guidelines in the [Contribution guide](CONTRIBUTION.md) have been run/followed
* [x] All active GitHub CI checks have passed
