### PR TITLE
Whitelist Auth0 IPs by default and show in wp-admin

### DIFF
--- a/WP_Auth0.php
+++ b/WP_Auth0.php
@@ -9,7 +9,7 @@
  */
 
 define( 'WPA0_VERSION', '3.9.0-beta' );
-define( 'AUTH0_DB_VERSION', 19 );
+define( 'AUTH0_DB_VERSION', 20 );
 
 define( 'WPA0_PLUGIN_FILE', __FILE__ );
 define( 'WPA0_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );

--- a/lib/WP_Auth0_Options_Generic.php
+++ b/lib/WP_Auth0_Options_Generic.php
@@ -200,6 +200,15 @@ class WP_Auth0_Options_Generic {
 	}
 
 	/**
+	 * Reset options to defaults.
+	 */
+	public function reset() {
+		$this->_opts = null;
+		$this->delete();
+		$this->get_options();
+	}
+
+	/**
 	 * Return default options as key => value or just keys.
 	 *
 	 * @param bool $keys_only - Only return the array keys for the default options.

--- a/lib/admin/WP_Auth0_Admin_Advanced.php
+++ b/lib/admin/WP_Auth0_Admin_Advanced.php
@@ -105,7 +105,7 @@ class WP_Auth0_Admin_Advanced extends WP_Auth0_Admin_Generic {
 				'function' => 'render_migration_ws_ips_filter',
 			),
 			array(
-				'name'     => __( 'IP Addresses', 'wp-auth0' ),
+				'name'     => '',
 				'opt'      => 'migration_ips',
 				'id'       => 'wpa0_migration_ws_ips',
 				'function' => 'render_migration_ws_ips',
@@ -419,10 +419,13 @@ class WP_Auth0_Admin_Advanced extends WP_Auth0_Admin_Generic {
 	 * @see add_settings_field()
 	 */
 	public function render_migration_ws_ips( $args = array() ) {
+		$ip_check = new WP_Auth0_Ip_Check( WP_Auth0_Options::Instance() );
 		$this->render_textarea_field( $args['label_for'], $args['opt_name'] );
 		$this->render_field_description(
-			__( 'Only requests from these IPs will be allowed to access the migration webservice. ', 'wp-auth0' ) .
-			__( 'Separate multiple IPs with commas', 'wp-auth0' )
+			__( 'Only requests from these IPs will be allowed to access the migration endpoints. ', 'wp-auth0' ) .
+			__( 'Separate multiple IPs with commas. ', 'wp-auth0' ) .
+			__( 'The following Auth0 IPs are automatically whitelisted: ', 'wp-auth0' ) .
+			'<br><br><code>' . $ip_check->get_ips_by_domain( null, '</code> <code>' ) . '</code>'
 		);
 	}
 

--- a/lib/admin/WP_Auth0_Admin_Generic.php
+++ b/lib/admin/WP_Auth0_Admin_Generic.php
@@ -231,7 +231,8 @@ class WP_Auth0_Admin_Generic {
 	 * @param string $text - description text to display
 	 */
 	protected function render_field_description( $text ) {
-		printf( '<div class="subelement"><span class="description">%s.</span></div>', $text );
+		$period = ! in_array( $text[ strlen( $text ) - 1 ], array( '.', ':', '>' ) ) ? '.' : '';
+		printf( '<div class="subelement"><span class="description">%s%s</span></div>', $text, $period );
 	}
 
 	/**

--- a/tests/testIpCheck.php
+++ b/tests/testIpCheck.php
@@ -14,14 +14,48 @@ use PHPUnit\Framework\TestCase;
  */
 class TestIpCheck extends TestCase {
 
-	use setUpTestDb;
+	use setUpTestDb {
+		setUp as setUpDb;
+	}
+
+	/**
+	 * Instance of WP_Auth0_Options.
+	 *
+	 * @var WP_Auth0_Options
+	 */
+	public static $opts;
+
+	/**
+	 * Original request IP address.
+	 *
+	 * @var string
+	 */
+	public static $backup_ip;
+
+	/**
+	 * Run before the test suite.
+	 */
+	public static function setUpBeforeClass() {
+		parent::setUpBeforeClass();
+		self::$opts      = WP_Auth0_Options::Instance();
+		self::$backup_ip = $_SERVER['REMOTE_ADDR'];
+	}
+
+	/**
+	 * Runs before each test method.
+	 */
+	public function setUp() {
+		$_SERVER['REMOTE_ADDR'] = self::$backup_ip;
+		parent::setUp();
+		$this->setUpDb();
+		self::$opts->reset();
+	}
 
 	/**
 	 * Test that a specific region and domain return the correct number of IP addresses.
 	 */
-	public function testGetIpByDomain() {
-		$opts     = WP_Auth0_Options::Instance();
-		$ip_check = new WP_Auth0_Ip_Check( $opts );
+	public function testThatIpCountDidNotChange() {
+		$ip_check = new WP_Auth0_Ip_Check( self::$opts );
 
 		$us_ips = explode( ',', $ip_check->get_ip_by_region( 'us' ) );
 		$this->assertCount( 16, $us_ips );
@@ -37,5 +71,70 @@ class TestIpCheck extends TestCase {
 		$this->assertCount( 11, $au_ips );
 		$au_ips = explode( ',', $ip_check->get_ips_by_domain( 'test.au.auth0.com' ) );
 		$this->assertCount( 11, $au_ips );
+
+		$us_ips = $ip_check->get_ip_by_region( 'us' );
+		self::$opts->set( 'domain', 'test.auth0.com' );
+		$domain_ips = $ip_check->get_ips_by_domain();
+		$this->assertEquals( $us_ips, $domain_ips );
+	}
+
+	/**
+	 * Test that unauthorized URLs are not allowed.
+	 */
+	public function testThatInvalidConnectionsAreNotAllowed() {
+		$ip_check = new WP_Auth0_Ip_Check( self::$opts );
+
+		$_SERVER['REMOTE_ADDR'] = '1.2.3.4';
+		$this->assertFalse( $ip_check->connection_is_valid() );
+		$this->assertFalse( $ip_check->connection_is_valid( '4.3.2.1' ) );
+
+		self::$opts->set( 'domain', 'test.auth0.com' );
+		$this->assertFalse( $ip_check->connection_is_valid() );
+		$this->assertFalse( $ip_check->connection_is_valid( '4.3.2.1' ) );
+	}
+
+	/**
+	 * Test that authorized IPs are allowed.
+	 */
+	public function testThatValidConnectionsAreAllowed() {
+		$ip_check = new WP_Auth0_Ip_Check( self::$opts );
+
+		$_SERVER['REMOTE_ADDR'] = '1.2.3.4';
+		$this->assertTrue( $ip_check->connection_is_valid( '1.2.3.4' ) );
+		$this->assertTrue( $ip_check->connection_is_valid( '1.2.3.0 - 1.2.3.10' ) );
+	}
+
+	/**
+	 * Test that the default Auth0 IPs are always allowed
+	 */
+	public function testThatDefaultConnectionsAreAllowed() {
+		$ip_check = new WP_Auth0_Ip_Check( self::$opts );
+
+		$_SERVER['REMOTE_ADDR'] = '34.195.142.251';
+		self::$opts->set( 'domain', 'test.auth0.com' );
+		$this->assertTrue( $ip_check->connection_is_valid() );
+		$this->assertTrue( $ip_check->connection_is_valid( '1.2.3.4' ) );
+
+		$_SERVER['REMOTE_ADDR'] = '34.253.4.94';
+		self::$opts->set( 'domain', 'test.eu.auth0.com' );
+		$this->assertTrue( $ip_check->connection_is_valid() );
+		$this->assertTrue( $ip_check->connection_is_valid( '1.2.3.4' ) );
+
+		$_SERVER['REMOTE_ADDR'] = '13.54.254.182';
+		self::$opts->set( 'domain', 'test.au.auth0.com' );
+		$this->assertTrue( $ip_check->connection_is_valid() );
+		$this->assertTrue( $ip_check->connection_is_valid( '1.2.3.4' ) );
+	}
+
+	/**
+	 * Test that a proxy IP address can be used.
+	 */
+	public function testThatProxyConnectionsAreAllowed() {
+		$ip_check = new WP_Auth0_Ip_Check( self::$opts );
+
+		self::$opts->set( 'valid_proxy_ip', '1.2.3.4' );
+		$_SERVER['REMOTE_ADDR']          = '1.2.3.4';
+		$_SERVER['HTTP_X_FORWARDED_FOR'] = '2.3.4.5';
+		$this->assertTrue( $ip_check->connection_is_valid( '2.3.4.5' ) );
 	}
 }

--- a/tests/testWPAuth0DbMigrations.php
+++ b/tests/testWPAuth0DbMigrations.php
@@ -17,11 +17,25 @@ class TestWPAuth0DbMigrations extends TestCase {
 	use setUpTestDb;
 
 	/**
-	 * Test the basic options functionality.
+	 * Instance of WP_Auth0_Options.
+	 *
+	 * @var WP_Auth0_Options
+	 */
+	public static $opts;
+
+	/**
+	 * Setup for entire test class.
+	 */
+	public static function setUpBeforeClass() {
+		parent::setUpBeforeClass();
+		self::$opts = WP_Auth0_Options::Instance();
+	}
+
+	/**
+	 * Test a DB upgrade from v18 to v19.
 	 */
 	public function testV19Update() {
-		$opts = new WP_Auth0_Options();
-
+		$test_version        = 19;
 		$initial_connections = [
 			'social_twitter_key'     => '__twitter_key_test__',
 			'social_twitter_secret'  => '__twitter_secret_test__',
@@ -32,22 +46,54 @@ class TestWPAuth0DbMigrations extends TestCase {
 		$connection_keys = array_keys( $initial_connections );
 
 			// Save a 'connections' settings array.
-		$opts->set( 'connections', $initial_connections );
-		$saved_connections = $opts->get( 'connections' );
+		self::$opts->set( 'connections', $initial_connections );
+		$saved_connections = self::$opts->get( 'connections' );
 		$this->assertEquals( $initial_connections, $saved_connections );
 
 		// Run the migration for v19.
-		update_option( 'auth0_db_version', 18 );
-		$db_manager = new WP_Auth0_DBManager( $opts );
+		update_option( 'auth0_db_version', $test_version - 1 );
+		$db_manager = new WP_Auth0_DBManager( self::$opts );
 		$db_manager->init();
 
 		foreach ( $connection_keys as $key ) {
-			$this->assertEmpty( $opts->get( $key ) );
+			$this->assertEmpty( self::$opts->get( $key ) );
 		}
 
-		$db_manager->install_db( 19, null );
+		$db_manager->install_db( $test_version, null );
+
 		foreach ( $connection_keys as $key ) {
-			$this->assertEquals( $initial_connections[ $key ], $opts->get( $key ) );
+			$this->assertEquals( $initial_connections[ $key ], self::$opts->get( $key ) );
 		}
+	}
+
+	/**
+	 * Test a DB upgrade from v19 to v20.
+	 */
+	public function testV20Update() {
+		$test_version = 20;
+
+		update_option( 'auth0_db_version', $test_version - 1 );
+		$db_manager = new WP_Auth0_DBManager( self::$opts );
+		$db_manager->init();
+
+		// Set a US domain.
+		self::$opts->set( 'domain', 'test.auth0.com' );
+
+		// Save custom IPs, default IPs for US, and default IPs for other regions.
+		self::$opts->set( 'migration_ips', '1.2.3.4,2.3.4.5,34.195.142.251,35.160.3.103,34.253.4.94,13.54.254.182' );
+
+		// Run the update.
+		$db_manager->install_db( $test_version, null );
+
+		// Check that the correct IPs were removed.
+		$remaining_ips = explode( ',', self::$opts->get( 'migration_ips' ) );
+
+		$this->assertContains( '1.2.3.4', $remaining_ips );
+		$this->assertContains( '2.3.4.5', $remaining_ips );
+		$this->assertContains( '34.253.4.94', $remaining_ips );
+		$this->assertContains( '13.54.254.182', $remaining_ips );
+
+		$this->assertNotContains( '34.195.142.251', $remaining_ips );
+		$this->assertNotContains( '35.160.3.103', $remaining_ips );
 	}
 }


### PR DESCRIPTION
### Changes

- Migration endpoints will always whitelist Auth0 IPs if whitelist filter is turned on.
- IP whitelist setting in wp-admin shows the Auth0 IPs being whitelisted (see screenshot below).
- DB migration to remove default IPs from the migration IP setting.

### References

**Setting shows default IPs**

<img width="770" alt="screenshot 2018-12-01 08 08 32" src="https://user-images.githubusercontent.com/855223/49330254-e1cfbc80-f540-11e8-83f7-2ea127f526bc.png">

### Testing

* [x] This change adds unit test coverage
* [x] This change has been tested on the latest version of the platform/language

### Checklist

* [x] All existing and new tests complete without errors
* [x] All code quality tools/guidelines in the [Contribution guide](CONTRIBUTION.md) have been run/followed
* [x] All active GitHub CI checks have passed
