### PR TITLE
Fix PHP notice on OAuth config endpoint

### DIFF
--- a/lib/WP_Auth0_Routes.php
+++ b/lib/WP_Auth0_Routes.php
@@ -53,11 +53,12 @@ class WP_Auth0_Routes {
 	/**
 	 * Route incoming Auth0 actions.
 	 *
-	 * @param WP $wp - WP object for current request.
+	 * @param WP   $wp - WP object for current request.
+	 * @param bool $return - True to return the data, false to echo and exit.
 	 *
 	 * @return bool|string
 	 */
-	public function custom_requests( $wp ) {
+	public function custom_requests( $wp, $return = false ) {
 		$page = null;
 
 		if ( isset( $wp->query_vars['auth0fallback'] ) ) {
@@ -93,7 +94,7 @@ class WP_Auth0_Routes {
 				return false;
 		}
 
-		if ( $wp->query_vars['custom_requests_return'] ) {
+		if ( $return ) {
 			return $output;
 		}
 

--- a/tests/testRoutes.php
+++ b/tests/testRoutes.php
@@ -72,7 +72,6 @@ class TestRoutes extends TestCase {
 		parent::setUp();
 		$this->setUpDb();
 		self::$wp = new WP();
-		self::$wp->set_query_var( 'custom_requests_return', true );
 		self::$opts->reset();
 	}
 
@@ -88,7 +87,7 @@ class TestRoutes extends TestCase {
 	 * If we have no query vars, the route should do nothing.
 	 */
 	public function testThatEmptyQueryVarsDoesNothing() {
-		$this->assertFalse( self::$routes->custom_requests( self::$wp ) );
+		$this->assertFalse( self::$routes->custom_requests( self::$wp, true ) );
 	}
 
 	/**
@@ -96,11 +95,11 @@ class TestRoutes extends TestCase {
 	 */
 	public function testThatUnknownRouteDoesNothing() {
 		self::$wp->query_vars['a0_action'] = uniqid();
-		$this->assertFalse( self::$routes->custom_requests( self::$wp ) );
+		$this->assertFalse( self::$routes->custom_requests( self::$wp, true ) );
 
 		unset( self::$wp->query_vars['a0_action'] );
 		self::$wp->query_vars['pagename'] = uniqid();
-		$this->assertFalse( self::$routes->custom_requests( self::$wp ) );
+		$this->assertFalse( self::$routes->custom_requests( self::$wp, true ) );
 
 		$this->assertEmpty( self::$error_log->get() );
 	}
@@ -111,7 +110,7 @@ class TestRoutes extends TestCase {
 	public function testThatOauthConfigIsCorrect() {
 		self::$wp->set_query_var( 'a0_action', 'oauth2-config' );
 
-		$output = json_decode( self::$routes->custom_requests( self::$wp ), true );
+		$output = json_decode( self::$routes->custom_requests( self::$wp, true ), true );
 
 		$this->assertEquals( 'Test Blog', $output['client_name'] );
 		$this->assertCount( 1, $output['redirect_uris'] );
@@ -122,7 +121,7 @@ class TestRoutes extends TestCase {
 
 		self::$wp->set_query_var( 'a0_action', null );
 		self::$wp->set_query_var( 'pagename', 'oauth2-config' );
-		$output_2 = json_decode( self::$routes->custom_requests( self::$wp ), true );
+		$output_2 = json_decode( self::$routes->custom_requests( self::$wp, true ), true );
 		$this->assertEquals( $output, $output_2 );
 	}
 
@@ -133,7 +132,7 @@ class TestRoutes extends TestCase {
 		self::auth0Ready( true );
 		self::$wp->set_query_var( 'a0_action', 'coo-fallback' );
 
-		$output = self::$routes->custom_requests( self::$wp );
+		$output = self::$routes->custom_requests( self::$wp, true );
 
 		$this->assertContains( '<script src="' . WPA0_AUTH0_JS_CDN_URL . '"></script>', $output );
 		$this->assertContains( 'var auth0 = new auth0.WebAuth({', $output );
@@ -144,7 +143,7 @@ class TestRoutes extends TestCase {
 
 		self::$wp->set_query_var( 'a0_action', null );
 		self::$wp->set_query_var( 'auth0fallback', 1 );
-		$output_2 = self::$routes->custom_requests( self::$wp );
+		$output_2 = self::$routes->custom_requests( self::$wp, true );
 		$this->assertEquals( $output, $output_2 );
 	}
 }

--- a/tests/testRoutesGetUser.php
+++ b/tests/testRoutesGetUser.php
@@ -75,7 +75,6 @@ class TestRoutesGetUser extends TestCase {
 		$this->setUpDb();
 		self::$opts->reset();
 		self::$wp = new WP();
-		self::$wp->set_query_var( 'custom_requests_return', true );
 	}
 
 	/**
@@ -92,7 +91,7 @@ class TestRoutesGetUser extends TestCase {
 	public function testThatGetUserRouteIsForbiddenByDefault() {
 		self::$wp->query_vars['a0_action'] = 'migration-ws-get-user';
 
-		$output = json_decode( self::$routes->custom_requests( self::$wp ) );
+		$output = json_decode( self::$routes->custom_requests( self::$wp, true ) );
 
 		$this->assertEquals( 403, $output->status );
 		$this->assertEquals( 'Forbidden', $output->error );
@@ -108,7 +107,7 @@ class TestRoutesGetUser extends TestCase {
 		self::$opts->set( 'migration_ips_filter', 1 );
 		self::$wp->query_vars['a0_action'] = 'migration-ws-get-user';
 
-		$output = json_decode( self::$routes->custom_requests( self::$wp ) );
+		$output = json_decode( self::$routes->custom_requests( self::$wp, true ) );
 
 		$this->assertEquals( 401, $output->status );
 		$this->assertEquals( 'Unauthorized', $output->error );
@@ -123,7 +122,7 @@ class TestRoutesGetUser extends TestCase {
 		self::$opts->set( 'migration_ws', 1 );
 		self::$wp->query_vars['a0_action'] = 'migration-ws-get-user';
 
-		$output = json_decode( self::$routes->custom_requests( self::$wp ) );
+		$output = json_decode( self::$routes->custom_requests( self::$wp, true ) );
 
 		$this->assertEquals( 401, $output->status );
 		$this->assertEquals( 'Unauthorized: missing authorization header', $output->error );
@@ -145,7 +144,7 @@ class TestRoutesGetUser extends TestCase {
 		self::$wp->query_vars['a0_action'] = 'migration-ws-get-user';
 		$_POST['access_token']             = JWT::encode( [ 'jti' => uniqid() ], $client_secret );
 
-		$output = json_decode( self::$routes->custom_requests( self::$wp ) );
+		$output = json_decode( self::$routes->custom_requests( self::$wp, true ) );
 
 		$this->assertEquals( 401, $output->status );
 		$this->assertEquals( 'Invalid token', $output->error );
@@ -169,7 +168,7 @@ class TestRoutesGetUser extends TestCase {
 		self::$wp->query_vars['a0_action'] = 'migration-ws-get-user';
 		$_POST['access_token']             = $migration_token;
 
-		$output = json_decode( self::$routes->custom_requests( self::$wp ) );
+		$output = json_decode( self::$routes->custom_requests( self::$wp, true ) );
 
 		$this->assertEquals( 400, $output->status );
 		$this->assertEquals( 'Username is required', $output->error );
@@ -195,7 +194,7 @@ class TestRoutesGetUser extends TestCase {
 		$_POST['access_token'] = $migration_token;
 		$_POST['username']     = uniqid();
 
-		$output = json_decode( self::$routes->custom_requests( self::$wp ) );
+		$output = json_decode( self::$routes->custom_requests( self::$wp, true ) );
 
 		$this->assertEquals( 401, $output->status );
 		$this->assertEquals( 'Invalid Credentials', $output->error );
@@ -227,7 +226,7 @@ class TestRoutesGetUser extends TestCase {
 		self::$wp->query_vars['a0_action'] = 'migration-ws-get-user';
 		$_POST['access_token']             = $migration_token;
 
-		$output_em = json_decode( self::$routes->custom_requests( self::$wp ) );
+		$output_em = json_decode( self::$routes->custom_requests( self::$wp, true ) );
 
 		$this->assertEquals( $user->ID, $output_em->data->ID );
 		$this->assertEquals( $user->user_login, $output_em->data->user_login );
@@ -238,7 +237,7 @@ class TestRoutesGetUser extends TestCase {
 
 		// Test username lookup.
 		$_POST['username'] = $user->user_login;
-		$output_un         = json_decode( self::$routes->custom_requests( self::$wp ) );
+		$output_un         = json_decode( self::$routes->custom_requests( self::$wp, true ) );
 
 		$this->assertEquals( $output_em, $output_un );
 		$this->assertEmpty( self::$error_log->get() );

--- a/tests/testRoutesLogin.php
+++ b/tests/testRoutesLogin.php
@@ -75,7 +75,6 @@ class TestRoutesLogin extends TestCase {
 		$this->setUpDb();
 		self::$opts->reset();
 		self::$wp = new WP();
-		self::$wp->set_query_var( 'custom_requests_return', true );
 	}
 
 	/**
@@ -92,7 +91,7 @@ class TestRoutesLogin extends TestCase {
 	public function testThatLoginRouteIsForbiddenByDefault() {
 		self::$wp->query_vars['a0_action'] = 'migration-ws-login';
 
-		$output = json_decode( self::$routes->custom_requests( self::$wp ) );
+		$output = json_decode( self::$routes->custom_requests( self::$wp, true ) );
 
 		$this->assertEquals( 403, $output->status );
 		$this->assertEquals( 'Forbidden', $output->error );
@@ -108,7 +107,7 @@ class TestRoutesLogin extends TestCase {
 		self::$opts->set( 'migration_ips_filter', 1 );
 		self::$wp->query_vars['a0_action'] = 'migration-ws-login';
 
-		$output = json_decode( self::$routes->custom_requests( self::$wp ) );
+		$output = json_decode( self::$routes->custom_requests( self::$wp, true ) );
 
 		$this->assertEquals( 401, $output->status );
 		$this->assertEquals( 'Unauthorized', $output->error );
@@ -123,7 +122,7 @@ class TestRoutesLogin extends TestCase {
 		self::$opts->set( 'migration_ws', 1 );
 		self::$wp->query_vars['a0_action'] = 'migration-ws-login';
 
-		$output = json_decode( self::$routes->custom_requests( self::$wp ) );
+		$output = json_decode( self::$routes->custom_requests( self::$wp, true ) );
 
 		$this->assertEquals( 401, $output->status );
 		$this->assertEquals( 'Unauthorized: missing authorization header', $output->error );
@@ -145,7 +144,7 @@ class TestRoutesLogin extends TestCase {
 		self::$wp->query_vars['a0_action'] = 'migration-ws-login';
 		$_POST['access_token']             = JWT::encode( [ 'jti' => uniqid() ], $client_secret );
 
-		$output = json_decode( self::$routes->custom_requests( self::$wp ) );
+		$output = json_decode( self::$routes->custom_requests( self::$wp, true ) );
 
 		$this->assertEquals( 401, $output->status );
 		$this->assertEquals( 'Invalid token', $output->error );
@@ -167,7 +166,7 @@ class TestRoutesLogin extends TestCase {
 		self::$wp->query_vars['a0_action'] = 'migration-ws-login';
 		$_POST['access_token']             = JWT::encode( [ 'iss' => uniqid() ], $client_secret );
 
-		$output = json_decode( self::$routes->custom_requests( self::$wp ) );
+		$output = json_decode( self::$routes->custom_requests( self::$wp, true ) );
 
 		$this->assertEquals( 401, $output->status );
 		$this->assertEquals( 'Invalid token', $output->error );
@@ -191,7 +190,7 @@ class TestRoutesLogin extends TestCase {
 		self::$wp->query_vars['a0_action'] = 'migration-ws-login';
 		$_POST['access_token']             = $migration_token;
 
-		$output = json_decode( self::$routes->custom_requests( self::$wp ) );
+		$output = json_decode( self::$routes->custom_requests( self::$wp, true ) );
 
 		$this->assertEquals( 400, $output->status );
 		$this->assertEquals( 'Username is required', $output->error );
@@ -216,7 +215,7 @@ class TestRoutesLogin extends TestCase {
 		$_POST['access_token']             = $migration_token;
 		$_POST['username']                 = uniqid();
 
-		$output = json_decode( self::$routes->custom_requests( self::$wp ) );
+		$output = json_decode( self::$routes->custom_requests( self::$wp, true ) );
 
 		$this->assertEquals( 400, $output->status );
 		$this->assertEquals( 'Password is required', $output->error );
@@ -243,7 +242,7 @@ class TestRoutesLogin extends TestCase {
 		$_POST['username']     = uniqid();
 		$_POST['password']     = uniqid();
 
-		$output = json_decode( self::$routes->custom_requests( self::$wp ) );
+		$output = json_decode( self::$routes->custom_requests( self::$wp, true ) );
 
 		$this->assertEquals( 401, $output->status );
 		$this->assertEquals( 'Invalid Credentials', $output->error );
@@ -275,7 +274,7 @@ class TestRoutesLogin extends TestCase {
 		self::$wp->query_vars['a0_action'] = 'migration-ws-login';
 		$_POST['access_token']             = $migration_token;
 
-		$output = json_decode( self::$routes->custom_requests( self::$wp ) );
+		$output = json_decode( self::$routes->custom_requests( self::$wp, true ) );
 
 		$this->assertEquals( $user->ID, $output->data->ID );
 		$this->assertEquals( $user->user_login, $output->data->user_login );


### PR DESCRIPTION
### Changes

Changed the OAuth config endpoint to use a function parameter instead of a global to fix a PHP notice in some cases and make for a more clear implementation.

### Testing

* [x] This change adds unit test coverage
* [x] This change has been tested on WP 5.0

### Checklist

* [x] All existing and new tests complete without errors
* [x] All code quality tools/guidelines in the [Contribution guide](CONTRIBUTION.md) have been run/followed
* [x] All active GitHub CI checks have passed
