### PR TITLE
Fix migration login route output and add tests

### DIFF
--- a/tests/testProfileChangeEmail.php
+++ b/tests/testProfileChangeEmail.php
@@ -69,7 +69,7 @@ class TestProfileChangeEmail extends TestCase {
 	 * Test that an email update works.
 	 */
 	public function testSuccessfulEmailUpdate() {
-		$user                       = $this->createUser( null, null, false );
+		$user                       = $this->createUser( [], false );
 		$new_email                  = $user->data->user_email;
 		$old_user                   = clone $user;
 		$old_user->data->user_email = 'OLD-' . $new_email;
@@ -88,7 +88,7 @@ class TestProfileChangeEmail extends TestCase {
 	 * Test that a non-Auth0 user will skip the email update.
 	 */
 	public function testThatNonAuth0UserSkipsUpdate() {
-		$user                       = $this->createUser( null, null, false );
+		$user                       = $this->createUser( [], false );
 		$old_user                   = clone $user;
 		$old_user->data->user_email = 'OLD-' . $old_user->data->user_email;
 
@@ -102,7 +102,7 @@ class TestProfileChangeEmail extends TestCase {
 	 * Test that a non-DB strategy user will skip the email update.
 	 */
 	public function testThatNonDbUserSkipsUpdate() {
-		$user                       = $this->createUser( null, null, false );
+		$user                       = $this->createUser( [], false );
 		$old_user                   = clone $user;
 		$old_user->data->user_email = 'OLD-' . $old_user->data->user_email;
 
@@ -119,7 +119,7 @@ class TestProfileChangeEmail extends TestCase {
 	 * Test that a user change without an email update will skip the email update.
 	 */
 	public function testThatSameEmailSkipsUpdate() {
-		$user     = $this->createUser( null, null, false );
+		$user     = $this->createUser( [], false );
 		$old_user = clone $user;
 
 		// API call mocked to succeed.
@@ -135,7 +135,7 @@ class TestProfileChangeEmail extends TestCase {
 	 * Test that a failed API call changes the email address back.
 	 */
 	public function testThatFailedApiCallStopsEmailUpdate() {
-		$user                       = $this->createUser( null, null, false );
+		$user                       = $this->createUser( [], false );
 		$old_user                   = clone $user;
 		$old_user->data->user_email = 'OLD-' . $old_user->data->user_email;
 
@@ -163,7 +163,7 @@ class TestProfileChangeEmail extends TestCase {
 	public function testThatFailedApiRedirectsOnUserEditPage() {
 		$this->startRedirectHalting();
 
-		$user                       = $this->createUser( null, null, false );
+		$user                       = $this->createUser( [], false );
 		$old_user                   = clone $user;
 		$old_user->data->user_email = 'OLD-' . $old_user->data->user_email;
 

--- a/tests/testProfileChangeEmail.php
+++ b/tests/testProfileChangeEmail.php
@@ -69,7 +69,7 @@ class TestProfileChangeEmail extends TestCase {
 	 * Test that an email update works.
 	 */
 	public function testSuccessfulEmailUpdate() {
-		$user                       = $this->createUser( null, false );
+		$user                       = $this->createUser( null, null, false );
 		$new_email                  = $user->data->user_email;
 		$old_user                   = clone $user;
 		$old_user->data->user_email = 'OLD-' . $new_email;
@@ -88,7 +88,7 @@ class TestProfileChangeEmail extends TestCase {
 	 * Test that a non-Auth0 user will skip the email update.
 	 */
 	public function testThatNonAuth0UserSkipsUpdate() {
-		$user                       = $this->createUser( null, false );
+		$user                       = $this->createUser( null, null, false );
 		$old_user                   = clone $user;
 		$old_user->data->user_email = 'OLD-' . $old_user->data->user_email;
 
@@ -102,7 +102,7 @@ class TestProfileChangeEmail extends TestCase {
 	 * Test that a non-DB strategy user will skip the email update.
 	 */
 	public function testThatNonDbUserSkipsUpdate() {
-		$user                       = $this->createUser( null, false );
+		$user                       = $this->createUser( null, null, false );
 		$old_user                   = clone $user;
 		$old_user->data->user_email = 'OLD-' . $old_user->data->user_email;
 
@@ -119,7 +119,7 @@ class TestProfileChangeEmail extends TestCase {
 	 * Test that a user change without an email update will skip the email update.
 	 */
 	public function testThatSameEmailSkipsUpdate() {
-		$user     = $this->createUser( null, false );
+		$user     = $this->createUser( null, null, false );
 		$old_user = clone $user;
 
 		// API call mocked to succeed.
@@ -135,7 +135,7 @@ class TestProfileChangeEmail extends TestCase {
 	 * Test that a failed API call changes the email address back.
 	 */
 	public function testThatFailedApiCallStopsEmailUpdate() {
-		$user                       = $this->createUser( null, false );
+		$user                       = $this->createUser( null, null, false );
 		$old_user                   = clone $user;
 		$old_user->data->user_email = 'OLD-' . $old_user->data->user_email;
 
@@ -163,7 +163,7 @@ class TestProfileChangeEmail extends TestCase {
 	public function testThatFailedApiRedirectsOnUserEditPage() {
 		$this->startRedirectHalting();
 
-		$user                       = $this->createUser( null, false );
+		$user                       = $this->createUser( null, null, false );
 		$old_user                   = clone $user;
 		$old_user->data->user_email = 'OLD-' . $old_user->data->user_email;
 

--- a/tests/testRoutesLogin.php
+++ b/tests/testRoutesLogin.php
@@ -279,7 +279,12 @@ class TestRoutesLogin extends TestCase {
 		$token_id          = '__test_token_id__';
 		$_POST['username'] = uniqid() . '@' . uniqid() . '.com';
 		$_POST['password'] = uniqid();
-		$user              = $this->createUser( $_POST['username'], $_POST['password'] );
+		$user              = $this->createUser(
+			[
+				'user_email' => $_POST['username'],
+				'user_pass'  => $_POST['password'],
+			]
+		);
 		self::$opts->set( 'migration_ws', 1 );
 		self::$opts->set( 'client_secret', $client_secret );
 		self::$opts->set( 'migration_token_id', $token_id );

--- a/tests/testRoutesLogin.php
+++ b/tests/testRoutesLogin.php
@@ -1,0 +1,267 @@
+<?php
+/**
+ * Contains Class TestRoutesLogin.
+ *
+ * @package WP-Auth0
+ *
+ * @since 3.9.0
+ */
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Class TestRoutesLogin.
+ */
+class TestRoutesLogin extends TestCase {
+
+	use HookHelpers;
+
+	use SetUpTestDb {
+		setUp as setUpDb;
+	}
+
+	use UsersHelper;
+
+	/**
+	 * Default query_vars state.
+	 */
+	const WP_OBJECT_DEFAULT = [ 'query_vars' => [ 'custom_requests_return' => true ] ];
+
+	/**
+	 * Instance of WP_Auth0_Options.
+	 *
+	 * @var WP_Auth0_Options
+	 */
+	public static $opts;
+
+	/**
+	 * Instance of WP_Auth0_Routes.
+	 *
+	 * @var WP_Auth0_Routes
+	 */
+	public static $routes;
+
+	/**
+	 * WP_Auth0_ErrorLog instance.
+	 *
+	 * @var WP_Auth0_ErrorLog
+	 */
+	protected static $error_log;
+
+	/**
+	 * Mock WP instance.
+	 *
+	 * @var stdClass
+	 */
+	protected static $wp;
+
+	/**
+	 * Run before test suite.
+	 */
+	public static function setUpBeforeClass() {
+		parent::setUpBeforeClass();
+		self::$opts   = WP_Auth0_Options::Instance();
+		self::$routes = new WP_Auth0_Routes( self::$opts );
+
+		self::$error_log = new WP_Auth0_ErrorLog();
+		self::$wp        = (object) self::WP_OBJECT_DEFAULT;
+	}
+
+	/**
+	 * Runs before each test method.
+	 */
+	public function setUp() {
+		$_POST    = [];
+		$_GET     = [];
+		$_REQUEST = [];
+
+		parent::setUp();
+		$this->setUpDb();
+		self::$opts->reset();
+		self::$wp = (object) self::WP_OBJECT_DEFAULT;
+	}
+
+	/**
+	 * Runs after each test method.
+	 */
+	public function tearDown() {
+		parent::tearDown();
+		self::$error_log->clear();
+	}
+
+	/**
+	 * If we have no query vars, the route should do nothing.
+	 */
+	public function testThatEmptyQueryVarsDoesNothing() {
+		$this->assertNull( self::$routes->custom_requests( self::$wp ) );
+	}
+
+	/**
+	 * If we have no valid query vars, the route should do nothing.
+	 */
+	public function testThatUnknownRouteDoesNothing() {
+		self::$wp->query_vars['a0_action'] = uniqid();
+		$this->assertFalse( self::$routes->custom_requests( self::$wp ) );
+
+		unset( self::$wp->query_vars['a0_action'] );
+		self::$wp->query_vars['pagename'] = uniqid();
+		$this->assertFalse( self::$routes->custom_requests( self::$wp ) );
+	}
+
+	/**
+	 * If migration services are off, the route should fail with an error.
+	 */
+	public function testThatLoginRouteIsForbiddenByDefault() {
+		self::$wp->query_vars['a0_action'] = 'migration-ws-login';
+
+		$output = json_decode( self::$routes->custom_requests( self::$wp ) );
+
+		$this->assertEquals( 403, $output->status );
+		$this->assertEquals( 'Forbidden', $output->error );
+	}
+
+	/**
+	 * If the incoming IP address is invalid, the route should fail with an error.
+	 */
+	public function testThatLoginRouteIsUnauthorizedIfWrongIp() {
+		self::$opts->set( 'migration_ws', 1 );
+		self::$opts->set( 'migration_ips_filter', 1 );
+		self::$wp->query_vars['a0_action'] = 'migration-ws-login';
+
+		$output = json_decode( self::$routes->custom_requests( self::$wp ) );
+
+		$this->assertEquals( 401, $output->status );
+		$this->assertEquals( 'Unauthorized', $output->error );
+	}
+
+	/**
+	 * If there is no token, the route should fail with an error.
+	 */
+	public function testThatLoginRouteIsUnauthorizedIfNoToken() {
+		self::$opts->set( 'migration_ws', 1 );
+		self::$wp->query_vars['a0_action'] = 'migration-ws-login';
+
+		$output = json_decode( self::$routes->custom_requests( self::$wp ) );
+
+		$this->assertEquals( 401, $output->status );
+		$this->assertEquals( 'Unauthorized: missing authorization header', $output->error );
+	}
+
+	/**
+	 * If the token is invalid, the route should fail with an error.
+	 */
+	public function testThatLoginRouteIsUnauthorizedIfBadToken() {
+		self::$opts->set( 'migration_ws', 1 );
+		self::$wp->query_vars['a0_action'] = 'migration-ws-login';
+		$_POST['access_token']             = uniqid();
+
+		$output = json_decode( self::$routes->custom_requests( self::$wp ) );
+
+		$this->assertEquals( 400, $output->status );
+		$this->assertEquals( 'Key may not be empty', $output->error );
+	}
+
+	/**
+	 * If the token has the wrong JTI, the route should fail with an error.
+	 */
+	public function testThatLoginRouteIsUnauthorizedIfWrongJti() {
+		$client_secret = '__test_client_secret__';
+		self::$opts->set( 'migration_ws', 1 );
+		self::$opts->set( 'client_secret', $client_secret );
+		self::$opts->set( 'migration_token_id', '__test_token_id__' );
+
+		self::$wp->query_vars['a0_action'] = 'migration-ws-login';
+		$_POST['access_token']             = JWT::encode( [ 'jti' => uniqid() ], $client_secret );
+
+		$output = json_decode( self::$routes->custom_requests( self::$wp ) );
+
+		$this->assertEquals( 401, $output->status );
+		$this->assertEquals( 'Invalid token ID', $output->error );
+	}
+
+	/**
+	 * If there is no username POSTed, the route should fail with an error.
+	 */
+	public function testThatLoginRouteIsBadRequestIfNoUsername() {
+		$client_secret = '__test_client_secret__';
+		$token_id      = '__test_token_id__';
+		self::$opts->set( 'migration_ws', 1 );
+		self::$opts->set( 'client_secret', $client_secret );
+		self::$opts->set( 'migration_token_id', $token_id );
+
+		self::$wp->query_vars['a0_action'] = 'migration-ws-login';
+		$_POST['access_token']             = JWT::encode( [ 'jti' => $token_id ], $client_secret );
+
+		$output = json_decode( self::$routes->custom_requests( self::$wp ) );
+
+		$this->assertEquals( 400, $output->status );
+		$this->assertEquals( 'Username is required', $output->error );
+	}
+
+	/**
+	 * If there is no password POSTed, the route should fail with an error.
+	 */
+	public function testThatLoginRouteIsBadRequestIfNoPassword() {
+		$client_secret = '__test_client_secret__';
+		$token_id      = '__test_token_id__';
+		self::$opts->set( 'migration_ws', 1 );
+		self::$opts->set( 'client_secret', $client_secret );
+		self::$opts->set( 'migration_token_id', $token_id );
+
+		self::$wp->query_vars['a0_action'] = 'migration-ws-login';
+		$_POST['access_token']             = JWT::encode( [ 'jti' => $token_id ], $client_secret );
+		$_POST['username']                 = uniqid();
+
+		$output = json_decode( self::$routes->custom_requests( self::$wp ) );
+
+		$this->assertEquals( 400, $output->status );
+		$this->assertEquals( 'Password is required', $output->error );
+	}
+
+	/**
+	 * If there the username or password are incorrect, the route should fail with an error.
+	 */
+	public function testThatLoginRouteIsUnauthorizedIfNotAuthenticated() {
+		$client_secret = '__test_client_secret__';
+		$token_id      = '__test_token_id__';
+		self::$opts->set( 'migration_ws', 1 );
+		self::$opts->set( 'client_secret', $client_secret );
+		self::$opts->set( 'migration_token_id', $token_id );
+
+		self::$wp->query_vars['a0_action'] = 'migration-ws-login';
+
+		$_POST['access_token'] = JWT::encode( [ 'jti' => $token_id ], $client_secret );
+		$_POST['username']     = uniqid();
+		$_POST['password']     = uniqid();
+
+		$output = json_decode( self::$routes->custom_requests( self::$wp ) );
+
+		$this->assertEquals( 401, $output->status );
+		$this->assertEquals( 'Invalid Credentials', $output->error );
+	}
+
+	/**
+	 * Route should return a user with no password set if provided a valid username and password.
+	 */
+	public function testThatLoginRouteReturnsUserIfSuccessful() {
+		$client_secret     = '__test_client_secret__';
+		$token_id          = '__test_token_id__';
+		$_POST['username'] = uniqid() . '@' . uniqid() . '.com';
+		$_POST['password'] = uniqid();
+		$user              = $this->createUser( $_POST['username'], $_POST['password'] );
+		self::$opts->set( 'migration_ws', 1 );
+		self::$opts->set( 'client_secret', $client_secret );
+		self::$opts->set( 'migration_token_id', $token_id );
+
+		self::$wp->query_vars['a0_action'] = 'migration-ws-login';
+		$_POST['access_token']             = JWT::encode( [ 'jti' => $token_id ], $client_secret );
+
+		$output = json_decode( self::$routes->custom_requests( self::$wp ) );
+
+		$this->assertEquals( $user->ID, $output->data->ID );
+		$this->assertEquals( $user->user_login, $output->data->user_login );
+		$this->assertEquals( $user->user_email, $output->data->user_email );
+		$this->assertEquals( $user->display_name, $output->data->display_name );
+		$this->assertObjectNotHasAttribute( 'user_pass', $output->data );
+	}
+}

--- a/tests/testRoutesLogin.php
+++ b/tests/testRoutesLogin.php
@@ -106,6 +106,8 @@ class TestRoutesLogin extends TestCase {
 		unset( self::$wp->query_vars['a0_action'] );
 		self::$wp->query_vars['pagename'] = uniqid();
 		$this->assertFalse( self::$routes->custom_requests( self::$wp ) );
+
+		$this->assertEmpty( self::$error_log->get() );
 	}
 
 	/**
@@ -118,6 +120,8 @@ class TestRoutesLogin extends TestCase {
 
 		$this->assertEquals( 403, $output->status );
 		$this->assertEquals( 'Forbidden', $output->error );
+
+		$this->assertEmpty( self::$error_log->get() );
 	}
 
 	/**
@@ -132,12 +136,15 @@ class TestRoutesLogin extends TestCase {
 
 		$this->assertEquals( 401, $output->status );
 		$this->assertEquals( 'Unauthorized', $output->error );
+
+		$this->assertEmpty( self::$error_log->get() );
 	}
 
 	/**
 	 * If there is no token, the route should fail with an error.
 	 */
 	public function testThatLoginRouteIsUnauthorizedIfNoToken() {
+		$expected_msg                      =
 		self::$opts->set( 'migration_ws', 1 );
 		self::$wp->query_vars['a0_action'] = 'migration-ws-login';
 
@@ -145,6 +152,10 @@ class TestRoutesLogin extends TestCase {
 
 		$this->assertEquals( 401, $output->status );
 		$this->assertEquals( 'Unauthorized: missing authorization header', $output->error );
+
+		$log = self::$error_log->get();
+		$this->assertCount( 1, $log );
+		$this->assertEquals( $output->error, $log[0]['message'] );
 	}
 
 	/**
@@ -159,6 +170,10 @@ class TestRoutesLogin extends TestCase {
 
 		$this->assertEquals( 400, $output->status );
 		$this->assertEquals( 'Key may not be empty', $output->error );
+
+		$log = self::$error_log->get();
+		$this->assertCount( 1, $log );
+		$this->assertEquals( $output->error, $log[0]['message'] );
 	}
 
 	/**
@@ -177,6 +192,10 @@ class TestRoutesLogin extends TestCase {
 
 		$this->assertEquals( 401, $output->status );
 		$this->assertEquals( 'Invalid token ID', $output->error );
+
+		$log = self::$error_log->get();
+		$this->assertCount( 1, $log );
+		$this->assertEquals( $output->error, $log[0]['message'] );
 	}
 
 	/**
@@ -196,6 +215,10 @@ class TestRoutesLogin extends TestCase {
 
 		$this->assertEquals( 400, $output->status );
 		$this->assertEquals( 'Username is required', $output->error );
+
+		$log = self::$error_log->get();
+		$this->assertCount( 1, $log );
+		$this->assertEquals( $output->error, $log[0]['message'] );
 	}
 
 	/**
@@ -216,6 +239,10 @@ class TestRoutesLogin extends TestCase {
 
 		$this->assertEquals( 400, $output->status );
 		$this->assertEquals( 'Password is required', $output->error );
+
+		$log = self::$error_log->get();
+		$this->assertCount( 1, $log );
+		$this->assertEquals( $output->error, $log[0]['message'] );
 	}
 
 	/**
@@ -238,6 +265,10 @@ class TestRoutesLogin extends TestCase {
 
 		$this->assertEquals( 401, $output->status );
 		$this->assertEquals( 'Invalid Credentials', $output->error );
+
+		$log = self::$error_log->get();
+		$this->assertCount( 1, $log );
+		$this->assertEquals( $output->error, $log[0]['message'] );
 	}
 
 	/**
@@ -263,5 +294,7 @@ class TestRoutesLogin extends TestCase {
 		$this->assertEquals( $user->user_email, $output->data->user_email );
 		$this->assertEquals( $user->display_name, $output->data->display_name );
 		$this->assertObjectNotHasAttribute( 'user_pass', $output->data );
+
+		$this->assertEmpty( self::$error_log->get() );
 	}
 }

--- a/tests/testUserRepoCreate.php
+++ b/tests/testUserRepoCreate.php
@@ -57,7 +57,7 @@ class TestUserRepoCreate extends TestCase {
 	 */
 	public function testRequiredEmailRejected() {
 		$userinfo = $this->getUserinfo( 'auth0' );
-		$this->createUser( $userinfo->email );
+		$this->createUser( [ 'user_email' => $userinfo->email ] );
 
 		// Require a verified email.
 		self::$opts->set( 'requires_verified_email', 1 );
@@ -75,7 +75,7 @@ class TestUserRepoCreate extends TestCase {
 	 */
 	public function testUserAlreadyExistsRejected() {
 		$userinfo = $this->getUserinfo();
-		$user     = $this->createUser( $userinfo->email );
+		$user     = $this->createUser( [ 'user_email' => $userinfo->email ] );
 		self::$repo->update_auth0_object( $user->ID, $userinfo );
 
 		// Require a verified email.
@@ -160,7 +160,7 @@ class TestUserRepoCreate extends TestCase {
 	 */
 	public function testJoinUserEmailVerificationOff() {
 		$userinfo = $this->getUserinfo();
-		$user     = $this->createUser( $userinfo->email );
+		$user     = $this->createUser( [ 'user_email' => $userinfo->email ] );
 
 		// Require a verified email.
 		self::$opts->set( 'requires_verified_email', 0 );
@@ -178,7 +178,7 @@ class TestUserRepoCreate extends TestCase {
 	 */
 	public function testJoinUserEmailVerified() {
 		$userinfo = $this->getUserinfo();
-		$user     = $this->createUser( $userinfo->email );
+		$user     = $this->createUser( [ 'user_email' => $userinfo->email ] );
 
 		// Require a verified email.
 		self::$opts->set( 'requires_verified_email', 1 );
@@ -199,7 +199,7 @@ class TestUserRepoCreate extends TestCase {
 	 */
 	public function testJoinUserSkipStrategy() {
 		$userinfo = $this->getUserinfo( 'auth0' );
-		$user     = $this->createUser( $userinfo->email );
+		$user     = $this->createUser( [ 'user_email' => $userinfo->email ] );
 
 		// Require a verified email.
 		self::$opts->set( 'requires_verified_email', 1 );

--- a/tests/traits/usersHelper.php
+++ b/tests/traits/usersHelper.php
@@ -21,18 +21,19 @@ trait UsersHelper {
 	/**
 	 * Create a new User.
 	 *
-	 * @param null $email              - Email to use, default is used if none provided.
-	 * @param bool $should_return_data - True to return data only, false to return WP_User.
+	 * @param null        $email              - Email to use, default is used if none provided.
+	 * @param null|string $password           - Password to use, default is used if empty.
+	 * @param bool        $should_return_data - True to return data only, false to return WP_User.
 	 *
 	 * @return null|object|stdClass|WP_User
 	 */
-	public function createUser( $email = null, $should_return_data = true ) {
+	public function createUser( $email = null, $password = null, $should_return_data = true ) {
 		$username = 'test_new_user' . uniqid();
 		$user_id  = wp_insert_user(
 			[
 				'user_login' => $username,
 				'user_email' => $email ? $email : $username . '@example.com',
-				'user_pass'  => uniqid(),
+				'user_pass'  => $password ? $password : uniqid(),
 			]
 		);
 

--- a/tests/traits/usersHelper.php
+++ b/tests/traits/usersHelper.php
@@ -21,21 +21,19 @@ trait UsersHelper {
 	/**
 	 * Create a new User.
 	 *
-	 * @param null        $email              - Email to use, default is used if none provided.
-	 * @param null|string $password           - Password to use, default is used if empty.
-	 * @param bool        $should_return_data - True to return data only, false to return WP_User.
+	 * @param array $user_data         - User data to use.
+	 * @param bool  $should_return_data - True to return data only, false to return WP_User.
 	 *
 	 * @return null|object|stdClass|WP_User
 	 */
-	public function createUser( $email = null, $password = null, $should_return_data = true ) {
-		$username = 'test_new_user' . uniqid();
-		$user_id  = wp_insert_user(
-			[
-				'user_login' => $username,
-				'user_email' => $email ? $email : $username . '@example.com',
-				'user_pass'  => $password ? $password : uniqid(),
-			]
-		);
+	public function createUser( array $user_data = [], $should_return_data = true ) {
+		$username     = 'test_new_user' . uniqid();
+		$default_data = [
+			'user_login' => 'test_new_user' . uniqid(),
+			'user_email' => $username . '@example.com',
+			'user_pass'  => uniqid() . uniqid() . uniqid(),
+		];
+		$user_id      = wp_insert_user( array_merge( $default_data, $user_data ) );
 
 		if ( is_wp_error( $user_id ) ) {
 			return null;


### PR DESCRIPTION
### Changes

- Add `WP_Auth0_Options_Generic::reset()` to reset all options back to defaults
- Add dependency injection to `WP_Auth0_Routes` for the `WP_Auth0_Ip_Check` class
- Add error output for migration login route to help with troubleshooting

### Testing

* [x] This change adds unit test coverage
* [x] This change has been tested on the latest version of the platform/language

### Checklist

* [x] All existing and new tests complete without errors
* [x] All code quality tools/guidelines in the [Contribution guide](CONTRIBUTION.md) have been run/followed 
* [x] All active GitHub CI checks have passed - `composer pre-commit`
