### PR TITLE
Fix notice when settings constant is defined too late

### DIFF
--- a/lib/WP_Auth0_Options_Generic.php
+++ b/lib/WP_Auth0_Options_Generic.php
@@ -38,8 +38,9 @@ class WP_Auth0_Options_Generic {
 	public function __construct() {
 		$option_keys = $this->get_defaults( true );
 		foreach ( $option_keys as $key ) {
-			if ( $this->has_constant_val( $key ) ) {
-				$this->constant_opts[ $key ] = $this->get_constant_val( $key );
+			$setting_const = $this->get_constant_name( $key );
+			if ( defined( $setting_const ) ) {
+				$this->constant_opts[ $key ] = constant( $setting_const );
 			}
 		}
 	}
@@ -65,8 +66,7 @@ class WP_Auth0_Options_Generic {
 	 * @return boolean
 	 */
 	public function has_constant_val( $key ) {
-		$setting_const = $this->get_constant_name( $key );
-		return defined( $setting_const );
+		return isset( $this->constant_opts[ $key ] );
 	}
 
 	/**

--- a/phpcs-compat-ruleset.xml
+++ b/phpcs-compat-ruleset.xml
@@ -2,31 +2,30 @@
 <ruleset name="WP-Auth0" namespace="WPAuth0\CS\Standard">
     <description>A custom compatibility standard for WP-Auth0</description>
 
-    <!-- Internal tool, will be removed-->
-    <exclude-pattern>/account_cleanup/*</exclude-pattern>
-
-    <!-- Not currently checking JS or CSS -->
-    <exclude-pattern>/assets/*</exclude-pattern>
-
     <!-- Tests have their own ruleset (different PHP version) -->
     <exclude-pattern>/tests/*</exclude-pattern>
 
     <!-- Dev tools only, currently -->
     <exclude-pattern>/vendor/*</exclude-pattern>
 
-    <!-- Not currently checking JS -->
-    <exclude-pattern>/webtask/*</exclude-pattern>
-
     <!-- Deprecated so no changes needed -->
     <exclude-pattern>/lib/admin/WP_Auth0_Admin_Dashboard.php</exclude-pattern>
     <exclude-pattern>/lib/dashboard-widgets/*</exclude-pattern>
 
-    <config name="testVersion" value="5.3-"/>
-    <config name="showProgress" value="1"/>
-    <config name="extensions" value="php"/>
-    <config name="minimum_supported_wp_version" value="3.8"/>
+    <!-- Only check PHP files. -->
+    <arg name="extensions" value="php"/>
 
+    <!-- Show progress, show the error codes for each message (source). -->
+    <arg value="sp"/>
+
+    <!-- Strip the filepaths down to the relevant bit. -->
+    <arg name="basepath" value="."/>
+
+    <!-- Show coloured output, if available. -->
     <arg name="colors"/>
+
+    <config name="testVersion" value="5.3-"/>
+    <config name="minimum_supported_wp_version" value="3.8"/>
 
     <rule ref="PHPCompatibility"/>
 </ruleset>

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -23,8 +23,6 @@
     <exclude-pattern>/lib/admin/WP_Auth0_Admin_Dashboard.php</exclude-pattern>
     <exclude-pattern>/lib/dashboard-widgets/*</exclude-pattern>
 
-    <config name="minimum_supported_wp_version" value="3.8"/>
-
     <!-- Only check PHP files. -->
     <arg name="extensions" value="php"/>
 
@@ -41,7 +39,8 @@
     PHPCompatibility sniffs to check for PHP cross-version incompatible code.
     https://github.com/PHPCompatibility/PHPCompatibility
     -->
-    <config name="testVersion" value="5.5-"/>
+    <config name="testVersion" value="5.3-"/>
+    <config name="minimum_supported_wp_version" value="3.8"/>
     <rule ref="PHPCompatibilityWP"/>
 
     <rule ref="Generic.CodeAnalysis"/>

--- a/tests/testConstantSettings.php
+++ b/tests/testConstantSettings.php
@@ -19,52 +19,20 @@ class TestConstantSettings extends TestCase {
 	use domDocumentHelpers;
 
 	/**
-	 * Test string to use.
-	 */
-	const FILTER_TEST_STRING = '__filter_test__';
-
-	/**
 	 * Default constant setting prefix.
 	 *
 	 * @see WP_Auth0_Options_Generic::get_constant_name()
 	 */
-	const DEFAULT_CONSTANT_PREFIX = 'AUTH0_ENV_';
+	const CONSTANT_PREFIX = 'AUTH0_ENV_';
 
 	/**
-	 * Notice text for a field with a constant value set.
-	 *
-	 * @see WP_Auth0_Admin_Generic::render_const_notice()
+	 * Test that setting a constant will store the constant key with a custom prefix.
 	 */
-	const CONSTANT_NOTICE_TEXT = 'Value is set in the constant';
-
-	/**
-	 * Test that setting a constant will store the constant key.
-	 *
-	 * @runInSeparateProcess
-	 */
-	public function testThatConstructorStoresConstants() {
-		// Set a few constant overrides.
-		define( self::DEFAULT_CONSTANT_PREFIX . 'DOMAIN', rand() );
-		define( self::DEFAULT_CONSTANT_PREFIX . 'CLIENT_ID', rand() );
-		define( self::DEFAULT_CONSTANT_PREFIX . 'CLIENT_SECRET', rand() );
-
-		// Make sure we have the right number of overrides.
-		$opts          = new WP_Auth0_Options();
-		$constant_keys = $opts->get_all_constant_keys();
-		$this->assertCount( 3, $constant_keys );
-		$this->assertContains( 'domain', $constant_keys );
-		$this->assertContains( 'client_id', $constant_keys );
-		$this->assertContains( 'client_secret', $constant_keys );
-	}
-
-	/**
-	 * Test that setting a constant will store the constant key.
-	 */
-	public function testConstantPrefixFilter() {
+	public function testThatCustomConstantPrefixIsUsed() {
 		$opts     = new WP_Auth0_Options();
 		$opt_name = 'domain';
 
-		$this->assertEquals( self::DEFAULT_CONSTANT_PREFIX . 'DOMAIN', $opts->get_constant_name( $opt_name ) );
+		$this->assertEquals( self::CONSTANT_PREFIX . 'DOMAIN', $opts->get_constant_name( $opt_name ) );
 
 		add_filter(
 			'auth0_settings_constant_prefix',
@@ -76,60 +44,45 @@ class TestConstantSettings extends TestCase {
 		);
 
 		$this->assertEquals(
-			'__TEST_PREFIX_' . self::DEFAULT_CONSTANT_PREFIX . 'DOMAIN',
+			'__TEST_PREFIX_' . self::CONSTANT_PREFIX . 'DOMAIN',
 			$opts->get_constant_name( $opt_name )
 		);
 	}
 
 	/**
-	 * Test that setting a constant will change it's value on output.
-	 *
-	 * @runInSeparateProcess
+	 * Test that no constants are set by default on load.
 	 */
-	public function testThatConstantOverridesWork() {
-		$opts          = new WP_Auth0_Options();
-		$expected_opts = [];
-		$option_keys   = array_keys( $opts->get_options() );
-
-		// Connections contains a sub-array of connection settings, does not need to be overridden.
-		foreach ( $option_keys as $opt_name ) {
-			$expected_opts[ $opt_name ] = rand();
-			$constant_name              = $opts->get_constant_name( $opt_name );
-			$this->assertNull( $opts->get_constant_val( $opt_name ) );
-			define( $constant_name, $expected_opts[ $opt_name ] );
-			$this->assertTrue( $opts->has_constant_val( $opt_name ) );
-		}
-
-		// Create a new instance of the class to reset constant-set options.
+	public function testThatNotConstantsSetByDefault() {
 		$opts = new WP_Auth0_Options();
-		foreach ( $option_keys as $opt_name ) {
-			$this->assertEquals( $expected_opts[ $opt_name ], $opts->get_constant_val( $opt_name ), 'Opt name: ' . $opt_name );
-			$this->assertEquals( $expected_opts[ $opt_name ], $opts->get( $opt_name ), 'Opt name: ' . $opt_name );
+		foreach ( array_keys( $opts->get_options() ) as $opt_name ) {
+			$this->assertNull( $opts->get_constant_val( $opt_name ) );
 		}
 	}
 
 	/**
-	 * Test that options can be set in memory and in the DB.
+	 * Test that setting a constant will change it's value on retrieval.
+	 *
+	 * @runInSeparateProcess
 	 */
-	public function testSet() {
-		$opt_name       = 'domain';
-		$expected_val_1 = rand();
-		$expected_val_2 = rand();
-		$opts           = new WP_Auth0_Options();
+	public function testThatConstantValuesAreUsed() {
+		define( self::CONSTANT_PREFIX . 'DOMAIN', '__test_domain__' );
+		define( self::CONSTANT_PREFIX . 'CLIENT_ID', '__test_client_id__' );
+		define( self::CONSTANT_PREFIX . 'CLIENT_SECRET', '__test_client_secret__' );
 
-		// Test that a basic set without DB update works.
-		$result = $opts->set( $opt_name, $expected_val_1, false );
-		$this->assertTrue( $result );
-		$this->assertEquals( $expected_val_1, $opts->get( $opt_name ) );
-		$db_options = get_option( $opts->get_options_name() );
-		$this->assertNotEquals( $expected_val_1, $db_options[ $opt_name ] );
+		$opts          = new WP_Auth0_Options();
+		$constant_keys = $opts->get_all_constant_keys();
 
-		// Test that a basic set with DB update works.
-		$result = $opts->set( $opt_name, $expected_val_2, true );
-		$this->assertTrue( $result );
-		$this->assertEquals( $expected_val_2, $opts->get( $opt_name ) );
-		$db_options = get_option( $opts->get_options_name() );
-		$this->assertEquals( $expected_val_2, $db_options[ $opt_name ] );
+		$this->assertTrue( $opts->has_constant_val( 'domain' ) );
+		$this->assertEquals( '__test_domain__', $opts->get( 'domain' ) );
+		$this->assertContains( 'domain', $constant_keys );
+
+		$this->assertTrue( $opts->has_constant_val( 'client_id' ) );
+		$this->assertEquals( '__test_client_id__', $opts->get( 'client_id' ) );
+		$this->assertContains( 'client_id', $constant_keys );
+
+		$this->assertTrue( $opts->has_constant_val( 'client_secret' ) );
+		$this->assertEquals( '__test_client_secret__', $opts->get( 'client_secret' ) );
+		$this->assertContains( 'client_secret', $constant_keys );
 	}
 
 	/**
@@ -138,67 +91,78 @@ class TestConstantSettings extends TestCase {
 	 * @runInSeparateProcess
 	 */
 	public function testSetWithConstant() {
-		$opt_name      = 'domain';
-		$expected_val  = rand();
-		$opts          = new WP_Auth0_Options();
-		$constant_name = $opts->get_constant_name( $opt_name );
+		$opt_name     = 'domain';
+		$constant_val = rand();
 
 		// Set a constant and make sure it works.
-		$this->assertNull( $opts->get_constant_val( $opt_name ) );
-		define( $constant_name, $expected_val );
-		$this->assertEquals( $expected_val, $opts->get_constant_val( $opt_name ) );
+		define( self::CONSTANT_PREFIX . 'DOMAIN', $constant_val );
+		$opts = new WP_Auth0_Options();
+		$this->assertEquals( $constant_val, $opts->get( $opt_name ) );
 
 		// Try to set an option with the constant set.
-		$result = $opts->set( $opt_name, rand(), false );
-		$this->assertFalse( $result );
-		$this->assertNotEquals( $expected_val, $opts->get( $opt_name ) );
+		$new_value  = str_shuffle( $constant_val );
+		$set_result = $opts->set( $opt_name, $new_value, false );
+		$this->assertFalse( $set_result );
+		$this->assertEquals( $constant_val, $opts->get( $opt_name ) );
 	}
 
 	/**
-	 * Test that commonly-overridden settings will show a notice.
+	 * Test that constant settings will show a notice.
 	 *
 	 * @runInSeparateProcess
 	 */
 	public function testConstantSettingNoticeBasic() {
-		$opts  = new WP_Auth0_Options();
-		$admin = new WP_Auth0_Admin_Basic( $opts );
 
 		$fields = [
 			[
 				'opt_name'        => 'domain',
 				'label_for'       => 'wpa0_domain',
 				'render_function' => 'render_domain',
+				'value'           => rand(),
 			],
 			[
 				'opt_name'        => 'client_id',
 				'label_for'       => 'wpa0_client_id',
 				'render_function' => 'render_client_id',
+				'value'           => rand(),
 			],
 			[
 				'opt_name'        => 'client_secret',
 				'label_for'       => 'wpa0_client_secret',
 				'render_function' => 'render_client_secret',
+				'value'           => rand(),
 			],
 			[
 				'opt_name'        => 'auth0_app_token',
 				'label_for'       => 'wpa0_auth0_app_token',
 				'render_function' => 'render_auth0_app_token',
+				'value'           => rand(),
 			],
 		];
 
+		// Set all constant values before initializing the options class.
 		foreach ( $fields as $field ) {
-			$constant_name = self::DEFAULT_CONSTANT_PREFIX . strtoupper( $field['opt_name'] );
-			$override_val  = self::FILTER_TEST_STRING . rand();
-			define( $constant_name, $override_val );
+			$constant_name = self::CONSTANT_PREFIX . strtoupper( $field['opt_name'] );
+			define( $constant_name, $field['value'] );
+		}
 
+		$opts  = new WP_Auth0_Options();
+		$admin = new WP_Auth0_Admin_Basic( $opts );
+
+		foreach ( $fields as $field ) {
+			$constant_name = $opts->get_constant_name( $field['opt_name'] );
 			ob_start();
 			$admin->{$field['render_function']}( $field );
 			$field_html = ob_get_clean();
 
 			$input = $this->getDomListFromTagName( $field_html, 'input' );
 			$this->assertTrue( $input->item( 0 )->hasAttribute( 'disabled' ) );
-			$this->assertContains( self::CONSTANT_NOTICE_TEXT, $field_html );
+			$this->assertContains( 'Value is set in the constant', $field_html );
 			$this->assertContains( $constant_name, $field_html );
+
+			// Sensitive fields will not output the current value.
+			$is_sensitive = in_array( $field['opt_name'], [ 'client_secret', 'auth0_app_token' ] );
+			$this->assertContains( 'value="' . ( $is_sensitive ? '' : $field['value'] ) . '"', $field_html );
 		}
 	}
 }

--- a/tests/testWPAuth0Options.php
+++ b/tests/testWPAuth0Options.php
@@ -153,4 +153,28 @@ class TestWPAuth0Options extends TestCase {
 		$this->assertTrue( $opts->delete() );
 		$this->assertFalse( get_option( $opts->get_options_name() ) );
 	}
+
+	/**
+	 * Test that options can be set in memory and in the DB.
+	 */
+	public function testSet() {
+		$opt_name       = 'domain';
+		$expected_val_1 = rand();
+		$expected_val_2 = rand();
+		$opts           = new WP_Auth0_Options();
+
+		// Test that a basic set without DB update works.
+		$result = $opts->set( $opt_name, $expected_val_1, false );
+		$this->assertTrue( $result );
+		$this->assertEquals( $expected_val_1, $opts->get( $opt_name ) );
+		$db_options = get_option( $opts->get_options_name() );
+		$this->assertNotEquals( $expected_val_1, $db_options[ $opt_name ] );
+
+		// Test that a basic set with DB update works.
+		$result = $opts->set( $opt_name, $expected_val_2, true );
+		$this->assertTrue( $result );
+		$this->assertEquals( $expected_val_2, $opts->get( $opt_name ) );
+		$db_options = get_option( $opts->get_options_name() );
+		$this->assertEquals( $expected_val_2, $db_options[ $opt_name ] );
+	}
 }


### PR DESCRIPTION
### Changes

When [defining a setting value with constant](https://auth0.com/docs/cms/wordpress/configuration#php-constant-setting-storage), the definition must happen before the plugin is loaded (specifically, before `WP_Auth0_Options` is initialized). This PR fixes an issue where the constant value is not used if defined too late (in the theme, typically) but the setting in wp-admin shows that the constant is loaded. 

### References

Closes #569

### Testing

1. Define a constant `AUTH0_ENV_DOMAIN` in `wp-config.php`
2. Refresh the wp-admin > Auth0 > Settings > Advanced tab 

**Expect (before and after fix)**

- The constant value displayed in the field
- Field is disabled
- A message above the field referencing the constant being used
- Setting to be used where needed (in login, for example)

![screenshot 2018-12-11 10 48 54](https://user-images.githubusercontent.com/855223/49822574-60431000-fd32-11e8-9893-61640fa85912.png)

3. Delete the constant definition in `wp-config.php`
4. Define a constant `AUTH0_ENV_DOMAIN` in the theme `functions.php` file
5. Refresh the wp-admin > Auth0 > Settings > Advanced tab 

**Expected before the fix**

- Setting NOT to be used where needed (in login, for example)
- The constant value displayed in the field
- Field is disabled
- A message above the field referencing the constant being used

**Expected after the fix**

- Setting NOT to be used where needed (in login, for example)
- No change to the field display

![screenshot 2018-12-11 10 51 28](https://user-images.githubusercontent.com/855223/49822709-bc0d9900-fd32-11e8-8e9d-4039be99a480.png)

* [x] I included manual testing steps above, if applicable
* [x] This change adds unit test coverage
* [x] This change has been tested on WP v5.0.0

### Checklist

* [x] All existing and new tests complete without errors
* [x] All code quality tools/guidelines in the [Contribution guide](CONTRIBUTION.md) have been run/followed
* [x] All active GitHub CI checks have passed
