### PR TITLE
Remove unused IP range setting

### DIFF
--- a/lib/WP_Auth0_Options.php
+++ b/lib/WP_Auth0_Options.php
@@ -248,8 +248,6 @@ class WP_Auth0_Options extends WP_Auth0_Options_Generic {
 			'auto_login'                => 0,
 			'auto_login_method'         => '',
 			'auth0_implicit_workflow'   => false,
-			'ip_range_check'            => 0,
-			'ip_ranges'                 => '',
 			'valid_proxy_ip'            => null,
 			'custom_signup_fields'      => '',
 			'extra_conf'                => '',

--- a/lib/admin/WP_Auth0_Admin_Advanced.php
+++ b/lib/admin/WP_Auth0_Admin_Advanced.php
@@ -123,18 +123,6 @@ class WP_Auth0_Admin_Advanced extends WP_Auth0_Admin_Generic {
 				'function' => 'render_auth0_implicit_workflow',
 			),
 			array(
-				'name'     => __( 'Enable IP Ranges', 'wp-auth0' ),
-				'opt'      => 'ip_range_check',
-				'id'       => 'wpa0_ip_range_check',
-				'function' => 'render_ip_range_check',
-			),
-			array(
-				'name'     => __( 'IP Ranges', 'wp-auth0' ),
-				'opt'      => 'ip_ranges',
-				'id'       => 'wpa0_ip_ranges',
-				'function' => 'render_ip_ranges',
-			),
-			array(
 				'name'     => __( 'Valid Proxy IP', 'wp-auth0' ),
 				'opt'      => 'valid_proxy_ip',
 				'id'       => 'wpa0_valid_proxy_ip',
@@ -441,10 +429,14 @@ class WP_Auth0_Admin_Advanced extends WP_Auth0_Admin_Generic {
 	 * Render form field and description for the `ip_range_check` option.
 	 * IMPORTANT: Internal callback use only, do not call this function directly!
 	 *
+	 * TODO: Deprecate, not used
+	 *
 	 * @param array $args - callback args passed in from add_settings_field().
 	 *
 	 * @see WP_Auth0_Admin_Generic::init_option_section()
 	 * @see add_settings_field()
+	 *
+	 * @codeCoverageIgnore - Deprecated
 	 */
 	public function render_ip_range_check( $args = array() ) {
 		$this->render_switch( $args['label_for'], $args['opt_name'], 'wpa0_ip_ranges' );
@@ -454,10 +446,14 @@ class WP_Auth0_Admin_Advanced extends WP_Auth0_Admin_Generic {
 	 * Render form field and description for the `ip_ranges` option.
 	 * IMPORTANT: Internal callback use only, do not call this function directly!
 	 *
+	 * TODO: Deprecate, not used
+	 *
 	 * @param array $args - callback args passed in from add_settings_field().
 	 *
 	 * @see WP_Auth0_Admin_Generic::init_option_section()
 	 * @see add_settings_field()
+	 *
+	 * @codeCoverageIgnore - Deprecated
 	 */
 	public function render_ip_ranges( $args = array() ) {
 		$this->render_textarea_field( $args['label_for'], $args['opt_name'] );

--- a/tests/testWPAuth0Options.php
+++ b/tests/testWPAuth0Options.php
@@ -28,7 +28,7 @@ class TestWPAuth0Options extends TestCase {
 	/**
 	 * Total number of options.
 	 */
-	const DEFAULT_OPTIONS_COUNT = 68;
+	const DEFAULT_OPTIONS_COUNT = 66;
 
 	/**
 	 * Test the basic options functionality.


### PR DESCRIPTION
### Changes

Remove the unused "IP Range" setting. This was once used for whitelisting IP addresses for wp-admin but the functionality has not been available for many versions. 

### Testing

Adjusted existing tests for removed options. 

### Checklist

* [x] All existing and new tests complete without errors
* [x] All code quality tools/guidelines in the [Contribution guide](CONTRIBUTION.md) have been run/followed
* [x] All active GitHub CI checks have passed
