### PR TITLE
Remove Social Amplificator functionality

### DIFF
--- a/WP_Auth0.php
+++ b/WP_Auth0.php
@@ -54,6 +54,8 @@ class WP_Auth0 {
 	protected $a0_options;
 
 	/**
+	 * TODO: Deprecate
+	 *
 	 * @var WP_Auth0_Amplificator
 	 */
 	protected $social_amplificator;
@@ -153,9 +155,6 @@ class WP_Auth0 {
 
 		$settings_section = new WP_Auth0_Settings_Section( $this->a0_options, $initial_setup, $users_exporter, $configure_jwt_auth, $error_log, $auth0_admin, $import_settings );
 		$settings_section->init();
-
-		$this->social_amplificator = new WP_Auth0_Amplificator( $this->db_manager, $this->a0_options );
-		$this->social_amplificator->init();
 
 		$edit_profile = new WP_Auth0_EditProfile( $this->db_manager, $users_repo, $this->a0_options );
 		$edit_profile->init();
@@ -335,9 +334,6 @@ class WP_Auth0 {
 	public function wp_register_widget() {
 		register_widget( 'WP_Auth0_Embed_Widget' );
 		register_widget( 'WP_Auth0_Popup_Widget' );
-
-		WP_Auth0_SocialAmplification_Widget::set_context( $this->db_manager, $this->social_amplificator );
-		register_widget( 'WP_Auth0_SocialAmplification_Widget' );
 	}
 
 	public function wp_enqueue() {

--- a/lib/WP_Auth0_Amplificator.php
+++ b/lib/WP_Auth0_Amplificator.php
@@ -1,10 +1,27 @@
 <?php
 
+/**
+ * Class WP_Auth0_Amplificator
+ *
+ * TODO: Deprecate, functionality removed
+ *
+ * @codeCoverageIgnore
+ */
 class WP_Auth0_Amplificator {
 
 	protected $a0_options;
 	protected $db_manager;
 
+	/**
+	 * WP_Auth0_Amplificator constructor.
+	 *
+	 * @param WP_Auth0_DBManager $db_manager
+	 * @param WP_Auth0_Options   $a0_options
+	 *
+	 * TODO: Deprecate, functionality removed
+	 *
+	 * @codeCoverageIgnore
+	 */
 	public function __construct( WP_Auth0_DBManager $db_manager, WP_Auth0_Options $a0_options ) {
 		$this->db_manager = $db_manager;
 		$this->a0_options = $a0_options;

--- a/lib/WP_Auth0_Api_Client.php
+++ b/lib/WP_Auth0_Api_Client.php
@@ -305,7 +305,6 @@ class WP_Auth0_Api_Client {
 
 			'callbacks'           => array(
 				$options->get_wp_auth0_url(),
-				$options->get_wp_auth0_url(),
 			),
 
 			// Web origins do not take into account the path

--- a/lib/WP_Auth0_Api_Client.php
+++ b/lib/WP_Auth0_Api_Client.php
@@ -305,6 +305,7 @@ class WP_Auth0_Api_Client {
 
 			'callbacks'           => array(
 				$options->get_wp_auth0_url(),
+				$options->get_wp_auth0_url(),
 			),
 
 			// Web origins do not take into account the path

--- a/lib/WP_Auth0_SocialAmplification_Widget.php
+++ b/lib/WP_Auth0_SocialAmplification_Widget.php
@@ -1,5 +1,12 @@
 <?php
 
+/**
+ * Class WP_Auth0_SocialAmplification_Widget
+ *
+ * TODO: Deprecate, functionality removed
+ *
+ * @codeCoverageIgnore
+ */
 class WP_Auth0_SocialAmplification_Widget extends WP_Widget {
 
 	protected static $db_manager;
@@ -11,6 +18,11 @@ class WP_Auth0_SocialAmplification_Widget extends WP_Widget {
 		self::$social_amplificator = $social_amplificator;
 	}
 
+	/**
+	 * WP_Auth0_SocialAmplification_Widget constructor.
+	 *
+	 * TODO: Deprecate, functionality removed
+	 */
 	function __construct() {
 		parent::__construct(
 			$this->getWidgetId(),
@@ -175,6 +187,9 @@ class WP_Auth0_SocialAmplification_Widget extends WP_Widget {
 
 	}
 
+	/**
+	 * TODO: Deprecate, functionality removed
+	 */
 	protected static function current_page_url() {
 
 		return home_url( $_SERVER['REQUEST_URI'] );

--- a/lib/admin/WP_Auth0_Admin_Advanced.php
+++ b/lib/admin/WP_Auth0_Admin_Advanced.php
@@ -153,30 +153,6 @@ class WP_Auth0_Admin_Advanced extends WP_Auth0_Admin_Generic {
 				'function' => 'render_custom_signup_fields',
 			),
 			array(
-				'name'     => __( 'Twitter Consumer Key', 'wp-auth0' ),
-				'opt'      => 'social_twitter_key',
-				'id'       => 'wpa0_social_twitter_key',
-				'function' => 'render_social_twitter_key',
-			),
-			array(
-				'name'     => __( 'Twitter Consumer Secret', 'wp-auth0' ),
-				'opt'      => 'social_twitter_secret',
-				'id'       => 'wpa0_social_twitter_secret',
-				'function' => 'render_social_twitter_secret',
-			),
-			array(
-				'name'     => __( 'Facebook App Key', 'wp-auth0' ),
-				'opt'      => 'social_facebook_key',
-				'id'       => 'wpa0_social_facebook_key',
-				'function' => 'render_social_facebook_key',
-			),
-			array(
-				'name'     => __( 'Facebook App Secret', 'wp-auth0' ),
-				'opt'      => 'social_facebook_secret',
-				'id'       => 'wpa0_social_facebook_secret',
-				'function' => 'render_social_facebook_secret',
-			),
-			array(
 				'name'     => __( 'Auth0 Server Domain', 'wp-auth0' ),
 				'opt'      => 'auth0_server_domain',
 				'id'       => 'wpa0_auth0_server_domain',
@@ -548,6 +524,8 @@ class WP_Auth0_Admin_Advanced extends WP_Auth0_Admin_Generic {
 	 * Render form field and description for the `social_twitter_key` option.
 	 * IMPORTANT: Internal callback use only, do not call this function directly!
 	 *
+	 * TODO: Deprecate, functionality removed
+	 *
 	 * @param array $args - callback args passed in from add_settings_field().
 	 *
 	 * @see WP_Auth0_Admin_Generic::init_option_section()
@@ -569,6 +547,8 @@ class WP_Auth0_Admin_Advanced extends WP_Auth0_Admin_Generic {
 	 * Render form field and description for the `social_twitter_secret` option.
 	 * IMPORTANT: Internal callback use only, do not call this function directly!
 	 *
+	 * TODO: Deprecate, functionality removed
+	 *
 	 * @param array $args - callback args passed in from add_settings_field().
 	 *
 	 * @see WP_Auth0_Admin_Generic::init_option_section()
@@ -588,6 +568,8 @@ class WP_Auth0_Admin_Advanced extends WP_Auth0_Admin_Generic {
 	/**
 	 * Render form field and description for the `social_facebook_key` option.
 	 * IMPORTANT: Internal callback use only, do not call this function directly!
+	 *
+	 * TODO: Deprecate, functionality removed
 	 *
 	 * @param array $args - callback args passed in from add_settings_field().
 	 *
@@ -610,6 +592,8 @@ class WP_Auth0_Admin_Advanced extends WP_Auth0_Admin_Generic {
 	/**
 	 * Render form field and description for the `social_facebook_secret` option.
 	 * IMPORTANT: Internal callback use only, do not call this function directly!
+	 *
+	 * TODO: Deprecate, functionality removed
 	 *
 	 * @param array $args - callback args passed in from add_settings_field().
 	 *

--- a/lib/twitter-api-php/TwitterAPIExchange.php
+++ b/lib/twitter-api-php/TwitterAPIExchange.php
@@ -11,6 +11,8 @@
  * @license  MIT License
  * @version  1.0.4
  * @link     http://github.com/j7mbo/twitter-api-php
+ *
+ * TODO: Deprecate with Amplificator, not used
  */
 class TwitterAPIExchange {
 


### PR DESCRIPTION
### Changes

Removes the Social Amplificator functionality and adds notes to formally deprecate classes. 

This does not introduce any breaking changes, just removes the widgets and options from the admin screens. 