### PR TITLE
Deprecate Social Amplificator classes + methods

### DIFF
--- a/WP_Auth0.php
+++ b/WP_Auth0.php
@@ -54,7 +54,7 @@ class WP_Auth0 {
 	protected $a0_options;
 
 	/**
-	 * TODO: Deprecate
+	 * @deprecated - 3.9.0, functionality removed
 	 *
 	 * @var WP_Auth0_Amplificator
 	 */

--- a/lib/WP_Auth0_Amplificator.php
+++ b/lib/WP_Auth0_Amplificator.php
@@ -3,7 +3,7 @@
 /**
  * Class WP_Auth0_Amplificator
  *
- * TODO: Deprecate, functionality removed
+ * @deprecated - 3.9.0, functionality removed
  *
  * @codeCoverageIgnore
  */
@@ -18,9 +18,7 @@ class WP_Auth0_Amplificator {
 	 * @param WP_Auth0_DBManager $db_manager
 	 * @param WP_Auth0_Options   $a0_options
 	 *
-	 * TODO: Deprecate, functionality removed
-	 *
-	 * @codeCoverageIgnore
+	 * @deprecated - 3.9.0, functionality removed
 	 */
 	public function __construct( WP_Auth0_DBManager $db_manager, WP_Auth0_Options $a0_options ) {
 		$this->db_manager = $db_manager;

--- a/lib/WP_Auth0_Amplificator.php
+++ b/lib/WP_Auth0_Amplificator.php
@@ -21,6 +21,8 @@ class WP_Auth0_Amplificator {
 	 * @deprecated - 3.9.0, functionality removed
 	 */
 	public function __construct( WP_Auth0_DBManager $db_manager, WP_Auth0_Options $a0_options ) {
+		// phpcs:ignore
+		@trigger_error( sprintf( __( 'Method %s is deprecated.', 'wp-auth0' ), __METHOD__ ), E_USER_DEPRECATED );
 		$this->db_manager = $db_manager;
 		$this->a0_options = $a0_options;
 	}

--- a/lib/WP_Auth0_SocialAmplification_Widget.php
+++ b/lib/WP_Auth0_SocialAmplification_Widget.php
@@ -24,6 +24,8 @@ class WP_Auth0_SocialAmplification_Widget extends WP_Widget {
 	 * @deprecated - 3.9.0, functionality removed
 	 */
 	function __construct() {
+		// phpcs:ignore
+		@trigger_error( sprintf( __( 'Method %s is deprecated.', 'wp-auth0' ), __METHOD__ ), E_USER_DEPRECATED );
 		parent::__construct(
 			$this->getWidgetId(),
 			__( $this->getWidgetName(), 'wp_auth0_widget_domain' ),
@@ -191,7 +193,8 @@ class WP_Auth0_SocialAmplification_Widget extends WP_Widget {
 	 * @deprecated - 3.9.0, functionality removed
 	 */
 	protected static function current_page_url() {
-
+		// phpcs:ignore
+		@trigger_error( sprintf( __( 'Method %s is deprecated.', 'wp-auth0' ), __METHOD__ ), E_USER_DEPRECATED );
 		return home_url( $_SERVER['REQUEST_URI'] );
 	}
 

--- a/lib/WP_Auth0_SocialAmplification_Widget.php
+++ b/lib/WP_Auth0_SocialAmplification_Widget.php
@@ -3,7 +3,7 @@
 /**
  * Class WP_Auth0_SocialAmplification_Widget
  *
- * TODO: Deprecate, functionality removed
+ * @deprecated - 3.9.0, functionality removed
  *
  * @codeCoverageIgnore
  */
@@ -21,7 +21,7 @@ class WP_Auth0_SocialAmplification_Widget extends WP_Widget {
 	/**
 	 * WP_Auth0_SocialAmplification_Widget constructor.
 	 *
-	 * TODO: Deprecate, functionality removed
+	 * @deprecated - 3.9.0, functionality removed
 	 */
 	function __construct() {
 		parent::__construct(
@@ -188,7 +188,7 @@ class WP_Auth0_SocialAmplification_Widget extends WP_Widget {
 	}
 
 	/**
-	 * TODO: Deprecate, functionality removed
+	 * @deprecated - 3.9.0, functionality removed
 	 */
 	protected static function current_page_url() {
 

--- a/lib/admin/WP_Auth0_Admin_Advanced.php
+++ b/lib/admin/WP_Auth0_Admin_Advanced.php
@@ -717,6 +717,8 @@ class WP_Auth0_Admin_Advanced extends WP_Auth0_Admin_Generic {
 	 * @codeCoverageIgnore - Deprecated
 	 */
 	public function render_social_twitter_key( $args = array() ) {
+		// phpcs:ignore
+		@trigger_error( sprintf( __( 'Method %s is deprecated.', 'wp-auth0' ), __METHOD__ ), E_USER_DEPRECATED );
 		$this->render_text_field( $args['label_for'], $args['opt_name'] );
 		$this->render_field_description(
 			__( 'Twitter app key for the Social Amplification Widget. ', 'wp-auth0' ) .
@@ -739,6 +741,8 @@ class WP_Auth0_Admin_Advanced extends WP_Auth0_Admin_Generic {
 	 * @codeCoverageIgnore - Deprecated
 	 */
 	public function render_social_twitter_secret( $args = array() ) {
+		// phpcs:ignore
+		@trigger_error( sprintf( __( 'Method %s is deprecated.', 'wp-auth0' ), __METHOD__ ), E_USER_DEPRECATED );
 		$this->render_text_field( $args['label_for'], $args['opt_name'] );
 		$this->render_field_description(
 			__( 'Secret for the app above. ', 'wp-auth0' ) .
@@ -760,6 +764,8 @@ class WP_Auth0_Admin_Advanced extends WP_Auth0_Admin_Generic {
 	 * @codeCoverageIgnore - Deprecated
 	 */
 	public function render_social_facebook_key( $args = array() ) {
+		// phpcs:ignore
+		@trigger_error( sprintf( __( 'Method %s is deprecated.', 'wp-auth0' ), __METHOD__ ), E_USER_DEPRECATED );
 		$this->render_text_field( $args['label_for'], $args['opt_name'] );
 		$this->render_field_description(
 			__( 'Facebook app key for the Social Amplification Widget. ', 'wp-auth0' ) .
@@ -783,6 +789,8 @@ class WP_Auth0_Admin_Advanced extends WP_Auth0_Admin_Generic {
 	 * @codeCoverageIgnore - Deprecated
 	 */
 	public function render_social_facebook_secret( $args = array() ) {
+		// phpcs:ignore
+		@trigger_error( sprintf( __( 'Method %s is deprecated.', 'wp-auth0' ), __METHOD__ ), E_USER_DEPRECATED );
 		$this->render_text_field( $args['label_for'], $args['opt_name'] );
 		$this->render_field_description(
 			__( 'Secret for the app above. ', 'wp-auth0' ) .

--- a/lib/admin/WP_Auth0_Admin_Advanced.php
+++ b/lib/admin/WP_Auth0_Admin_Advanced.php
@@ -521,97 +521,6 @@ class WP_Auth0_Admin_Advanced extends WP_Auth0_Admin_Generic {
 	}
 
 	/**
-	 * Render form field and description for the `social_twitter_key` option.
-	 * IMPORTANT: Internal callback use only, do not call this function directly!
-	 *
-	 * TODO: Deprecate, functionality removed
-	 *
-	 * @param array $args - callback args passed in from add_settings_field().
-	 *
-	 * @see WP_Auth0_Admin_Generic::init_option_section()
-	 * @see add_settings_field()
-	 */
-	public function render_social_twitter_key( $args = array() ) {
-		$this->render_text_field( $args['label_for'], $args['opt_name'] );
-		$this->render_field_description(
-			__( 'Twitter app key for the Social Amplification Widget. ', 'wp-auth0' ) .
-			__( 'The app used here needs to have "read" and "write" permissions. ', 'wp-auth0' ) .
-			$this->get_docs_link(
-				'connections/social/twitter#2-get-your-consumer-key-and-consumer-secret',
-				__( 'Instructions here', 'wp-auth0' )
-			)
-		);
-	}
-
-	/**
-	 * Render form field and description for the `social_twitter_secret` option.
-	 * IMPORTANT: Internal callback use only, do not call this function directly!
-	 *
-	 * TODO: Deprecate, functionality removed
-	 *
-	 * @param array $args - callback args passed in from add_settings_field().
-	 *
-	 * @see WP_Auth0_Admin_Generic::init_option_section()
-	 * @see add_settings_field()
-	 */
-	public function render_social_twitter_secret( $args = array() ) {
-		$this->render_text_field( $args['label_for'], $args['opt_name'] );
-		$this->render_field_description(
-			__( 'Secret for the app above. ', 'wp-auth0' ) .
-			$this->get_docs_link(
-				'connections/social/twitter#2-get-your-consumer-key-and-consumer-secret',
-				__( 'Instructions here', 'wp-auth0' )
-			)
-		);
-	}
-
-	/**
-	 * Render form field and description for the `social_facebook_key` option.
-	 * IMPORTANT: Internal callback use only, do not call this function directly!
-	 *
-	 * TODO: Deprecate, functionality removed
-	 *
-	 * @param array $args - callback args passed in from add_settings_field().
-	 *
-	 * @see WP_Auth0_Admin_Generic::init_option_section()
-	 * @see add_settings_field()
-	 */
-	public function render_social_facebook_key( $args = array() ) {
-		$this->render_text_field( $args['label_for'], $args['opt_name'] );
-		$this->render_field_description(
-			__( 'Facebook app key for the Social Amplification Widget. ', 'wp-auth0' ) .
-			__( 'The app used here needs to have "publish_actions" permission. ', 'wp-auth0' ) .
-			__( 'Used for the Social Amplification Widget. ', 'wp-auth0' ) .
-			$this->get_docs_link(
-				'connections/social/facebook#5-get-your-app-id-and-app-secret',
-				__( 'Instructions here', 'wp-auth0' )
-			)
-		);
-	}
-
-	/**
-	 * Render form field and description for the `social_facebook_secret` option.
-	 * IMPORTANT: Internal callback use only, do not call this function directly!
-	 *
-	 * TODO: Deprecate, functionality removed
-	 *
-	 * @param array $args - callback args passed in from add_settings_field().
-	 *
-	 * @see WP_Auth0_Admin_Generic::init_option_section()
-	 * @see add_settings_field()
-	 */
-	public function render_social_facebook_secret( $args = array() ) {
-		$this->render_text_field( $args['label_for'], $args['opt_name'] );
-		$this->render_field_description(
-			__( 'Secret for the app above. ', 'wp-auth0' ) .
-			$this->get_docs_link(
-				'connections/social/facebook#5-get-your-app-id-and-app-secret',
-				__( 'Instructions here', 'wp-auth0' )
-			)
-		);
-	}
-
-	/**
 	 * Render form field and description for the `auth0_server_domain` option.
 	 * IMPORTANT: Internal callback use only, do not call this function directly!
 	 *
@@ -791,6 +700,97 @@ class WP_Auth0_Admin_Advanced extends WP_Auth0_Admin_Generic {
 			$domain = array_pop( $host_pieces ) . '.' . $domain;
 		}
 		return $domain;
+	}
+
+	/*
+	 * DEPRECATED
+	 */
+
+	/**
+	 * Render form field and description for the `social_twitter_key` option.
+	 * IMPORTANT: Internal callback use only, do not call this function directly!
+	 *
+	 * @deprecated - 3.9.0, functionality removed
+	 *
+	 * @param array $args - callback args passed in from add_settings_field().
+	 *
+	 * @codeCoverageIgnore - Deprecated
+	 */
+	public function render_social_twitter_key( $args = array() ) {
+		$this->render_text_field( $args['label_for'], $args['opt_name'] );
+		$this->render_field_description(
+			__( 'Twitter app key for the Social Amplification Widget. ', 'wp-auth0' ) .
+			__( 'The app used here needs to have "read" and "write" permissions. ', 'wp-auth0' ) .
+			$this->get_docs_link(
+				'connections/social/twitter#2-get-your-consumer-key-and-consumer-secret',
+				__( 'Instructions here', 'wp-auth0' )
+			)
+		);
+	}
+
+	/**
+	 * Render form field and description for the `social_twitter_secret` option.
+	 * IMPORTANT: Internal callback use only, do not call this function directly!
+	 *
+	 * @deprecated - 3.9.0, functionality removed
+	 *
+	 * @param array $args - callback args passed in from add_settings_field().
+	 *
+	 * @codeCoverageIgnore - Deprecated
+	 */
+	public function render_social_twitter_secret( $args = array() ) {
+		$this->render_text_field( $args['label_for'], $args['opt_name'] );
+		$this->render_field_description(
+			__( 'Secret for the app above. ', 'wp-auth0' ) .
+			$this->get_docs_link(
+				'connections/social/twitter#2-get-your-consumer-key-and-consumer-secret',
+				__( 'Instructions here', 'wp-auth0' )
+			)
+		);
+	}
+
+	/**
+	 * Render form field and description for the `social_facebook_key` option.
+	 * IMPORTANT: Internal callback use only, do not call this function directly!
+	 *
+	 * @deprecated - 3.9.0, functionality removed
+	 *
+	 * @param array $args - callback args passed in from add_settings_field().
+	 *
+	 * @codeCoverageIgnore - Deprecated
+	 */
+	public function render_social_facebook_key( $args = array() ) {
+		$this->render_text_field( $args['label_for'], $args['opt_name'] );
+		$this->render_field_description(
+			__( 'Facebook app key for the Social Amplification Widget. ', 'wp-auth0' ) .
+			__( 'The app used here needs to have "publish_actions" permission. ', 'wp-auth0' ) .
+			__( 'Used for the Social Amplification Widget. ', 'wp-auth0' ) .
+			$this->get_docs_link(
+				'connections/social/facebook#5-get-your-app-id-and-app-secret',
+				__( 'Instructions here', 'wp-auth0' )
+			)
+		);
+	}
+
+	/**
+	 * Render form field and description for the `social_facebook_secret` option.
+	 * IMPORTANT: Internal callback use only, do not call this function directly!
+	 *
+	 * @deprecated - 3.9.0, functionality removed
+	 *
+	 * @param array $args - callback args passed in from add_settings_field().
+	 *
+	 * @codeCoverageIgnore - Deprecated
+	 */
+	public function render_social_facebook_secret( $args = array() ) {
+		$this->render_text_field( $args['label_for'], $args['opt_name'] );
+		$this->render_field_description(
+			__( 'Secret for the app above. ', 'wp-auth0' ) .
+			$this->get_docs_link(
+				'connections/social/facebook#5-get-your-app-id-and-app-secret',
+				__( 'Instructions here', 'wp-auth0' )
+			)
+		);
 	}
 
 	/**

--- a/lib/twitter-api-php/TwitterAPIExchange.php
+++ b/lib/twitter-api-php/TwitterAPIExchange.php
@@ -5,14 +5,14 @@
  *
  * PHP version 5.3.10
  *
+ * @deprecated - 3.9.0, functionality removed
+ *
  * @category Awesomeness
  * @package  Twitter-API-PHP
  * @author   James Mallison <me@j7mbo.co.uk>
  * @license  MIT License
  * @version  1.0.4
  * @link     http://github.com/j7mbo/twitter-api-php
- *
- * TODO: Deprecate with Amplificator, not used
  */
 class TwitterAPIExchange {
 


### PR DESCRIPTION
### Changes

Officially deprecating methods/classes for the Social Amplificator feature. 

### References

Removed in #607 

