### PR TITLE
Fix Connection update over-writing Connection settings.

### DIFF
--- a/lib/WP_Auth0_Api_Client.php
+++ b/lib/WP_Auth0_Api_Client.php
@@ -611,6 +611,17 @@ class WP_Auth0_Api_Client {
 		return json_decode( $response['body'] );
 	}
 
+	/**
+	 * Update a Connection via the Management API.
+	 * Note: $payload must be a complete settings object, not just the property to change.
+	 *
+	 * @param string   $domain - Auth0 Domain.
+	 * @param string   $app_token - Valid Auth0 Management API token.
+	 * @param string   $id - DB Connection ID.
+	 * @param stdClass $payload - DB Connection settings, will override existing.
+	 *
+	 * @return bool|object
+	 */
 	public static function update_connection( $domain, $app_token, $id, $payload ) {
 		$endpoint = "https://$domain/api/v2/connections/$id";
 
@@ -618,6 +629,14 @@ class WP_Auth0_Api_Client {
 
 		$headers['Authorization'] = "Bearer $app_token";
 		$headers['content-type']  = 'application/json';
+
+		unset( $payload->name );
+		unset( $payload->strategy );
+		unset( $payload->id );
+
+		if ( ! empty( $payload->enabled_clients ) ) {
+			$payload->enabled_clients = array_values( $payload->enabled_clients );
+		}
 
 		$response = wp_remote_post(
 			$endpoint,

--- a/lib/WP_Auth0_Api_Operations.php
+++ b/lib/WP_Auth0_Api_Operations.php
@@ -30,10 +30,6 @@ class WP_Auth0_Api_Operations {
 		$connection->options->customScripts->login    = $login_script;
 		$connection->options->customScripts->get_user = $get_user_script;
 
-		unset( $connection->name );
-		unset( $connection->strategy );
-		unset( $connection->id );
-
 		WP_Auth0_Api_Client::update_connection( $domain, $app_token, $connection_id, $connection );
 
 	}
@@ -99,34 +95,10 @@ class WP_Auth0_Api_Operations {
 		$response = WP_Auth0_Api_Client::create_connection( $domain, $app_token, $body );
 
 		if ( $response === false ) {
-
 			return false;
-
 		}
 
-		$connections   = WP_Auth0_Api_Client::search_connection( $domain, $app_token, 'auth0' );
-		$db_connection = null;
-
-		$migration_connection_id = $response->id;
-
-		foreach ( $connections as $connection ) {
-			if ( $migration_connection_id != $connection->id && in_array( $client_id, $connection->enabled_clients ) ) {
-				$db_connection = $connection;
-
-				$enabled_clients = array_diff( $db_connection->enabled_clients, array( $client_id ) );
-
-				WP_Auth0_Api_Client::update_connection(
-					$domain,
-					$app_token,
-					$db_connection->id,
-					array(
-						'enabled_clients' => array_values( $enabled_clients ),
-					)
-				);
-			}
-		}
-
-		return $migration_connection_id;
+		return $response->id;
 	}
 
 	// $input['geo_rule'] = ( isset( $input['geo_rule'] ) ? $input['geo_rule'] : 0 );

--- a/lib/admin/WP_Auth0_Admin_Advanced.php
+++ b/lib/admin/WP_Auth0_Admin_Advanced.php
@@ -741,10 +741,6 @@ class WP_Auth0_Admin_Advanced extends WP_Auth0_Admin_Generic {
 					$connection->options->enabledDatabaseCustomization = false;
 					$connection->options->import_mode                  = false;
 
-					unset( $connection->name );
-					unset( $connection->strategy );
-					unset( $connection->id );
-
 					$response = WP_Auth0_Api_Client::update_connection( $input['domain'], $input['auth0_app_token'], $old_options['db_connection_id'], $connection );
 				} else {
 					$response = false;

--- a/lib/admin/WP_Auth0_Admin_Features.php
+++ b/lib/admin/WP_Auth0_Admin_Features.php
@@ -427,8 +427,10 @@ class WP_Auth0_Admin_Features extends WP_Auth0_Admin_Generic {
 
 			foreach ( $connections as $connection ) {
 				if ( in_array( $input['client_id'], $connection->enabled_clients ) ) {
-					$patch       = array( 'options' => array( 'passwordPolicy' => $input['password_policy'] ) );
-					$update_resp = WP_Auth0_Api_Client::update_connection( $domain, $app_token, $connection->id, $patch );
+					$u_connection                          = clone $connection;
+					$u_connection->options->passwordPolicy = $input['password_policy'];
+
+					$update_resp = WP_Auth0_Api_Client::update_connection( $domain, $app_token, $u_connection->id, $u_connection );
 
 					if ( false === $update_resp ) {
 						$this->add_validation_error(

--- a/lib/admin/WP_Auth0_Admin_Features.php
+++ b/lib/admin/WP_Auth0_Admin_Features.php
@@ -423,6 +423,8 @@ class WP_Auth0_Admin_Features extends WP_Auth0_Admin_Generic {
 					__( 'No database connections found for this application. ', 'wp-auth0' ) .
 					$this->get_dashboard_link( 'connections/database', __( 'See all database connections', 'wp-auth0' ) )
 				);
+				$input['password_policy'] = $old_options['password_policy'];
+				return $input;
 			}
 
 			foreach ( $connections as $connection ) {
@@ -438,6 +440,7 @@ class WP_Auth0_Admin_Features extends WP_Auth0_Admin_Generic {
 							__( 'Please manually review and update the policy. ', 'wp-auth0' ) .
 							$this->get_dashboard_link( 'connections/database', __( 'See all database connections', 'wp-auth0' ) )
 						);
+						$input['password_policy'] = $old_options['password_policy'];
 					}
 				}
 			}

--- a/tests/testAdminFeatures.php
+++ b/tests/testAdminFeatures.php
@@ -1,0 +1,215 @@
+<?php
+/**
+ * Contains Class TestAdminFeatures.
+ *
+ * @package WP-Auth0
+ *
+ * @since 3.8.1
+ */
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Class TestAdminFeatures.
+ */
+class TestAdminFeatures extends TestCase {
+
+	use HttpHelpers;
+
+	use RedirectHelpers;
+
+	use SetUpTestDb;
+
+	/**
+	 * Instance of WP_Auth0_Options.
+	 *
+	 * @var WP_Auth0_Options
+	 */
+	public static $opts;
+
+	/**
+	 * WP_Auth0_ErrorLog instance.
+	 *
+	 * @var WP_Auth0_ErrorLog
+	 */
+	protected static $error_log;
+
+	/**
+	 * Runs once before all tests.
+	 */
+	public static function setUpBeforeClass() {
+		parent::setUpBeforeClass();
+		self::$opts      = WP_Auth0_Options::Instance();
+		self::$error_log = new WP_Auth0_ErrorLog();
+	}
+
+	/**
+	 * Test that the validation does not run if the current value matches the old value.
+	 */
+	public function testThatInputIsNotValidatedIfItIsNotChanged() {
+		$admin_features = new WP_Auth0_Admin_Features( self::$opts );
+
+		$old_input = [ 'password_policy' => 'fair' ];
+		$new_input = [ 'password_policy' => 'fair' ];
+		$result    = $admin_features->security_validation( $old_input, $new_input );
+
+		$this->assertEquals( $old_input, $result );
+
+		global $wp_settings_errors;
+		$this->assertEmpty( $wp_settings_errors );
+	}
+
+	/**
+	 * Test the connection search request structure.
+	 */
+	public function testThatConnectionsAreSearchedDuringValidation() {
+		$this->startHttpHalting();
+
+		$test_domain    = 'test-wp.auth0.com';
+		$test_token     = implode( '.', [ uniqid(), uniqid(), uniqid() ] );
+		$admin_features = new WP_Auth0_Admin_Features( self::$opts );
+
+		$old_input = [ 'password_policy' => 'fair' ];
+		$new_input = [
+			'password_policy' => 'good',
+			'domain'          => $test_domain,
+			'auth0_app_token' => $test_token,
+		];
+
+		$caught_request = [];
+		try {
+			$admin_features->security_validation( $old_input, $new_input );
+		} catch ( Exception $e ) {
+			$caught_request = unserialize( $e->getMessage() );
+		}
+
+		$this->assertEquals( 'https://test-wp.auth0.com/api/v2/connections?strategy=auth0', $caught_request['url'] );
+		$this->assertEquals( 'Bearer ' . $test_token, $caught_request['headers']['Authorization'] );
+		$this->assertEmpty( $caught_request['body'] );
+	}
+
+	/**
+	 * Test that we get a UI error if there are no connections to set.
+	 */
+	public function testThatAnErrorIsSetIfThereAreNoConnections() {
+		$this->startHttpMocking();
+
+		$admin_features = new WP_Auth0_Admin_Features( self::$opts );
+
+		$old_input = [ 'password_policy' => 'fair' ];
+		$new_input = [
+			'password_policy' => 'good',
+			'domain'          => 'test-wp.auth0.com',
+			'auth0_app_token' => implode( '.', [ uniqid(), uniqid(), uniqid() ] ),
+		];
+
+		$this->http_request_type = 'success_empty_body';
+
+		$result = $admin_features->security_validation( $old_input, $new_input );
+
+		global $wp_settings_errors;
+
+		$this->assertContains( 'No database connections found', $wp_settings_errors[0]['message'] );
+		$this->assertContains( 'https://manage.auth0.com/#/connections/database', $wp_settings_errors[0]['message'] );
+		$this->assertEquals( 'wp_auth0_settings', $wp_settings_errors[0]['code'] );
+		$this->assertEquals( 'wp_auth0_settings', $wp_settings_errors[0]['setting'] );
+		$this->assertEquals( $old_input['password_policy'], $result['password_policy'] );
+	}
+
+	/**
+	 * Test that the update connection request is set properly.
+	 */
+	public function testThatAnUpdateRequestIsSent() {
+		$this->startHttpMocking();
+
+		$admin_features = new WP_Auth0_Admin_Features( self::$opts );
+
+		$old_input = [ 'password_policy' => 'fair' ];
+		$new_input = [
+			'password_policy' => 'good',
+			'domain'          => 'test-wp.auth0.com',
+			'auth0_app_token' => implode( '.', [ uniqid(), uniqid(), uniqid() ] ),
+			'client_id'       => 'TEST_CLIENT_ID',
+		];
+
+		$this->http_request_type = [ 'success_get_connections', 'halt' ];
+
+		$caught_request = [ 'Nothing caught' ];
+		try {
+			$admin_features->security_validation( $old_input, $new_input );
+		} catch ( Exception $e ) {
+			$caught_request = unserialize( $e->getMessage() );
+		}
+
+		$this->assertEquals( 'https://test-wp.auth0.com/api/v2/connections/TEST_CONN_ID', $caught_request['url'] );
+		$this->assertEquals( 'Bearer ' . $new_input['auth0_app_token'], $caught_request['headers']['Authorization'] );
+		$this->assertContains( $new_input['client_id'], $caught_request['body']['enabled_clients'] );
+		$this->assertEquals( $new_input['password_policy'], $caught_request['body']['options']['passwordPolicy'] );
+	}
+
+	/**
+	 * Test that we get a UI error if the connection cannot be updated properly.
+	 */
+	public function testThatAnErrorIsSetIfConnectionUpdateFails() {
+		$this->startHttpMocking();
+
+		$admin_features = new WP_Auth0_Admin_Features( self::$opts );
+
+		$old_input = [ 'password_policy' => 'fair' ];
+		$new_input = [
+			'password_policy' => 'good',
+			'domain'          => 'test-wp.auth0.com',
+			'auth0_app_token' => implode( '.', [ uniqid(), uniqid(), uniqid() ] ),
+			'client_id'       => 'TEST_CLIENT_ID',
+		];
+
+		$this->http_request_type = [ 'success_get_connections', 'wp_error' ];
+
+		$result = $admin_features->security_validation( $old_input, $new_input );
+
+		global $wp_settings_errors;
+
+		$this->assertContains( 'There was a problem updating the password policy.', $wp_settings_errors[0]['message'] );
+		$this->assertContains( 'https://manage.auth0.com/#/connections/database', $wp_settings_errors[0]['message'] );
+		$this->assertEquals( 'wp_auth0_settings', $wp_settings_errors[0]['code'] );
+		$this->assertEquals( 'wp_auth0_settings', $wp_settings_errors[0]['setting'] );
+		$this->assertEquals( $old_input['password_policy'], $result['password_policy'] );
+	}
+
+	/**
+	 * Test that an end-to-end update is successful.
+	 */
+	public function testThatPasswordPolicyUpdatesWithoutErrors() {
+		$this->startHttpMocking();
+
+		$admin_features = new WP_Auth0_Admin_Features( self::$opts );
+
+		$old_input = [ 'password_policy' => 'fair' ];
+		$new_input = [
+			'password_policy' => 'good',
+			'domain'          => 'test-wp.auth0.com',
+			'auth0_app_token' => implode( '.', [ uniqid(), uniqid(), uniqid() ] ),
+			'client_id'       => 'TEST_CLIENT_ID',
+		];
+
+		$this->http_request_type = [ 'success_get_connections', 'success_update_connection' ];
+
+		$result = $admin_features->security_validation( $old_input, $new_input );
+		$this->assertEquals( $new_input['password_policy'], $result['password_policy'] );
+
+		global $wp_settings_errors;
+		$this->assertEmpty( $wp_settings_errors );
+	}
+
+	/**
+	 * Runs after each test method.
+	 */
+	public function tearDown() {
+		parent::tearDown();
+
+		$this->stopHttpHalting();
+		$this->stopHttpMocking();
+
+		self::$error_log->clear();
+	}
+}

--- a/tests/testApiOperations.php
+++ b/tests/testApiOperations.php
@@ -1,0 +1,173 @@
+<?php
+/**
+ * Contains Class TestApiOperations.
+ *
+ * @package WP-Auth0
+ *
+ * @since 3.8.1
+ */
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Class TestApiOperations.
+ */
+class TestApiOperations extends TestCase {
+
+	use HttpHelpers;
+
+	use RedirectHelpers;
+
+	use SetUpTestDb;
+
+	/**
+	 * Instance of WP_Auth0_Options.
+	 *
+	 * @var WP_Auth0_Options
+	 */
+	public static $opts;
+
+	/**
+	 * WP_Auth0_ErrorLog instance.
+	 *
+	 * @var WP_Auth0_ErrorLog
+	 */
+	protected static $error_log;
+
+	/**
+	 * Setup for entire test class.
+	 */
+	public static function setUpBeforeClass() {
+		parent::setUpBeforeClass();
+		self::$opts      = WP_Auth0_Options::Instance();
+		self::$error_log = new WP_Auth0_ErrorLog();
+	}
+
+	/**
+	 * Test that a basic create connection command requests properly.
+	 */
+	public function testThatCreateConnectionRequestsCorrectly() {
+		$this->startHttpHalting();
+
+		$api_ops    = new WP_Auth0_Api_Operations( self::$opts );
+		$test_token = implode( '.', [ uniqid(), uniqid(), uniqid() ] );
+
+		self::$opts->set( 'domain', 'test-wp.auth0.com' );
+		self::$opts->set( 'client_id', 'TEST_CLIENT_ID' );
+
+		$caught_http = [];
+		try {
+			$api_ops->create_wordpress_connection( $test_token, false, 'good' );
+		} catch ( Exception $e ) {
+			$caught_http = unserialize( $e->getMessage() );
+		}
+
+		$this->assertEquals( 'https://test-wp.auth0.com/api/v2/connections', $caught_http['url'] );
+		$this->assertEquals( 'Bearer ' . $test_token, $caught_http['headers']['Authorization'] );
+		$this->assertEquals( 'DB-Test-Blog', $caught_http['body']['name'] );
+		$this->assertEquals( 'auth0', $caught_http['body']['strategy'] );
+		$this->assertEquals( 'good', $caught_http['body']['options']['passwordPolicy'] );
+		$this->assertContains( 'TEST_CLIENT_ID', $caught_http['body']['enabled_clients'] );
+	}
+
+	/**
+	 * Test that a migration create connection command requests properly.
+	 */
+	public function testThatCreateConnectionWithMigrationRequestsCorrectly() {
+		$this->startHttpHalting();
+
+		$api_ops    = new WP_Auth0_Api_Operations( self::$opts );
+		$test_token = implode( '.', [ uniqid(), uniqid(), uniqid() ] );
+
+		self::$opts->set( 'domain', 'test-wp2.auth0.com' );
+		self::$opts->set( 'client_id', 'TEST_CLIENT_ID_2' );
+
+		$caught_http = [];
+		try {
+			$api_ops->create_wordpress_connection( $test_token, true, 'fair', 'TEST_MIGRATION_TOKEN' );
+		} catch ( Exception $e ) {
+			$caught_http = unserialize( $e->getMessage() );
+		}
+
+		$this->assertEquals( 'https://test-wp2.auth0.com/api/v2/connections', $caught_http['url'] );
+		$this->assertEquals( 'Bearer ' . $test_token, $caught_http['headers']['Authorization'] );
+		$this->assertEquals( 'DB-Test-Blog', $caught_http['body']['name'] );
+		$this->assertEquals( 'auth0', $caught_http['body']['strategy'] );
+		$this->assertContains( 'TEST_CLIENT_ID_2', $caught_http['body']['enabled_clients'] );
+
+		$this->assertEquals( true, $caught_http['body']['options']['requires_username'] );
+		$this->assertEquals( true, $caught_http['body']['options']['import_mode'] );
+		$this->assertEquals( true, $caught_http['body']['options']['enabledDatabaseCustomization'] );
+		$this->assertEquals(
+			[
+				'min' => 1,
+				'max' => 100,
+			],
+			$caught_http['body']['options']['validation']['username']
+		);
+
+		$this->assertContains(
+			'request.post("http://example.org/index.php?a0_action=migration-ws-login"',
+			$caught_http['body']['options']['customScripts']['login']
+		);
+
+		$this->assertContains(
+			'form:{username:email, password:password, access_token:"TEST_MIGRATION_TOKEN"}',
+			$caught_http['body']['options']['customScripts']['login']
+		);
+
+		$this->assertContains(
+			'request.post("http://example.org/index.php?a0_action=migration-ws-get-user"',
+			$caught_http['body']['options']['customScripts']['get_user']
+		);
+
+		$this->assertContains(
+			'form:{username:email, access_token:"TEST_MIGRATION_TOKEN',
+			$caught_http['body']['options']['customScripts']['get_user']
+		);
+	}
+
+	/**
+	 * Test that successful and unsuccessful requests return properly.
+	 */
+	public function testThatCreateConnectionReturnsCorrectly() {
+		$this->startHttpMocking();
+
+		$api_ops    = new WP_Auth0_Api_Operations( self::$opts );
+		$test_token = implode( '.', [ uniqid(), uniqid(), uniqid() ] );
+
+		self::$opts->set( 'domain', 'test-wp.auth0.com' );
+		self::$opts->set( 'client_id', 'TEST_CLIENT_ID' );
+
+		$this->http_request_type = 'success_create_connection';
+
+		$result = $api_ops->create_wordpress_connection( $test_token, false );
+
+		$this->assertEquals( 'TEST_CREATED_CONN_ID', $result );
+		$this->assertEquals( 'DB-Test-Blog', self::$opts->get( 'db_connection_name' ) );
+
+		$this->http_request_type = 'wp_error';
+
+		$result = $api_ops->create_wordpress_connection( $test_token, false );
+
+		$this->assertFalse( $result );
+	}
+
+	/**
+	 * Runs after each test method.
+	 */
+	public function tearDown() {
+		parent::tearDown();
+
+		self::$opts->set( 'domain', self::$opts->get_default( 'domain' ) );
+		self::$opts->set( 'client_id', self::$opts->get_default( 'client_id' ) );
+		self::$opts->set( 'migration_ips', self::$opts->get_default( 'migration_ips' ) );
+		self::$opts->set( 'migration_ips_filter', self::$opts->get_default( 'migration_ips_filter' ) );
+		self::$opts->set( 'db_connection_name', null );
+
+		$this->stopHttpHalting();
+		$this->stopHttpMocking();
+
+		self::$error_log->clear();
+	}
+}

--- a/tests/testInitialSetupConsent.php
+++ b/tests/testInitialSetupConsent.php
@@ -1,0 +1,297 @@
+<?php
+/**
+ * Contains Class TestInitialSetupConsent.
+ *
+ * @package WP-Auth0
+ *
+ * @since 3.8.1
+ */
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Class TestInitialSetupConsent.
+ */
+class TestInitialSetupConsent extends TestCase {
+
+	use httpHelpers {
+		httpMock as protected httpMockDefault;
+	}
+
+	use RedirectHelpers;
+
+	use SetUpTestDb;
+
+	/**
+	 * Instance of WP_Auth0_Options.
+	 *
+	 * @var WP_Auth0_Options
+	 */
+	public static $opts;
+
+	/**
+	 * WP_Auth0_ErrorLog instance.
+	 *
+	 * @var WP_Auth0_ErrorLog
+	 */
+	protected static $error_log;
+
+	/**
+	 * Setup for entire test class.
+	 */
+	public static function setUpBeforeClass() {
+		parent::setUpBeforeClass();
+		self::$opts      = WP_Auth0_Options::Instance();
+		self::$error_log = new WP_Auth0_ErrorLog();
+	}
+
+	/**
+	 * Test that an invalid state is redirected to the right place.
+	 */
+	public function testThatInvalidStateRedirectsProperly() {
+		$this->startRedirectHalting();
+
+		$setup_consent = new WP_Auth0_InitialSetup_Consent( self::$opts );
+		$test_domain   = 'test-wp.auth0.com';
+		$test_token    = implode( '.', [ uniqid(), uniqid(), uniqid() ] );
+
+		$caught_redirect = [];
+		try {
+			$setup_consent->callback_with_token( $test_domain, $test_token, 'invalid_state' );
+		} catch ( Exception $e ) {
+			$caught_redirect = unserialize( $e->getMessage() );
+		}
+
+		$this->assertNotEmpty( $caught_redirect );
+		$this->assertEquals( 302, $caught_redirect['status'] );
+
+		$redirect_url = parse_url( $caught_redirect['location'] );
+
+		$this->assertEquals( '/wp-admin/admin.php', $redirect_url['path'] );
+		$this->assertContains( 'page=wpa0-setup', $redirect_url['query'] );
+		$this->assertContains( 'error=invalid_state', $redirect_url['query'] );
+
+		$this->assertEquals( $test_domain, self::$opts->get( 'domain' ) );
+		$this->assertEquals( $test_token, self::$opts->get( 'auth0_app_token' ) );
+
+		$this->assertEmpty( self::$error_log->get() );
+	}
+
+	/**
+	 * Test that the create client call is made.
+	 */
+	public function testThatClientCreationIsAttempted() {
+		$this->startHttpHalting();
+
+		$setup_consent = new WP_Auth0_InitialSetup_Consent( self::$opts );
+		$test_token    = implode( '.', [ uniqid(), uniqid(), uniqid() ] );
+
+		$caught_http = [];
+		try {
+			$setup_consent->callback_with_token( 'test-wp.auth0.com', $test_token, 'social' );
+		} catch ( Exception $e ) {
+			$caught_http = unserialize( $e->getMessage() );
+		}
+
+		// Just want to test if the Create Client call happened.
+		// Unit testing for what exactly was sent should be written against WP_Auth0_Api_Client::create_client().
+		$this->assertNotEmpty( $caught_http );
+		$this->assertEquals( 'https://test-wp.auth0.com/api/v2/clients', $caught_http['url'] );
+		$this->assertEquals( 'Bearer ' . $test_token, $caught_http['headers']['Authorization'] );
+
+		$this->assertEmpty( self::$error_log->get() );
+	}
+
+	/**
+	 * Test that the redirect when the create client call fails.
+	 */
+	public function testThatClientCreationFailureIsRedirected() {
+		$this->startRedirectHalting();
+		$this->startHttpMocking();
+
+		$setup_consent = new WP_Auth0_InitialSetup_Consent( self::$opts );
+		$test_token    = implode( '.', [ uniqid(), uniqid(), uniqid() ] );
+
+		// Mock the create client call with a WP error.
+		$this->http_request_type = 'wp_error';
+		$caught_redirect         = [];
+		try {
+			$setup_consent->callback_with_token( 'test-wp.auth0.com', $test_token, 'social' );
+		} catch ( Exception $e ) {
+			$caught_redirect = unserialize( $e->getMessage() );
+		}
+
+		$this->assertNotEmpty( $caught_redirect );
+		$this->assertEquals( 302, $caught_redirect['status'] );
+
+		$redirect_url = parse_url( $caught_redirect['location'] );
+
+		$this->assertEquals( '/wp-admin/admin.php', $redirect_url['path'] );
+		$this->assertContains( 'page=wpa0', $redirect_url['query'] );
+		$this->assertContains( 'error=cant_create_client', $redirect_url['query'] );
+
+		$this->assertCount( 1, self::$error_log->get() );
+	}
+
+	/**
+	 * Test that an existing DB connection is used instead of creating one.
+	 */
+	public function testThatExistingConnectionSkipsCreation() {
+		$this->startHttpMocking();
+		$this->startRedirectHalting();
+
+		self::$opts->set( 'client_signing_algorithm', 'HS256' );
+
+		$setup_consent = new WP_Auth0_InitialSetup_Consent( self::$opts );
+		$test_token    = implode( '.', [ uniqid(), uniqid(), uniqid() ] );
+
+		// Mock consecutive HTTP calls.
+		$this->http_request_type = [
+			// Successful client creation.
+			'success_create_client',
+			// Found a connection with the same name.
+			'success_get_existing_conn',
+			// Client grant created successfully.
+			'success_create_empty_body',
+		];
+
+		$caught_redirect = [];
+		try {
+			$setup_consent->callback_with_token( 'test-wp.auth0.com', $test_token, 'social' );
+		} catch ( Exception $e ) {
+			$caught_redirect = unserialize( $e->getMessage() );
+		}
+
+		$this->assertNotEmpty( $caught_redirect );
+		$this->assertEquals( 302, $caught_redirect['status'] );
+
+		$redirect_url = parse_url( $caught_redirect['location'] );
+
+		$this->assertEquals( '/wp-admin/admin.php', $redirect_url['path'] );
+		$this->assertContains( 'page=wpa0-setup', $redirect_url['query'] );
+		$this->assertContains( 'step=2', $redirect_url['query'] );
+		$this->assertContains( 'profile=social', $redirect_url['query'] );
+
+		$this->assertEquals( 'TEST_CLIENT_ID', self::$opts->get( 'client_id' ) );
+		$this->assertEquals( 'TEST_CLIENT_SECRET', self::$opts->get( 'client_secret' ) );
+		$this->assertEquals( 1, self::$opts->get( 'db_connection_enabled' ) );
+		$this->assertEquals( 'TEST_CONN_ID', self::$opts->get( 'db_connection_id' ) );
+		$this->assertEquals( 'good', self::$opts->get( 'password_policy' ) );
+
+		$this->assertEmpty( self::$error_log->get() );
+	}
+
+	/**
+	 * Test that an connection is created and the Client Grant fails.
+	 */
+	public function testThatNewConnectionIsCreatedAndFailedClientGrantRedirects() {
+		$this->startHttpMocking();
+		$this->startRedirectHalting();
+
+		$setup_consent = new WP_Auth0_InitialSetup_Consent( self::$opts );
+		$test_token    = implode( '.', [ uniqid(), uniqid(), uniqid() ] );
+
+		self::$opts->set( 'client_signing_algorithm', 'HS256' );
+
+		// Mock consecutive HTTP calls.
+		$this->http_request_type = [
+			// Successful client creation.
+			'success_create_client',
+			// Get en existing connection enabled for this client.
+			'success_get_connections',
+			// Connection updated successfully.
+			'success_update_connection',
+			// Connection created successfully.
+			'success_create_connection',
+			// Client grant failed.
+			'wp_error',
+		];
+
+		$caught_redirect = [];
+		try {
+			$setup_consent->callback_with_token( 'test-wp.auth0.com', $test_token, 'social' );
+		} catch ( Exception $e ) {
+			$caught_redirect = unserialize( $e->getMessage() );
+		}
+
+		$this->assertNotEmpty( $caught_redirect );
+		$this->assertEquals( 302, $caught_redirect['status'] );
+
+		$redirect_url = parse_url( $caught_redirect['location'] );
+
+		$this->assertEquals( '/wp-admin/admin.php', $redirect_url['path'] );
+		$this->assertContains( 'page=wpa0', $redirect_url['query'] );
+		$this->assertContains( 'error=cant_create_client_grant', $redirect_url['query'] );
+
+		$this->assertEquals( 'TEST_CLIENT_ID', self::$opts->get( 'client_id' ) );
+		$this->assertEquals( 'TEST_CLIENT_SECRET', self::$opts->get( 'client_secret' ) );
+		$this->assertEquals( 1, self::$opts->get( 'db_connection_enabled' ) );
+		$this->assertEquals( 'TEST_CREATED_CONN_ID', self::$opts->get( 'db_connection_id' ) );
+		$this->assertEquals( 'DB-' . get_auth0_curatedBlogName(), self::$opts->get( 'db_connection_name' ) );
+
+		$this->assertCount( 1, self::$error_log->get() );
+	}
+
+	/*
+	 * PhpUnit suite methods.
+	 */
+
+	/**
+	 * Runs after each test method.
+	 */
+	public function tearDown() {
+		parent::tearDown();
+
+		self::$opts->set( 'auth0_app_token', self::$opts->get_default( 'auth0_app_token' ) );
+		self::$opts->set( 'domain', self::$opts->get_default( 'domain' ) );
+		self::$opts->set( 'client_id', self::$opts->get_default( 'client_id' ) );
+		self::$opts->set( 'client_secret', self::$opts->get_default( 'client_secret' ) );
+		self::$opts->set( 'password_policy', self::$opts->get_default( 'password_policy' ) );
+		self::$opts->set( 'account_profile', null );
+		self::$opts->set( 'db_connection_enabled', null );
+		self::$opts->set( 'db_connection_id', null );
+		self::$opts->set( 'db_connection_name', null );
+
+		$this->stopHttpHalting();
+		$this->stopHttpMocking();
+
+		$this->stopRedirectHalting();
+
+		self::$error_log->clear();
+	}
+
+	/*
+	 * Test helper functions.
+	 */
+
+	/**
+	 * Specific mock API responses for this suite.
+	 *
+	 * @return array|null|WP_Error
+	 */
+	public function httpMock() {
+		$response_type = $this->getResponseType();
+		switch ( $response_type ) {
+			case 'success_create_client':
+				return [
+					'body'     => '{"client_id":"TEST_CLIENT_ID","client_secret":"TEST_CLIENT_SECRET"}',
+					'response' => [ 'code' => 201 ],
+				];
+
+			case 'success_get_existing_conn':
+				return [
+					'body'     => '[{"id":"TEST_CONN_ID","name":"DB-' . get_auth0_curatedBlogName() .
+						'","enabled_clients":["TEST_CLIENT_ID"],"options":{"passwordPolicy":"good"}}]',
+					'response' => [ 'code' => 200 ],
+				];
+
+			case 'success_get_connections':
+				return [
+					'body'     => '[{"id":"TEST_CONN_ID","name":"TEST_CONNECTION","enabled_clients":["TEST_CLIENT_ID"]}]',
+					'response' => [ 'code' => 200 ],
+				];
+		}
+
+		return $this->httpMockDefault( $response_type );
+	}
+}

--- a/tests/testInitialSetupConsent.php
+++ b/tests/testInitialSetupConsent.php
@@ -284,12 +284,6 @@ class TestInitialSetupConsent extends TestCase {
 						'","enabled_clients":["TEST_CLIENT_ID"],"options":{"passwordPolicy":"good"}}]',
 					'response' => [ 'code' => 200 ],
 				];
-
-			case 'success_get_connections':
-				return [
-					'body'     => '[{"id":"TEST_CONN_ID","name":"TEST_CONNECTION","enabled_clients":["TEST_CLIENT_ID"]}]',
-					'response' => [ 'code' => 200 ],
-				];
 		}
 
 		return $this->httpMockDefault( $response_type );

--- a/tests/traits/httpHelpers.php
+++ b/tests/traits/httpHelpers.php
@@ -71,16 +71,21 @@ trait HttpHelpers {
 	 * @return string|null
 	 */
 	public function getResponseType() {
+		if ( is_array( $this->http_request_type ) ) {
+			return array_shift( $this->http_request_type );
+		}
 		return $this->http_request_type;
 	}
 
 	/**
-	 * Return a mocked API call based on type.
+	 * Mock returns from the HTTP client.
 	 *
-	 * @return array|null|WP_Error
+	 * @param null|string $response_type - Response type to use.
+	 *
+	 * @return array|WP_Error
 	 */
-	public function httpMock() {
-		switch ( $this->getResponseType() ) {
+	public function httpMock( $response_type = null ) {
+		switch ( $response_type ?: $this->getResponseType() ) {
 
 			case 'wp_error':
 				return new WP_Error( 1, 'Caught WP_Error.' );
@@ -109,8 +114,26 @@ trait HttpHelpers {
 					'response' => [ 'code' => 200 ],
 				];
 
+			case 'success_create_empty_body':
+				return [
+					'body'     => '',
+					'response' => [ 'code' => 201 ],
+				];
+
+			case 'success_create_connection':
+				return [
+					'body'     => '{"id":"TEST_CREATED_CONN_ID"}',
+					'response' => [ 'code' => 201 ],
+				];
+
+			case 'success_update_connection':
+				return [
+					'body'     => '{"id":"TEST_UPDATED_CONN_ID"}',
+					'response' => [ 'code' => 200 ],
+				];
+
 			default:
-				return null;
+				return new WP_Error( 2, 'No mock type found.' );
 		}
 	}
 

--- a/tests/traits/httpHelpers.php
+++ b/tests/traits/httpHelpers.php
@@ -62,7 +62,7 @@ trait HttpHelpers {
 	 * Use this at the top of tests that should test behavior for different HTTP responses.
 	 */
 	public function startHttpMocking() {
-		add_filter( 'pre_http_request', [ $this, 'httpMock' ], 1 );
+		add_filter( 'pre_http_request', [ $this, 'httpMock' ], 1, 3 );
 	}
 
 	/**
@@ -80,12 +80,18 @@ trait HttpHelpers {
 	/**
 	 * Mock returns from the HTTP client.
 	 *
-	 * @param null|string $response_type - Response type to use.
+	 * @param string|null $response_type - HTTP response type to use.
+	 * @param array|null  $args - HTTP args.
+	 * @param string|null $url - Remote URL.
 	 *
 	 * @return array|WP_Error
 	 */
-	public function httpMock( $response_type = null ) {
+	public function httpMock( $response_type = null, array $args = null, $url = null ) {
 		switch ( $response_type ?: $this->getResponseType() ) {
+
+			case 'halt':
+				$this->httpHalt( false, $args, $url );
+				return new WP_Error( 3, 'Halted.' );
 
 			case 'wp_error':
 				return new WP_Error( 1, 'Caught WP_Error.' );
@@ -129,6 +135,17 @@ trait HttpHelpers {
 			case 'success_update_connection':
 				return [
 					'body'     => '{"id":"TEST_UPDATED_CONN_ID"}',
+					'response' => [ 'code' => 200 ],
+				];
+
+			case 'success_get_connections':
+				return [
+					'body'     => '[{
+						"id":"TEST_CONN_ID",
+						"name":"TEST_CONNECTION",
+						"enabled_clients":["TEST_CLIENT_ID"],
+						"options":{"passwordPolicy":"poor"}
+					}]',
 					'response' => [ 'code' => 200 ],
 				];
 


### PR DESCRIPTION
### Changes

This fixes a bug that can cause unintended changes to database connection settings when saving a new password policy. Specific changes:

- Add object property checking to `WP_Auth0_Api_Client::update_connection()` to avoid unnecessary payload errors from the server.
- Remove duplicate connection cleanup from `WP_Auth0_Api_Operations::update_wordpress_connection()`
- Return old password policy setting if an API call fails during validation
- Pass entire connection object to the update API call to avoid unintended settings changes in password policy validation and new connection creation
- Add a large number of tests to confirm behavior
- Docblocks to help investigation and refactoring in the future

### References

- [WP forum report](https://wordpress.org/support/topic/db-migration-automaticly-disable-it-self-after-plugin-save-in-wp-admin/)

### Testing

* [x] This change adds unit test coverage
* [x] I included manual testing steps above, if applicable
* [x] This change has been tested on the latest version of the platform/language or why not

#### Scenario 1: Updates to the password policy in wp-admin

1. Start with a working WP-Auth0 install with a DB connection active
2. In the Auth0 dashboard, make sure the connection has a non-default setting (username required turned ON or custom DB migration)
3. In wp-admin, change the password policy and save

**Expected behavior:**

Password policy is changed, other settings are not affected.

#### Scenario 2: Connection creation during the setup wizard

1. Start with a WP install without WP-Auth0 installed
2. Activate the plugin and walk through the setup wizard (any option)

**Expected behavior:**

Install completes without errors in WordPress; New client created associated to new DB connection in Auth0.

### Checklist

* [x] All existing and new tests complete without errors
* [x] All code quality tools/guidelines in the [Contribution guide](CONTRIBUTION.md) have been run/followed
* [x] All active GitHub CI checks have passed
