### PR TITLE
Fix escaped passwords sent to Auth0

### DIFF
--- a/lib/profile/WP_Auth0_Profile_Change_Password.php
+++ b/lib/profile/WP_Auth0_Profile_Change_Password.php
@@ -64,7 +64,7 @@ class WP_Auth0_Profile_Change_Password {
 		}
 
 		$field_name   = ! empty( $_POST['pass1'] ) ? 'pass1' : 'password_1';
-		$new_password = $_POST[ $field_name ];
+		$new_password = wp_unslash( $_POST[ $field_name ] );
 
 		if ( isset( $_POST['user_id'] ) ) {
 			// Input field from user edit or profile update.

--- a/tests/testProfileChangePassword.php
+++ b/tests/testProfileChangePassword.php
@@ -73,6 +73,15 @@ class TestProfileChangePassword extends TestCase {
 	}
 
 	/**
+	 * Run after each test is completed.
+	 */
+	public function tearDown() {
+		parent::tearDown();
+		self::$options->reset();
+		$this->stopHttpHalting();
+	}
+
+	/**
 	 * Test that correct hooks are loaded.
 	 */
 	public function testInitHooks() {


### PR DESCRIPTION
### Changes

Add `wp_unslash` to new password before sending to Auth0. 

### References

[Reported in the WP support forums](https://wordpress.org/support/topic/characters-allowed-in-password/).

### Testing

* [x] This change adds unit test coverage
* [x] This change has been tested on WP 5.0

### Checklist

* [x] All existing and new tests complete without errors
* [x] All code quality tools/guidelines in the [Contribution guide](CONTRIBUTION.md) have been run/followed
* [x] All active GitHub CI checks have passed
