### PR TITLE
Fix email update on Auth0

### DIFF
--- a/WP_Auth0.php
+++ b/WP_Auth0.php
@@ -157,6 +157,10 @@ class WP_Auth0 {
 		$profile_change_pwd  = new WP_Auth0_Profile_Change_Password( $api_change_password );
 		$profile_change_pwd->init();
 
+		$api_change_email     = new WP_Auth0_Api_Change_Email( $this->a0_options, $api_client_creds );
+		$profile_change_email = new WP_Auth0_Profile_Change_Email( $api_change_email );
+		$profile_change_email->init();
+
 		$profile_delete_data = new WP_Auth0_Profile_Delete_Data( $users_repo );
 		$profile_delete_data->init();
 

--- a/lib/WP_Auth0_EditProfile.php
+++ b/lib/WP_Auth0_EditProfile.php
@@ -1,8 +1,15 @@
 <?php
+/**
+ * Contains class WP_Auth0_EditProfile.
+ *
+ * @package WP-Auth0
+ *
+ * @since 2.0.0
+ */
 
 /**
  * Class WP_Auth0_EditProfile.
- * Provides functionality on the edit profile and edit user page.
+ * Loads assets for the user profile and user edit screens.
  */
 class WP_Auth0_EditProfile {
 
@@ -49,7 +56,6 @@ class WP_Auth0_EditProfile {
 	 */
 	public function init() {
 		add_action( 'admin_enqueue_scripts', array( $this, 'admin_enqueue_scripts' ) );
-		add_action( 'personal_options_update', array( $this, 'override_email_update' ), 1 );
 	}
 
 	/**
@@ -95,9 +101,17 @@ class WP_Auth0_EditProfile {
 		);
 	}
 
+	/*
+	 * DEPRECATED
+	 * phpcs:disable
+	 */
+
 	/**
 	 * Process email changes and pass the update to Auth0 if it passes validation.
-	 * Hooked to: personal_options_update
+	 *
+	 * @deprecated - 3.9.0, use WP_Auth0_Profile_Change_Email::update_email() instead.
+	 *
+	 * @codeCoverageIgnore - Deprecated
 	 */
 	public function override_email_update() {
 		global $wpdb;
@@ -536,4 +550,6 @@ class WP_Auth0_EditProfile {
 			}
 		}
 	}
+
+	// phpcs:enable
 }

--- a/lib/api/WP_Auth0_Api_Change_Email.php
+++ b/lib/api/WP_Auth0_Api_Change_Email.php
@@ -1,16 +1,16 @@
 <?php
 /**
- * Contains WP_Auth0_Api_Change_Password.
+ * Contains WP_Auth0_Api_Change_Email.
  *
  * @package WP-Auth0
  *
- * @since 3.8.0
+ * @since 3.9.0
  */
 
 /**
- * Class WP_Auth0_Api_Change_Password to update a user's password at Auth0.
+ * Class WP_Auth0_Api_Change_Email to update a user's email at Auth0.
  */
-class WP_Auth0_Api_Change_Password extends WP_Auth0_Api_Abstract {
+class WP_Auth0_Api_Change_Email extends WP_Auth0_Api_Abstract {
 
 	/**
 	 * Default value to return on failure.
@@ -30,7 +30,7 @@ class WP_Auth0_Api_Change_Password extends WP_Auth0_Api_Abstract {
 	protected $token_decoded = null;
 
 	/**
-	 * WP_Auth0_Api_Change_Password constructor.
+	 * WP_Auth0_Api_Change_Email constructor.
 	 *
 	 * @param WP_Auth0_Options                $options - WP_Auth0_Options instance.
 	 * @param WP_Auth0_Api_Client_Credentials $api_client_creds - WP_Auth0_Api_Client_Credentials instance.
@@ -44,16 +44,16 @@ class WP_Auth0_Api_Change_Password extends WP_Auth0_Api_Abstract {
 	}
 
 	/**
-	 * Set the user_id and password, make the API call, and handle the response.
+	 * Set the user_id and email, make the API call, and handle the response.
 	 *
-	 * @param string|null $user_id - Auth0 user ID to change the password for.
-	 * @param string|null $password - New password.
+	 * @param string|null $user_id - Auth0 user ID to change the email for.
+	 * @param string|null $email - New email.
 	 *
 	 * @return bool|string
 	 */
-	public function call( $user_id = null, $password = null ) {
+	public function call( $user_id = null, $email = null ) {
 
-		if ( empty( $user_id ) || empty( $password ) ) {
+		if ( empty( $user_id ) || empty( $email ) ) {
 			return self::RETURN_ON_FAILURE;
 		}
 
@@ -63,7 +63,9 @@ class WP_Auth0_Api_Change_Password extends WP_Auth0_Api_Abstract {
 
 		return $this
 			->set_path( 'api/v2/users/' . rawurlencode( $user_id ) )
-			->add_body( 'password', $password )
+			->add_body( 'email', $email )
+			// Email is either changed by an admin or verified by WP.
+			->add_body( 'email_verified', true )
 			->patch()
 			->handle_response( __METHOD__ );
 	}
@@ -82,10 +84,6 @@ class WP_Auth0_Api_Change_Password extends WP_Auth0_Api_Abstract {
 		}
 
 		if ( $this->handle_failed_response( $method ) ) {
-			$response_body = json_decode( $this->response_body );
-			if ( isset( $response_body->message ) && false !== strpos( $response_body->message, 'PasswordStrengthError' ) ) {
-				return __( 'Password is too weak, please choose a different one.', 'wp-auth0' );
-			}
 			return self::RETURN_ON_FAILURE;
 		}
 

--- a/lib/profile/WP_Auth0_Profile_Change_Email.php
+++ b/lib/profile/WP_Auth0_Profile_Change_Email.php
@@ -1,0 +1,124 @@
+<?php
+/**
+ * Contains class WP_Auth0_Profile_Change_Email.
+ *
+ * @package WP-Auth0
+ *
+ * @since 3.9.0
+ */
+
+/**
+ * Class WP_Auth0_Profile_Change_Email.
+ */
+class WP_Auth0_Profile_Change_Email {
+
+	/**
+	 * WP_Auth0_Api_Change_Email instance.
+	 *
+	 * @var WP_Auth0_Api_Change_Email
+	 */
+	protected $api_change_email;
+
+	/**
+	 * WP_Auth0_Profile_Change_Email constructor.
+	 *
+	 * @param WP_Auth0_Api_Change_Email $api_change_email - WP_Auth0_Api_Change_Email instance.
+	 */
+	public function __construct( WP_Auth0_Api_Change_Email $api_change_email ) {
+		$this->api_change_email = $api_change_email;
+	}
+
+	/**
+	 * Add actions for the update user process.
+	 *
+	 * @codeCoverageIgnore - Tested in TestProfileChangeEmail::testInitHooks()
+	 */
+	public function init() {
+
+		// Used during profile update in wp-admin or email verification link.
+		add_action( 'profile_update', array( $this, 'update_email' ), 100, 2 );
+	}
+
+	/**
+	 * Update the user's email at Auth0
+	 * Hooked to: profile_update
+	 * IMPORTANT: Internal callback use only, do not call this function directly!
+	 *
+	 * @param integer $wp_user_id - WP user ID.
+	 * @param WP_User $old_user_data - WP user before changes.
+	 *
+	 * @return boolean
+	 */
+	public function update_email( $wp_user_id, $old_user_data ) {
+
+		// Exit if this is not an Auth0 user.
+		$auth0_id = WP_Auth0_UsersRepo::get_meta( $wp_user_id, 'auth0_id' );
+		if ( empty( $auth0_id ) ) {
+			return false;
+		}
+
+		// Exit if this is not a database strategy user.
+		if ( 'auth0' !== WP_Auth0_Users::get_strategy( $auth0_id ) ) {
+			return false;
+		}
+
+		$wp_user = get_user_by( 'id', $wp_user_id );
+
+		$current_email = $wp_user->data->user_email;
+		$old_email     = $old_user_data->data->user_email;
+
+		// No email address changes, exit.
+		if ( $old_email === $current_email ) {
+			return false;
+		}
+
+		// Password change was successful, nothing else to do.
+		if ( $this->api_change_email->call( $auth0_id, $current_email ) ) {
+			return true;
+		}
+
+		// Suppress the notification for email change.
+		add_filter( 'email_change_email', array( $this, 'suppress_email_change_notification' ), 100 );
+
+		// Remove this method from profile_update, which is called by wp_update_user, to avoid an infinite loop.
+		remove_action( 'profile_update', array( $this, __FUNCTION__ ), 100 );
+
+		// Revert the email address to previous.
+		$wp_user->data->user_email = $old_email;
+		wp_update_user( $wp_user );
+
+		// Revert hooks.
+		add_action( 'profile_update', array( $this, __FUNCTION__ ), 100, 2 );
+		remove_filter( 'email_change_email', array( $this, 'suppress_email_change_notification' ), 100 );
+
+		// Remove the pending email address change so it can be tried again.
+		delete_user_meta( $wp_user_id, '_new_email' );
+
+		// Can't set a custom message here so redirect with an error for WP to pick up.
+		if ( in_array( $GLOBALS['pagenow'], array( 'user-edit.php', 'profile.php' ) ) ) {
+			$redirect_url = admin_url( $GLOBALS['pagenow'] );
+			$redirect_url = add_query_arg( 'user_id', $wp_user_id, $redirect_url );
+			$redirect_url = add_query_arg( 'error', 'new-email', $redirect_url );
+			wp_safe_redirect( $redirect_url );
+			exit;
+		}
+
+		return false;
+	}
+
+	/**
+	 * Modify the user email change notification when the Auth0 API call fails.
+	 *
+	 * @param array $email - Email notification data.
+	 *
+	 * @return array
+	 *
+	 * @see wp_update_user()
+	 */
+	public function suppress_email_change_notification( array $email ) {
+		$email['to']      = null;
+		$email['message'] = null;
+		$email['subject'] = __( 'Email suppressed - Auth0 email change failed.', 'wp-auth0' );
+		return $email;
+	}
+}

--- a/lib/profile/WP_Auth0_Profile_Change_Password.php
+++ b/lib/profile/WP_Auth0_Profile_Change_Password.php
@@ -38,7 +38,7 @@ class WP_Auth0_Profile_Change_Password {
 		// Used during profile update in wp-admin.
 		add_action( 'user_profile_update_errors', array( $this, 'validate_new_password' ), 10, 2 );
 
-		// Used during password reset on wp-login.php
+		// Used during password reset on wp-login.php.
 		add_action( 'validate_password_reset', array( $this, 'validate_new_password' ), 10, 2 );
 
 		// Used during WooCommerce edit account save.
@@ -47,7 +47,7 @@ class WP_Auth0_Profile_Change_Password {
 
 	/**
 	 * Update the user's password at Auth0
-	 * Hooked to: user_profile_update_errors, validate_password_reset
+	 * Hooked to: user_profile_update_errors, validate_password_reset, woocommerce_save_account_details_errors
 	 * IMPORTANT: Internal callback use only, do not call this function directly!
 	 *
 	 * @param WP_Error         $errors - WP_Error object to use if validation fails.

--- a/tests/testApiChangeEmail.php
+++ b/tests/testApiChangeEmail.php
@@ -1,0 +1,188 @@
+<?php
+/**
+ * Contains Class TestApiChangeEmail.
+ *
+ * @package WP-Auth0
+ *
+ * @since 3.9.0
+ */
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Class TestApiChangeEmail.
+ * Test the WP_Auth0_Api_Change_Email class.
+ */
+class TestApiChangeEmail extends TestCase {
+
+	use httpHelpers {
+		httpMock as protected httpMockDefault;
+	}
+
+	use SetUpTestDb;
+
+	/**
+	 * Test API domain to use.
+	 */
+	const TEST_DOMAIN = 'test.domain.com';
+
+	/**
+	 * WP_Auth0_Options instance.
+	 *
+	 * @var WP_Auth0_Options
+	 */
+	protected static $options;
+
+	/**
+	 * WP_Auth0_ErrorLog instance.
+	 *
+	 * @var WP_Auth0_ErrorLog
+	 */
+	protected static $error_log;
+
+	/**
+	 * WP_Auth0_Api_Client_Credentials instance.
+	 *
+	 * @var WP_Auth0_Api_Client_Credentials
+	 */
+	protected static $api_client_creds;
+
+	/**
+	 * Run before the test suite.
+	 */
+	public static function setUpBeforeClass() {
+		parent::setUpBeforeClass();
+		self::$options          = WP_Auth0_Options::Instance();
+		self::$error_log        = new WP_Auth0_ErrorLog();
+		self::$api_client_creds = new WP_Auth0_Api_Client_Credentials( self::$options );
+	}
+
+	/**
+	 * Run after each test.
+	 */
+	public function tearDown() {
+		parent::tearDown();
+		self::$options->set( 'domain', null );
+		$this->stopHttpHalting();
+		$this->stopHttpMocking();
+		self::$error_log->clear();
+	}
+
+	/**
+	 * Test that empty parameters will return false.
+	 */
+	public function testThatEmptyUserParamsReturnsFalse() {
+		$change_email = $this->getStub( true );
+
+		// Should fail with a missing user_id and email.
+		$this->assertFalse( $change_email->call() );
+
+		// Should fail with a missing email.
+		$this->assertFalse( $change_email->call( uniqid() ) );
+	}
+
+	/**
+	 * Test that a failed Client Credentials grant will return false.
+	 */
+	public function testThatFailedApiReturnsFalse() {
+		$change_email = $this->getStub( false );
+		$this->assertFalse( $change_email->call( uniqid(), uniqid() ) );
+	}
+
+	/**
+	 * Test the request sent by the change email call.
+	 */
+	public function testThatApiCallIsFormedCorrectly() {
+		$this->startHttpHalting();
+		self::$options->set( 'domain', self::TEST_DOMAIN );
+
+		// Should succeed with a user_id + provider and set_bearer returning true.
+		$change_email = $this->getStub( true );
+		$decoded_res  = [];
+		try {
+			$change_email->call( 'test|1234567890', 'email@address.com' );
+		} catch ( Exception $e ) {
+			$decoded_res = unserialize( $e->getMessage() );
+		}
+
+		$this->assertNotEmpty( $decoded_res );
+		$this->assertEquals(
+			'https://' . self::TEST_DOMAIN . '/api/v2/users/test%7C1234567890',
+			$decoded_res['url']
+		);
+		$this->assertEquals( 'PATCH', $decoded_res['method'] );
+		$this->assertArrayHasKey( 'email', $decoded_res['body'] );
+		$this->assertEquals( 'email@address.com', $decoded_res['body']['email'] );
+		$this->assertTrue( $decoded_res['body']['email_verified'] );
+	}
+
+	/**
+	 * Make sure that a transport error returns the default failed response and logs an error.
+	 */
+	public function testThatWpErrorIsHandledProperly() {
+		$this->startHttpMocking();
+		self::$options->set( 'domain', self::TEST_DOMAIN );
+
+		// Mock for a successful API call.
+		$change_email = $this->getStub( true );
+
+		$this->http_request_type = 'wp_error';
+		$this->assertFalse( $change_email->call( uniqid(), uniqid() ) );
+		$log = self::$error_log->get();
+		$this->assertCount( 1, $log );
+		$this->assertEquals( 'Caught WP_Error.', $log[0]['message'] );
+	}
+
+	/**
+	 * Make sure that an Auth0 API error returns the default failed response and logs an error.
+	 */
+	public function testThatApiErrorIsHandledProperly() {
+		$this->startHttpMocking();
+		self::$options->set( 'domain', self::TEST_DOMAIN );
+
+		// Mock for a successful API call.
+		$change_email = $this->getStub( true );
+
+		$this->http_request_type = 'auth0_api_error';
+		$this->assertFalse( $change_email->call( uniqid(), uniqid() ) );
+		$log = self::$error_log->get();
+		$this->assertCount( 1, $log );
+		$this->assertEquals( 'caught_api_error', $log[0]['code'] );
+	}
+
+	/**
+	 * Test a successful API call.
+	 */
+	public function testThatSuccessfulApiCallReturnsTrue() {
+		$this->startHttpMocking();
+		self::$options->set( 'domain', self::TEST_DOMAIN );
+
+		// Mock for a successful API call.
+		$change_email = $this->getStub( true );
+
+		$this->http_request_type = 'success_empty_body';
+		$this->assertTrue( $change_email->call( uniqid(), uniqid() ) );
+		$this->assertEmpty( self::$error_log->get() );
+	}
+
+	/*
+	 * Test helper functions.
+	 */
+
+	/**
+	 * Get a mocked WP_Auth0_Api_Change_Email to return true or false for set_bearer.
+	 *
+	 * @param bool $set_bearer_returns - Should the set_bearer call succeed or fail.
+	 *
+	 * @return PHPUnit_Framework_MockObject_MockObject|WP_Auth0_Api_Change_Email
+	 */
+	public function getStub( $set_bearer_returns ) {
+		$mock = $this
+			->getMockBuilder( WP_Auth0_Api_Change_Email::class )
+			->setMethods( [ 'set_bearer' ] )
+			->setConstructorArgs( [ self::$options, self::$api_client_creds ] )
+			->getMock();
+		$mock->method( 'set_bearer' )->willReturn( $set_bearer_returns );
+		return $mock;
+	}
+}

--- a/tests/testEditProfile.php
+++ b/tests/testEditProfile.php
@@ -83,14 +83,6 @@ class TestEditProfile extends TestCase {
 	public function testInitHooks() {
 		global $pagenow;
 
-		$expect_hooked = [
-			'override_email_update' => [
-				'priority'      => 1,
-				'accepted_args' => 1,
-			],
-		];
-		$this->assertHooked( 'personal_options_update', 'WP_Auth0_EditProfile', $expect_hooked );
-
 		// Test page-specific JS enqueuing.
 		$expect_hooked = [
 			'admin_enqueue_scripts' => [

--- a/tests/testProfileChangeEmail.php
+++ b/tests/testProfileChangeEmail.php
@@ -1,0 +1,214 @@
+<?php
+/**
+ * Contains Class TestProfileChangeEmail.
+ *
+ * @package WP-Auth0
+ *
+ * @since 3.9.0
+ */
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Class TestProfileChangeEmail.
+ */
+class TestProfileChangeEmail extends TestCase {
+
+	use HookHelpers;
+
+	use RedirectHelpers;
+
+	use SetUpTestDb;
+
+	use UsersHelper;
+
+	/**
+	 * WP_Auth0_Options instance.
+	 *
+	 * @var WP_Auth0_Options
+	 */
+	public static $options;
+
+	/**
+	 * WP_Auth0_Api_Client_Credentials instance.
+	 *
+	 * @var WP_Auth0_Api_Client_Credentials
+	 */
+	public static $api_client_creds;
+
+	/**
+	 * WP_Auth0_UsersRepo instance used by the UsersHelper trait.
+	 *
+	 * @var WP_Auth0_UsersRepo
+	 */
+	protected static $users_repo;
+
+	/**
+	 * Run before the test suite.
+	 */
+	public static function setUpBeforeClass() {
+		self::$options          = WP_Auth0_Options::Instance();
+		self::$api_client_creds = new WP_Auth0_Api_Client_Credentials( self::$options );
+		self::$users_repo       = new WP_Auth0_UsersRepo( self::$options );
+	}
+
+	/**
+	 * Test that correct hooks are loaded.
+	 */
+	public function testThatHooksAreLoaded() {
+		$expect_hooked = [
+			'update_email' => [
+				'priority'      => 100,
+				'accepted_args' => 2,
+			],
+		];
+		$this->assertHooked( 'profile_update', 'WP_Auth0_Profile_Change_Email', $expect_hooked );
+	}
+
+	/**
+	 * Test that an email update works.
+	 */
+	public function testSuccessfulEmailUpdate() {
+		$user                       = $this->createUser( null, false );
+		$new_email                  = $user->data->user_email;
+		$old_user                   = clone $user;
+		$old_user->data->user_email = 'OLD-' . $new_email;
+
+		// API call mocked to succeed.
+		$change_email = $this->getStub( true );
+
+		// Store userinfo for a DB strategy user.
+		$this->storeAuth0Data( $user->ID, 'auth0' );
+
+		$this->assertTrue( $change_email->update_email( $user->ID, $old_user ) );
+		$this->assertEquals( $new_email, get_user_by( 'id', $user->ID )->data->user_email );
+	}
+
+	/**
+	 * Test that a non-Auth0 user will skip the email update.
+	 */
+	public function testThatNonAuth0UserSkipsUpdate() {
+		$user                       = $this->createUser( null, false );
+		$old_user                   = clone $user;
+		$old_user->data->user_email = 'OLD-' . $old_user->data->user_email;
+
+		// API call mocked to succeed.
+		$change_email = $this->getStub( true );
+
+		$this->assertFalse( $change_email->update_email( $user->ID, $old_user ) );
+	}
+
+	/**
+	 * Test that a non-DB strategy user will skip the email update.
+	 */
+	public function testThatNonDbUserSkipsUpdate() {
+		$user                       = $this->createUser( null, false );
+		$old_user                   = clone $user;
+		$old_user->data->user_email = 'OLD-' . $old_user->data->user_email;
+
+		// API call mocked to succeed.
+		$change_email = $this->getStub( true );
+
+		// Store userinfo for a DB strategy user.
+		$this->storeAuth0Data( $user->ID, 'not-auth0' );
+
+		$this->assertFalse( $change_email->update_email( $user->ID, $old_user ) );
+	}
+
+	/**
+	 * Test that a user change without an email update will skip the email update.
+	 */
+	public function testThatSameEmailSkipsUpdate() {
+		$user     = $this->createUser( null, false );
+		$old_user = clone $user;
+
+		// API call mocked to succeed.
+		$change_email = $this->getStub( true );
+
+		// Store userinfo for a DB strategy user.
+		$this->storeAuth0Data( $user->ID, 'not-auth0' );
+
+		$this->assertFalse( $change_email->update_email( $user->ID, $old_user ) );
+	}
+
+	/**
+	 * Test that a failed API call changes the email address back.
+	 */
+	public function testThatFailedApiCallStopsEmailUpdate() {
+		$user                       = $this->createUser( null, false );
+		$old_user                   = clone $user;
+		$old_user->data->user_email = 'OLD-' . $old_user->data->user_email;
+
+		// Store userinfo for a DB strategy user.
+		$this->storeAuth0Data( $user->ID, 'auth0' );
+
+		// Store the usermeta value set for email verification.
+		update_user_meta( $user->ID, '_new_email', $user->data->user_email );
+
+		// API call mocked to fail.
+		$change_email = $this->getStub( false );
+
+		// Need to remove existing filters and re-init with filters from the test class.
+		remove_all_filters( 'profile_update' );
+		$change_email->init();
+
+		$this->assertFalse( $change_email->update_email( $user->ID, $old_user ) );
+		$this->assertEquals( $old_user->data->user_email, get_user_by( 'id', $user->ID )->data->user_email );
+		$this->assertEmpty( get_user_meta( $user->ID, '_new_email', true ) );
+	}
+
+	/**
+	 * Test that failed API calls from the user edit or user profile page redirect properly.
+	 */
+	public function testThatFailedApiRedirectsOnUserEditPage() {
+		$this->startRedirectHalting();
+
+		$user                       = $this->createUser( null, false );
+		$old_user                   = clone $user;
+		$old_user->data->user_email = 'OLD-' . $old_user->data->user_email;
+
+		// Store userinfo for a DB strategy user.
+		$this->storeAuth0Data( $user->ID, 'auth0' );
+
+		// API call mocked to fail.
+		$change_email = $this->getStub( false );
+
+		// Need to remove existing filters and re-init with filters from the test class.
+		remove_all_filters( 'profile_update' );
+		$change_email->init();
+
+		// Set current page to the user profile.
+		global $pagenow;
+		$pagenow = 'user-edit.php';
+
+		$caught_redirect = [];
+		try {
+			$change_email->update_email( $user->ID, $old_user );
+		} catch ( Exception $e ) {
+			$caught_redirect = unserialize( $e->getMessage() );
+		}
+
+		$this->assertNotEmpty( $caught_redirect );
+		$this->assertEquals( 302, $caught_redirect['status'] );
+		$this->assertContains( 'wp-admin/user-edit.php', $caught_redirect['location'] );
+		$this->assertContains( 'user_id=' . $user->ID, $caught_redirect['location'] );
+		$this->assertContains( 'error=new-email', $caught_redirect['location'] );
+	}
+
+	/**
+	 * Get an API stub set to pass or fail.
+	 *
+	 * @param boolean $success - True for the API call to succeed, false for it to fail.
+	 *
+	 * @return WP_Auth0_Profile_Change_Email
+	 */
+	public function getStub( $success ) {
+		$mock_api_test_email = $this
+			->getMockBuilder( WP_Auth0_Api_Change_Email::class )
+			->setMethods( [ 'call' ] )
+			->setConstructorArgs( [ self::$options, self::$api_client_creds ] )
+			->getMock();
+		$mock_api_test_email->method( 'call' )->willReturn( $success );
+		return new WP_Auth0_Profile_Change_Email( $mock_api_test_email );
+	}
+}

--- a/tests/traits/usersHelper.php
+++ b/tests/traits/usersHelper.php
@@ -21,13 +21,14 @@ trait UsersHelper {
 	/**
 	 * Create a new User.
 	 *
-	 * @param null $email - Email to use, default is used if none provided.
+	 * @param null $email              - Email to use, default is used if none provided.
+	 * @param bool $should_return_data - True to return data only, false to return WP_User.
 	 *
-	 * @return null|object|stdClass
+	 * @return null|object|stdClass|WP_User
 	 */
-	public function createUser( $email = null ) {
+	public function createUser( $email = null, $should_return_data = true ) {
 		$username = 'test_new_user' . uniqid();
-		$user     = wp_insert_user(
+		$user_id  = wp_insert_user(
 			[
 				'user_login' => $username,
 				'user_email' => $email ? $email : $username . '@example.com',
@@ -35,7 +36,12 @@ trait UsersHelper {
 			]
 		);
 
-		return is_wp_error( $user ) ? null : get_user_by( 'id', $user )->data;
+		if ( is_wp_error( $user_id ) ) {
+			return null;
+		}
+
+		$user = get_user_by( 'id', $user_id );
+		return $should_return_data ? $user->data : $user;
 	}
 
 	/**


### PR DESCRIPTION
### Changes

This PR fixes email updates mapping to Auth0 user accounts. 

- Add `WP_Auth0_Api_Change_Email` class to handle API requests for the updated email
- Add `WP_Auth0_Profile_Change_Email` class to handle the hook when an email is updated in the user edit screen or after verification.
- Minor code comment changes in other relevant files. 

### References

[Reported in the WP plugin support forums](https://wordpress.org/support/topic/cant-change-email-using-profile-page/). 

### Testing

To test:

1. Make sure your Application is set to allow a client credentials grant (this is configured by default and covered in the [configuration documentation](https://auth0.com/docs/cms/wordpress/configuration)).
2. Make sure your user account has been associated to an Auth0 user (if you're logged in as an admin, you should see a **Delete Auth0 data** button at the bottom of the profile screen).
3. Go to wp-admin > Users > Your Profile, change the email address, and click **Save Changes**
4. The email field should have a message below to verify your email address if on your own profile
5. Find the verification email and follow the link

**Expect**

- The email address to be changed in WordPress and in Auth0. 
- No errors in the Auth0 plugin error log

* [x] I included manual testing steps above, if applicable
* [x] This change adds unit test coverage
* [x] This change has been tested on the latest version of the platform/language or why not

### Checklist

* [x] All existing and new tests complete without errors
* [x] All code quality tools/guidelines in the [Contribution guide](CONTRIBUTION.md) have been run/followed
* [x] All active GitHub CI checks have passed
