### PR TITLE
Change logged-in user redirect to login_init hook

### DIFF
--- a/WP_Auth0.php
+++ b/WP_Auth0.php
@@ -372,18 +372,6 @@ class WP_Auth0 {
 			return;
 		}
 
-		// If the user has a WP session, determine where they should end up and redirect.
-		if ( is_user_logged_in() ) {
-			$login_redirect = empty( $_REQUEST['redirect_to'] ) ?
-				$this->a0_options->get( 'default_login_redirection' ) :
-				filter_var( $_REQUEST['redirect_to'], FILTER_SANITIZE_URL );
-
-			// Add a cache buster to avoid an infinite redirect loop on pages that check for auth.
-			$login_redirect = add_query_arg( time(), '', $login_redirect );
-			wp_safe_redirect( $login_redirect );
-			exit;
-		}
-
 		wp_enqueue_style( 'auth0', WPA0_PLUGIN_CSS_URL . 'login.css', false, WPA0_VERSION );
 	}
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -39,12 +39,13 @@ require $_tests_dir . '/includes/bootstrap.php';
 
 require dirname( __FILE__ ) . '/../vendor/autoload.php';
 
+// TODO: Move these to an autoloader.
 require dirname( __FILE__ ) . '/classes/Test_WP_Auth0_Api_Abstract.php';
-
 require dirname( __FILE__ ) . '/traits/ajaxHelpers.php';
 require dirname( __FILE__ ) . '/traits/domDocumentHelpers.php';
 require dirname( __FILE__ ) . '/traits/hookHelpers.php';
 require dirname( __FILE__ ) . '/traits/httpHelpers.php';
+require dirname( __FILE__ ) . '/traits/optionsHelpers.php';
 require dirname( __FILE__ ) . '/traits/redirectHelpers.php';
 require dirname( __FILE__ ) . '/traits/setUpTestDb.php';
 require dirname( __FILE__ ) . '/traits/usersHelper.php';

--- a/tests/testLoginManager.php
+++ b/tests/testLoginManager.php
@@ -14,7 +14,50 @@ use PHPUnit\Framework\TestCase;
  */
 class TestLoginManager extends TestCase {
 
-	use setUpTestDb;
+	use OptionsHelpers;
+
+	use RedirectHelpers;
+
+	use SetUpTestDb;
+
+	use UsersHelper;
+
+	/**
+	 * WP_Auth0_ErrorLog instance.
+	 *
+	 * @var WP_Auth0_ErrorLog
+	 */
+	protected static $error_log;
+
+	/**
+	 * WP_Auth0_UsersRepo instance.
+	 *
+	 * @var WP_Auth0_UsersRepo
+	 */
+	protected static $users_repo;
+
+	/**
+	 * Setup for entire test class.
+	 */
+	public static function setUpBeforeClass() {
+		parent::setUpBeforeClass();
+		self::$opts       = WP_Auth0_Options::Instance();
+		self::$users_repo = new WP_Auth0_UsersRepo( self::$opts );
+		self::$error_log  = new WP_Auth0_ErrorLog();
+	}
+
+	/**
+	 * Run after each test.
+	 */
+	public function tearDown() {
+		parent::tearDown();
+		self::auth0Ready( false );
+		$this->stopRedirectHalting();
+		self::$error_log->clear();
+		self::$opts->set( 'custom_domain', '' );
+		self::$opts->set( 'auth0_implicit_workflow', false );
+		self::$opts->set( 'auto_login', 0 );
+	}
 
 	/**
 	 * Test that the default auth scopes are returned and filtered properly.
@@ -54,13 +97,12 @@ class TestLoginManager extends TestCase {
 		$auth_params = WP_Auth0_LoginManager::get_authorize_params( $test_connection );
 		$this->assertEquals( $test_connection, $auth_params['connection'] );
 
-		$options = WP_Auth0_Options::Instance();
-		$options->set( 'client_id', $test_client_id );
+		self::$opts->set( 'client_id', $test_client_id );
 
 		$auth_params = WP_Auth0_LoginManager::get_authorize_params();
 		$this->assertEquals( $test_client_id, $auth_params['client_id'] );
 
-		$options->set( 'auth0_implicit_workflow', 1 );
+		self::$opts->set( 'auth0_implicit_workflow', 1 );
 		$auth_params = WP_Auth0_LoginManager::get_authorize_params();
 		$this->assertEquals( add_query_arg( 'auth0', 'implicit', site_url( 'index.php' ) ), $auth_params['redirect_uri'] );
 		$this->assertEquals( 'id_token', $auth_params['response_type'] );
@@ -85,17 +127,15 @@ class TestLoginManager extends TestCase {
 	 * Test that the authorize URL is built properly.
 	 */
 	public function testBuildAuthorizeUrl() {
-		$options = WP_Auth0_Options::Instance();
 
 		// Basic authorize URL.
-		$options->set( 'domain', 'test.auth0.com' );
-		$options->set( 'custom_domain', '' );
+		self::$opts->set( 'domain', 'test.auth0.com' );
 		$auth_url = WP_Auth0_LoginManager::build_authorize_url();
 
 		$this->assertEquals( 'https://test.auth0.com/authorize', $auth_url );
 
 		// Custom domain authorize URL.
-		$options->set( 'custom_domain', 'test-custom.auth0.com' );
+		self::$opts->set( 'custom_domain', 'test-custom.auth0.com' );
 		$auth_url = WP_Auth0_LoginManager::build_authorize_url();
 
 		$this->assertEquals( 'https://test-custom.auth0.com/authorize', $auth_url );
@@ -132,5 +172,134 @@ class TestLoginManager extends TestCase {
 			]
 		);
 		$this->assertEquals( 'https://test-custom.auth0.com/authorize?test=this', $auth_url );
+	}
+
+	/**
+	 * Test that logged-in users are redirected from the wp-login.php page.
+	 */
+	public function testThatLoggedInUserIsRedirectedFromWpLogin() {
+		$this->startRedirectHalting();
+
+		$login_manager = new WP_Auth0_LoginManager( self::$users_repo, self::$opts );
+
+		// Configure Auth0.
+		self::auth0Ready();
+		$this->assertTrue( WP_Auth0::ready() );
+
+		// Set the current user to admin.
+		$this->setGlobalUser();
+
+		// Use the default login redirection.
+		$caught_redirect = [
+			'location' => null,
+			'status'   => null,
+		];
+		try {
+			$login_manager->login_auto();
+		} catch ( Exception $e ) {
+			$caught_redirect = unserialize( $e->getMessage() );
+		}
+
+		// Redirect will have a dynamic cache breaker so cannot assertEquals here.
+		$this->assertNotFalse( strpos( $caught_redirect['location'], 'http://example.org?' ) );
+		$this->assertEquals( 302, $caught_redirect['status'] );
+
+		// Set a one-time login redirect URL.
+		$_REQUEST['redirect_to'] = 'http://example.org/custom';
+
+		// Use the default login redirection.
+		$caught_redirect = [
+			'location' => null,
+			'status'   => null,
+		];
+		try {
+			$login_manager->login_auto();
+		} catch ( Exception $e ) {
+			$caught_redirect = unserialize( $e->getMessage() );
+		}
+
+		// Redirect will have a dynamic cache breaker so cannot assertEquals here.
+		$this->assertNotFalse( strpos( $caught_redirect['location'], 'http://example.org/custom?' ) );
+		$this->assertEquals( 302, $caught_redirect['status'] );
+	}
+
+	/**
+	 * Test that the ULP redirect happens.
+	 */
+	public function testUlpRedirect() {
+		$this->startRedirectHalting();
+
+		$login_manager = new WP_Auth0_LoginManager( self::$users_repo, self::$opts );
+		$this->assertFalse( $login_manager->login_auto() );
+
+		// Activate settings that result in a ULP redirect.
+		self::$opts->set( 'auto_login', 1 );
+		self::auth0Ready( true );
+		self::$opts->set( 'domain', 'test-wp.auth0.com' );
+		$this->assertTrue( WP_Auth0::ready() );
+
+		$caught_redirect = [
+			'location' => null,
+			'status'   => null,
+		];
+		try {
+			// Need to hide error messages here because a cookie is set.
+			// phpcs:ignore
+			@$login_manager->login_auto();
+		} catch ( Exception $e ) {
+			$caught_redirect = unserialize( $e->getMessage() );
+		}
+
+		$this->assertNotFalse( strpos( $caught_redirect['location'], 'https://test-wp.auth0.com/authorize?' ) );
+		$this->assertEquals( 302, $caught_redirect['status'] );
+	}
+
+	/**
+	 * Test that the ULP redirect does not happen under certain conditions.
+	 */
+	public function testThatUlpRedirectDoesNotOccur() {
+		$this->startRedirectHalting();
+
+		$login_manager = new WP_Auth0_LoginManager( self::$users_repo, self::$opts );
+		$this->assertFalse( $login_manager->login_auto() );
+
+		// First, check that a redirect is happening.
+		self::$opts->set( 'auto_login', 1 );
+		self::auth0Ready( true );
+		$this->assertTrue( WP_Auth0::ready() );
+
+		$caught_redirect = [
+			'location' => null,
+			'status'   => null,
+		];
+		try {
+			// Need to hide error messages here because a cookie is set.
+			// phpcs:ignore
+			@$login_manager->login_auto();
+		} catch ( Exception $e ) {
+			$caught_redirect = unserialize( $e->getMessage() );
+		}
+		$this->assertEquals( 302, $caught_redirect['status'] );
+
+		// Test that request method will stop redirect.
+		$req_method_backup         = $_SERVER['REQUEST_METHOD'];
+		$_SERVER['REQUEST_METHOD'] = 'POST';
+		$this->assertFalse( $login_manager->login_auto() );
+		$_SERVER['REQUEST_METHOD'] = $req_method_backup;
+
+		// Test that WP login override will skip the redirect.
+		$_GET['wle'] = 1;
+		$this->assertFalse( $login_manager->login_auto() );
+		unset( $_GET['wle'] );
+
+		// Test that logout will skip the redirect.
+		$_GET['action'] = 'logout';
+		$this->assertFalse( $login_manager->login_auto() );
+		unset( $_GET['action'] );
+
+		// Test that the auth0 URL param will skip the redirect.
+		$_REQUEST['auth0'] = 1;
+		$this->assertFalse( $login_manager->login_auto() );
+		unset( $_REQUEST['auth0'] );
 	}
 }

--- a/tests/traits/optionsHelpers.php
+++ b/tests/traits/optionsHelpers.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * Contains Trait OptionsHelpers.
+ *
+ * @package WP-Auth0
+ *
+ * @since 3.8.1
+ */
+
+/**
+ * Trait Users.
+ */
+trait OptionsHelpers {
+
+	/**
+	 * Instance of WP_Auth0_Options.
+	 *
+	 * @var WP_Auth0_Options
+	 */
+	public static $opts;
+
+	/**
+	 * Set the Auth0 plugin settings.
+	 *
+	 * @param boolean $on - True to turn Auth0 on, false to turn off.
+	 */
+	public static function auth0Ready( $on = true ) {
+		$value = $on ? uniqid() : null;
+		self::$opts->set( 'domain', $value );
+		self::$opts->set( 'client_id', $value );
+		self::$opts->set( 'client_secret', $value );
+	}
+}


### PR DESCRIPTION
### Changes

PR #583 did not address all warnings that came from this change. Moving this to an existing method hooked to `login_init` and adding tests for this and all other functionality in the `login_auto` method. 

### References

#583

### Testing

* [x] This change adds unit test coverage
* [x] This change has been tested on the latest version of the platform/language or why not

