### PR TITLE
Added filter to allow for changing the output of die_on_login

### DIFF
--- a/lib/WP_Auth0_LoginManager.php
+++ b/lib/WP_Auth0_LoginManager.php
@@ -760,23 +760,24 @@ class WP_Auth0_LoginManager {
 	 * @param bool       $login_link - TRUE for login link, FALSE for logout link.
 	 */
 	protected function die_on_login( $msg = '', $code = 0, $login_link = true ) {
-		wp_die(
-			sprintf(
-				'%s: %s [%s: %s]<br><br><a href="%s">%s</a>',
-				$login_link
-					? __( 'There was a problem with your log in', 'wp-auth0' )
-					: __( 'You have logged in successfully, but there is a problem accessing this site', 'wp-auth0' ),
-				! empty( $msg )
-					? sanitize_text_field( $msg )
-					: __( 'Please see the site administrator', 'wp-auth0' ),
-				__( 'error code', 'wp-auth0' ),
-				$code ? sanitize_text_field( $code ) : __( 'unknown', 'wp-auth0' ),
-				$login_link ? add_query_arg( 'skip_sso', '', wp_login_url() ) : wp_logout_url(),
-				$login_link
-					? __( '← Login', 'wp-auth0' )
-					: __( '← Logout', 'wp-auth0' )
-			)
+		$html = sprintf(
+			'%s: %s [%s: %s]<br><br><a href="%s">%s</a>',
+			$login_link
+				? __( 'There was a problem with your log in', 'wp-auth0' )
+				: __( 'You have logged in successfully, but there is a problem accessing this site', 'wp-auth0' ),
+			! empty( $msg )
+				? sanitize_text_field( $msg )
+				: __( 'Please see the site administrator', 'wp-auth0' ),
+			__( 'error code', 'wp-auth0' ),
+			$code ? sanitize_text_field( $code ) : __( 'unknown', 'wp-auth0' ),
+			$login_link ? add_query_arg( 'skip_sso', '', wp_login_url() ) : wp_logout_url(),
+			$login_link
+				? __( '← Login', 'wp-auth0' )
+				: __( '← Logout', 'wp-auth0' )
 		);
+
+		$html = apply_filters( 'auth0_die_on_login_output', $html, $msg, $code, $login_link );
+		wp_die( $html );
 	}
 
 	/**


### PR DESCRIPTION
### Motivation

Error messages during login should be shown in a helpful way to the enduser.  We want to add further information to the wp-auth0 error message, which are specific for our setup. The filter allows a modification of the shown html, similar to how it is already done for the email verification prompt.

### Changes

- Changed method die_on_login in class WP_Auth0_LoginManager to apply a filter on the html output.

### Testing

No tests added & modified.

* [ ] I included manual testing steps above, if applicable
* [ ] This change adds unit test coverage
* [x] This change has been tested on the latest version of the platform/language or why not

### Checklist

* [x] I read [Auth0's general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)?
* [x] I read [Auth0's code of conduct guidelines](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
* [x] All existing and new tests complete without errors
* [x] All code quality tools/guidelines in the [Contribution guide](CONTRIBUTION.md) have been run/followed
* [x] All relevant assets have been compiled as directed in the [Contribution guide](CONTRIBUTION.md), if applicable
* [x] All active GitHub CI checks have passed
