### PR TITLE
Add WooCommerce password change action.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,6 +37,7 @@
         "phpcbf-tests": "./vendor/bin/phpcbf --standard=phpcs-test-ruleset.xml -s ./tests/",
         "sniffs": "vendor/bin/phpcs --standard=phpcs-ruleset.xml -e",
         "test": "\"vendor/bin/phpunit\" --coverage-text",
-        "test-ci": "vendor/bin/phpunit --debug --coverage-clover=coverage.xml"
+        "test-ci": "vendor/bin/phpunit --debug --coverage-clover=coverage.xml",
+        "pre-commit": [ "@compat", "@phpcbf", "@phpcbf-tests", "@phpcs-tests", "@test" ]
     }
 }

--- a/lib/profile/WP_Auth0_Profile_Change_Password.php
+++ b/lib/profile/WP_Auth0_Profile_Change_Password.php
@@ -34,8 +34,14 @@ class WP_Auth0_Profile_Change_Password {
 	 * @codeCoverageIgnore - Tested in TestProfileChangePassword::testInitHooks()
 	 */
 	public function init() {
+
+		// Used during profile update in wp-admin.
 		add_action( 'user_profile_update_errors', array( $this, 'validate_new_password' ), 10, 2 );
+
+		// Used during password reset on wp-login.php
 		add_action( 'validate_password_reset', array( $this, 'validate_new_password' ), 10, 2 );
+
+		// Used during WooCommerce edit account save.
 		add_action( 'woocommerce_save_account_details_errors', array( $this, 'validate_new_password' ), 10, 2 );
 	}
 
@@ -44,8 +50,8 @@ class WP_Auth0_Profile_Change_Password {
 	 * Hooked to: user_profile_update_errors, validate_password_reset
 	 * IMPORTANT: Internal callback use only, do not call this function directly!
 	 *
-	 * @param WP_Error        $errors - WP_Error object to use if validation fails.
-	 * @param boolean|WP_User $user - Boolean update or WP_User instance, depending on action.
+	 * @param WP_Error         $errors - WP_Error object to use if validation fails.
+	 * @param boolean|stdClass $user - Boolean update or WP_User instance, depending on action.
 	 *
 	 * @return boolean
 	 */

--- a/lib/profile/WP_Auth0_Profile_Change_Password.php
+++ b/lib/profile/WP_Auth0_Profile_Change_Password.php
@@ -61,8 +61,10 @@ class WP_Auth0_Profile_Change_Password {
 		$new_password = $_POST[ $field_name ];
 
 		if ( isset( $_POST['user_id'] ) ) {
+			// Input field from user edit or profile update.
 			$wp_user_id = absint( $_POST['user_id'] );
 		} elseif ( is_object( $user ) && ! empty( $user->ID ) ) {
+			// User object passed in from an action.
 			$wp_user_id = absint( $user->ID );
 		} else {
 			return false;

--- a/lib/profile/WP_Auth0_Profile_Delete_Data.php
+++ b/lib/profile/WP_Auth0_Profile_Delete_Data.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Contains class WP_Auth0_Profile_Delete_Data.
+ *
+ * @package WP-Auth0
+ *
+ * @since 3.8.0
+ */
 
 /**
  * Class WP_Auth0_Profile_Delete_Data.

--- a/lib/profile/WP_Auth0_Profile_Delete_Mfa.php
+++ b/lib/profile/WP_Auth0_Profile_Delete_Mfa.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Contains class WP_Auth0_Profile_Delete_Mfa.
+ *
+ * @package WP-Auth0
+ *
+ * @since 3.8.0
+ */
 
 /**
  * Class WP_Auth0_Profile_Delete_Mfa.

--- a/tests/testApiChangePassword.php
+++ b/tests/testApiChangePassword.php
@@ -123,7 +123,7 @@ class TestApiChangePassword extends TestCase {
 		$this->assertCount( 2, $log );
 		$this->assertEquals( 'caught_api_error', $log[0]['code'] );
 
-		// 4. Make sure that a weak password error returns the correct message.
+		// 3. Make sure that a weak password error returns the correct message.
 		$this->http_request_type = 'failed_weak_password';
 		$this->assertEquals(
 			'Password is too weak, please choose a different one.',
@@ -133,7 +133,7 @@ class TestApiChangePassword extends TestCase {
 		$this->assertCount( 3, $log );
 		$this->assertEquals( '400', $log[0]['code'] );
 
-		// 5. Make sure it succeeds.
+		// 4. Make sure it succeeds.
 		$this->http_request_type = 'success_empty_body';
 		$this->assertTrue( $change_password->call( uniqid(), uniqid() ) );
 		$this->assertCount( 3, self::$error_log->get() );

--- a/tests/testApiChangePassword.php
+++ b/tests/testApiChangePassword.php
@@ -58,7 +58,7 @@ class TestApiChangePassword extends TestCase {
 	}
 
 	/**
-	 * Test the request sent by the Client Credentials call.
+	 * Test the request sent by the change password call.
 	 */
 	public function testRequest() {
 		$this->startHttpHalting();
@@ -100,25 +100,25 @@ class TestApiChangePassword extends TestCase {
 	}
 
 	/**
-	 * Test a basic Delete MFA call against a mock API server.
+	 * Test a basic change password call against a mock API server.
 	 */
 	public function testCall() {
 		$this->startHttpMocking();
 		self::$options->set( 'domain', self::TEST_DOMAIN );
 
 		// Mock for a successful API call.
-		$delete_mfa = $this->getStub( true );
+		$change_password = $this->getStub( true );
 
 		// 1. Make sure that a transport returns the default failed response and logs an error.
 		$this->http_request_type = 'wp_error';
-		$this->assertFalse( $delete_mfa->call( uniqid(), uniqid() ) );
+		$this->assertFalse( $change_password->call( uniqid(), uniqid() ) );
 		$log = self::$error_log->get();
 		$this->assertCount( 1, $log );
 		$this->assertEquals( 'Caught WP_Error.', $log[0]['message'] );
 
 		// 2. Make sure that an Auth0 API error returns the default failed response and logs an error.
 		$this->http_request_type = 'auth0_api_error';
-		$this->assertFalse( $delete_mfa->call( uniqid(), uniqid() ) );
+		$this->assertFalse( $change_password->call( uniqid(), uniqid() ) );
 		$log = self::$error_log->get();
 		$this->assertCount( 2, $log );
 		$this->assertEquals( 'caught_api_error', $log[0]['code'] );
@@ -127,15 +127,15 @@ class TestApiChangePassword extends TestCase {
 		$this->http_request_type = 'failed_weak_password';
 		$this->assertEquals(
 			'Password is too weak, please choose a different one.',
-			$delete_mfa->call( uniqid(), uniqid() )
+			$change_password->call( uniqid(), uniqid() )
 		);
 		$log = self::$error_log->get();
 		$this->assertCount( 3, $log );
 		$this->assertEquals( '400', $log[0]['code'] );
 
-		// 4. Make sure it succeeds.
+		// 5. Make sure it succeeds.
 		$this->http_request_type = 'success_empty_body';
-		$this->assertTrue( $delete_mfa->call( uniqid(), uniqid() ) );
+		$this->assertTrue( $change_password->call( uniqid(), uniqid() ) );
 		$this->assertCount( 3, self::$error_log->get() );
 	}
 

--- a/tests/testProfileChangePassword.php
+++ b/tests/testProfileChangePassword.php
@@ -71,7 +71,7 @@ class TestProfileChangePassword extends TestCase {
 	}
 
 	/**
-	 * Test that correct hooks are loaded
+	 * Test that correct hooks are loaded.
 	 */
 	public function testInitHooks() {
 
@@ -81,58 +81,135 @@ class TestProfileChangePassword extends TestCase {
 				'accepted_args' => 2,
 			],
 		];
-		// Same method hooked to both actions.
-		$this->assertHooked( 'user_profile_update_errors', 'WP_Auth0_Profile_Change_Password', $expect_hooked );
-		$this->assertHooked( 'validate_password_reset', 'WP_Auth0_Profile_Change_Password', $expect_hooked );
+		// Same method hooked to all 3 actions.
+		$class_name = 'WP_Auth0_Profile_Change_Password';
+		$this->assertHooked( 'user_profile_update_errors', $class_name, $expect_hooked );
+		$this->assertHooked( 'validate_password_reset', $class_name, $expect_hooked );
+		$this->assertHooked( 'woocommerce_save_account_details_errors', $class_name, $expect_hooked );
 	}
 
 	/**
-	 * Test that the validate_new_password method works as expected.
+	 * Test that empty password fields will skip password update.
 	 */
-	public function testValidateNewPassword() {
-		$errors = new WP_Error();
+	public function testThatEmptyPasswordFieldSkipsUpdate() {
+		$user_id = $this->createUser()->ID;
+		$errors  = new WP_Error();
 
-		$user_data = $this->createUser();
-		$user_id   = $user_data->ID;
-		$user_obj  = get_user_by( 'id', $user_id );
+		$mock_api_test_password = $this->getStub( true );
+		$change_password        = new WP_Auth0_Profile_Change_Password( $mock_api_test_password );
 
-		// Create a stub for the WP_Auth0_Api_Change_Password class.
+		$_POST['pass1']   = uniqid();
+		$_POST['user_id'] = $user_id;
+		$this->storeAuth0Data( $user_id );
+		$this->assertTrue( $change_password->validate_new_password( $errors, false ) );
+		$this->assertEmpty( $errors->get_error_messages() );
+
+		// Test core WP password field.
+		unset( $_POST['pass1'] );
+		$this->assertFalse( $change_password->validate_new_password( $errors, false ) );
+
+		$_POST['password_1'] = uniqid();
+		$this->assertTrue( $change_password->validate_new_password( $errors, false ) );
+
+		// Test WooCommerce password field.
+		unset( $_POST['password_1'] );
+		$this->assertFalse( $change_password->validate_new_password( $errors, false ) );
+	}
+
+	/**
+	 * Test that empty user data will skip the password update.
+	 */
+	public function testThatMissingUserDataSkipsUpdate() {
+		$user_obj = $this->createUser();
+		$user_id  = $user_obj->ID;
+		$errors   = new WP_Error();
+
+		$mock_api_test_password = $this->getStub( true );
+		$change_password        = new WP_Auth0_Profile_Change_Password( $mock_api_test_password );
+
+		$_POST['pass1']   = uniqid();
+		$_POST['user_id'] = $user_id;
+		$this->storeAuth0Data( $user_id );
+		$this->assertTrue( $change_password->validate_new_password( $errors, false ) );
+		$this->assertEmpty( $errors->get_error_messages() );
+
+		// Test core WP profile update screen field.
+		unset( $_POST['user_id'] );
+		$this->assertFalse( $change_password->validate_new_password( $errors, false ) );
+
+		// Test user object.
+		$this->assertTrue( $change_password->validate_new_password( $errors, $user_obj ) );
+	}
+
+	/**
+	 * Test that a user without Auth0 data or with a non-DB strategy skips update.
+	 */
+	public function testThatNonAuth0UserSkipsUpdate() {
+		$user_id = $this->createUser()->ID;
+		$errors  = new WP_Error();
+
+		$mock_api_test_password = $this->getStub( true );
+		$change_password        = new WP_Auth0_Profile_Change_Password( $mock_api_test_password );
+
+		$_POST['pass1']   = uniqid();
+		$_POST['user_id'] = $user_id;
+		$this->storeAuth0Data( $user_id );
+		$this->assertTrue( $change_password->validate_new_password( $errors, false ) );
+		$this->assertEmpty( $errors->get_error_messages() );
+
+		// Test that an unlinked user will not be updated.
+		self::$users_repo->delete_auth0_object( $user_id );
+		$this->assertFalse( $change_password->validate_new_password( $errors, false ) );
+
+		// Test that a linked, non-DB user will not be updated.
+		$this->storeAuth0Data( $user_id, 'not-a-db-strategy' );
+		$this->assertFalse( $change_password->validate_new_password( $errors, false ) );
+	}
+
+	/**
+	 * Test that an API failure will set UI banners and cancel the password change.
+	 */
+	public function testThatApiFailureSetsErrorsUnsetsPassword() {
+		$user_id = $this->createUser()->ID;
+		$errors  = new WP_Error();
+
+		// API call mocked to succeed.
+		$mock_api_test_password = $this->getStub( true );
+		$change_password        = new WP_Auth0_Profile_Change_Password( $mock_api_test_password );
+
+		// Confirm that data is set to succeed.
+		$_POST['pass1']   = uniqid();
+		$_POST['pass2']   = $_POST['pass1'];
+		$_POST['user_id'] = $user_id;
+		$this->storeAuth0Data( $user_id );
+		$this->assertTrue( $change_password->validate_new_password( $errors, false ) );
+		$this->assertEmpty( $errors->get_error_messages() );
+
+		// API call mocked to fail.
+		$mock_api_test_password = $this->getStub( false );
+		$change_password        = new WP_Auth0_Profile_Change_Password( $mock_api_test_password );
+
+		$this->assertFalse( $change_password->validate_new_password( $errors, false ) );
+		$this->assertEquals( 'Password could not be updated.', $errors->errors['auth0_password'][0] );
+		$this->assertEquals( 'pass1', $errors->error_data['auth0_password']['form-field'] );
+		$this->assertFalse( isset( $_POST['pass1'] ) );
+		$this->assertFalse( isset( $_POST['pass2'] ) );
+	}
+
+	/**
+	 * Get an API stub set to pass or fail.
+	 *
+	 * @param boolean $success - True for the API call to succeed, false for it to fail.
+	 *
+	 * @return \PHPUnit\Framework\MockObject\MockObject
+	 */
+	public function getStub( $success ) {
 		$mock_api_test_password = $this
 			->getMockBuilder( WP_Auth0_Api_Change_Password::class )
 			->setMethods( [ 'call' ] )
 			->setConstructorArgs( [ self::$options, self::$api_client_creds ] )
 			->getMock();
-		$mock_api_test_password->method( 'call' )->willReturn( true, false );
-
-		$change_password = new WP_Auth0_Profile_Change_Password( $mock_api_test_password );
-
-		// Call should fail because of a missing password.
-		$this->assertFalse( $change_password->validate_new_password( $errors, false ) );
-
-		$_POST['pass1'] = uniqid();
-
-		// Call should fail with a password because of a missing user ID.
-		$this->assertFalse( $change_password->validate_new_password( $errors, false ) );
-
-		// Call should fail with a user object or user_id in $_POST because of no Auth0 data stored.
-		$this->assertFalse( $change_password->validate_new_password( $errors, $user_obj ) );
-		$_POST['user_id'] = $user_id;
-		$this->assertFalse( $change_password->validate_new_password( $errors, false ) );
-
-		$this->storeAuth0Data( $user_id, 'not-auth0' );
-
-		// Call should fail with Auth0 data stored because of a wrong strategy.
-		$this->assertFalse( $change_password->validate_new_password( $errors, false ) );
-
-		$this->storeAuth0Data( $user_id );
-
-		// Call should succeed with a mocked API.
-		$this->assertTrue( $change_password->validate_new_password( $errors, false ) );
-
-		// Call should fail on the second call with a mocked API.
-		$this->assertFalse( $change_password->validate_new_password( $errors, false ) );
-		$this->assertEquals( 'Password could not be updated.', $errors->errors['auth0_password'][0] );
-		$this->assertEquals( 'pass1', $errors->error_data['auth0_password']['form-field'] );
-		$this->assertFalse( isset( $_POST['pass1'] ) );
+		$mock_api_test_password->method( 'call' )->willReturn( $success );
+		return $mock_api_test_password;
 	}
 }

--- a/tests/testProfileChangePassword.php
+++ b/tests/testProfileChangePassword.php
@@ -102,7 +102,6 @@ class TestProfileChangePassword extends TestCase {
 		$_POST['user_id'] = $user_id;
 		$this->storeAuth0Data( $user_id );
 		$this->assertTrue( $change_password->validate_new_password( $errors, false ) );
-		$this->assertEmpty( $errors->get_error_messages() );
 
 		// Test core WP password field.
 		unset( $_POST['pass1'] );
@@ -131,7 +130,6 @@ class TestProfileChangePassword extends TestCase {
 		$_POST['user_id'] = $user_id;
 		$this->storeAuth0Data( $user_id );
 		$this->assertTrue( $change_password->validate_new_password( $errors, false ) );
-		$this->assertEmpty( $errors->get_error_messages() );
 
 		// Test core WP profile update screen field.
 		unset( $_POST['user_id'] );
@@ -142,7 +140,7 @@ class TestProfileChangePassword extends TestCase {
 	}
 
 	/**
-	 * Test that a user without Auth0 data or with a non-DB strategy skips update.
+	 * Test that a user without Auth0 data skips update.
 	 */
 	public function testThatNonAuth0UserSkipsUpdate() {
 		$user_id = $this->createUser()->ID;
@@ -155,11 +153,26 @@ class TestProfileChangePassword extends TestCase {
 		$_POST['user_id'] = $user_id;
 		$this->storeAuth0Data( $user_id );
 		$this->assertTrue( $change_password->validate_new_password( $errors, false ) );
-		$this->assertEmpty( $errors->get_error_messages() );
 
 		// Test that an unlinked user will not be updated.
 		self::$users_repo->delete_auth0_object( $user_id );
 		$this->assertFalse( $change_password->validate_new_password( $errors, false ) );
+	}
+
+	/**
+	 * Test that a user with a non-DB strategy skips update.
+	 */
+	public function testThatNonDbStrategySkipsUpdate() {
+		$user_id = $this->createUser()->ID;
+		$errors  = new WP_Error();
+
+		$mock_api_test_password = $this->getStub( true );
+		$change_password        = new WP_Auth0_Profile_Change_Password( $mock_api_test_password );
+
+		$_POST['pass1']   = uniqid();
+		$_POST['user_id'] = $user_id;
+		$this->storeAuth0Data( $user_id );
+		$this->assertTrue( $change_password->validate_new_password( $errors, false ) );
 
 		// Test that a linked, non-DB user will not be updated.
 		$this->storeAuth0Data( $user_id, 'not-a-db-strategy' );
@@ -183,7 +196,6 @@ class TestProfileChangePassword extends TestCase {
 		$_POST['user_id'] = $user_id;
 		$this->storeAuth0Data( $user_id );
 		$this->assertTrue( $change_password->validate_new_password( $errors, false ) );
-		$this->assertEmpty( $errors->get_error_messages() );
 
 		// API call mocked to fail.
 		$mock_api_test_password = $this->getStub( false );


### PR DESCRIPTION
### Changes

Add Auth0 password change functionality to WooCommerce edit account + tests. 

### References

[Reported on the WP support forums](https://wordpress.org/support/topic/password-change-issue). 

### Testing

This PR adds unit tests. It can also be tested manually by:

1. Start with Auth0 and WooCommerce installed and configured
2. Go to the edit account page for WooCommerce (front-end of the site)
3. Attempt to change the password to something invalid; expect a visible warning, no changes made, and an error in the error log
4. Attempt to change the password to something valid; expect the change to complete with no errors

* [x] I included manual testing steps above, if applicable
* [x] This change adds unit test coverage
* [x] This change has been tested on the latest version of the platform

### Checklist

* [x] All existing and new tests complete without errors
* [x] All code quality tools/guidelines in the [Contribution guide](CONTRIBUTION.md) have been run/followed
* [x] All active GitHub CI checks have passed
