### PR TITLE
Fix Migration Token Generation; Add JSON Content-Type header

### DIFF
--- a/lib/WP_Auth0_Routes.php
+++ b/lib/WP_Auth0_Routes.php
@@ -77,6 +77,7 @@ class WP_Auth0_Routes {
 			return false;
 		}
 
+		$json_header = true;
 		switch ( $page ) {
 			case 'oauth2-config':
 				$output = wp_json_encode( $this->oauth2_config() );
@@ -88,7 +89,8 @@ class WP_Auth0_Routes {
 				$output = wp_json_encode( $this->migration_ws_get_user() );
 				break;
 			case 'coo-fallback':
-				$output = $this->coo_fallback();
+				$json_header = false;
+				$output      = $this->coo_fallback();
 				break;
 			default:
 				return false;
@@ -98,8 +100,25 @@ class WP_Auth0_Routes {
 			return $output;
 		}
 
+		if ( $json_header ) {
+			add_filter( 'wp_headers', array( $this, 'add_json_header' ) );
+			$wp->send_headers();
+		}
+
 		echo $output;
 		exit;
+	}
+
+	/**
+	 * Use with the wp_headers filter to add a Content-Type header for JSON output.
+	 *
+	 * @param array $headers - Existing headers to modify.
+	 *
+	 * @return mixed
+	 */
+	public function add_json_header( array $headers ) {
+		$headers['Content-Type'] = 'application/json; charset=' . get_bloginfo( 'charset' );
+		return $headers;
 	}
 
 	protected function coo_fallback() {

--- a/lib/admin/WP_Auth0_Admin_Advanced.php
+++ b/lib/admin/WP_Auth0_Admin_Advanced.php
@@ -567,14 +567,14 @@ class WP_Auth0_Admin_Advanced extends WP_Auth0_Admin_Generic {
 	 * @return array
 	 */
 	public function migration_ws_validation( array $old_options, array $input ) {
-		$input['migration_ws'] = (int) ! empty( $input['migration_ws'] );
+		$input['migration_ws']    = (int) ! empty( $input['migration_ws'] );
+		$input['migration_token'] = $this->options->get( 'migration_token' );
 
 		// Migration endpoints or turned off, nothing to do.
 		if ( empty( $input['migration_ws'] ) ) {
 			return $input;
 		}
 
-		$input['migration_token']    = $this->options->get( 'migration_token' );
 		$input['migration_token_id'] = null;
 		$this->router->setup_rewrites();
 		flush_rewrite_rules();

--- a/lib/admin/WP_Auth0_Admin_Advanced.php
+++ b/lib/admin/WP_Auth0_Admin_Advanced.php
@@ -574,6 +574,7 @@ class WP_Auth0_Admin_Advanced extends WP_Auth0_Admin_Generic {
 			return $input;
 		}
 
+		$input['migration_token']    = $this->options->get( 'migration_token' );
 		$input['migration_token_id'] = null;
 		$this->router->setup_rewrites();
 		flush_rewrite_rules();
@@ -589,6 +590,7 @@ class WP_Auth0_Admin_Advanced extends WP_Auth0_Admin_Generic {
 		if ( ! empty( $input['client_secret_b64_encoded'] ) ) {
 			$secret = base64_decode( $input['client_secret'] );
 		}
+
 		try {
 			$token_decoded               = JWT::decode( $input['migration_token'], $secret, array( 'HS256' ) );
 			$input['migration_token_id'] = isset( $token_decoded->jti ) ? $token_decoded->jti : null;

--- a/tests/testOptionLoginRedirect.php
+++ b/tests/testOptionLoginRedirect.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Contains Class TestAdvancedOptionsValidation.
+ * Contains Class TestOptionLoginRedirect.
  *
  * @package WP-Auth0
  *
@@ -10,10 +10,10 @@
 use PHPUnit\Framework\TestCase;
 
 /**
- * Class TestAdvancedOptionsValidation.
+ * Class TestOptionLoginRedirect.
  * Tests that Advanced settings are validated properly.
  */
-class TestAdvancedOptionsValidation extends TestCase {
+class TestOptionLoginRedirect extends TestCase {
 
 	use setUpTestDb {
 		setUp as setUpDb;

--- a/tests/testOptionMigrationWs.php
+++ b/tests/testOptionMigrationWs.php
@@ -92,7 +92,7 @@ class TestOptionMigrationWs extends TestCase {
 	 */
 	public function testThatChangingMigrationToOnKeepsToken() {
 		self::$opts->set( 'migration_token', 'new_token' );
-		$input     = [
+		$input = [
 			'migration_ws'  => 1,
 			'client_secret' => '__test_client_secret__',
 		];
@@ -111,7 +111,7 @@ class TestOptionMigrationWs extends TestCase {
 		$client_secret   = '__test_client_secret__';
 		$migration_token = JWT::encode( [ 'jti' => '__test_token_id__' ], $client_secret );
 		self::$opts->set( 'migration_token', $migration_token );
-		$input     = [
+		$input = [
 			'migration_ws'  => 1,
 			'client_secret' => $client_secret,
 		];
@@ -129,7 +129,7 @@ class TestOptionMigrationWs extends TestCase {
 	public function testThatChangingMigrationToOnKeepsWithBase64JwtSetsId() {
 		$client_secret = '__test_client_secret__';
 		self::$opts->set( 'migration_token', JWT::encode( [ 'jti' => '__test_token_id__' ], $client_secret ) );
-		$input     = [
+		$input = [
 			'migration_ws'              => 1,
 			'client_secret'             => JWT::urlsafeB64Encode( $client_secret ),
 			'client_secret_b64_encoded' => 1,
@@ -144,7 +144,7 @@ class TestOptionMigrationWs extends TestCase {
 	 * Test that turning on migration endpoints without a stored token will generate one.
 	 */
 	public function testThatChangingMigrationToOnGeneratesNewToken() {
-		$input     = [ 'migration_ws' => 1 ];
+		$input = [ 'migration_ws' => 1 ];
 
 		$validated = self::$admin->migration_ws_validation( [], $input );
 
@@ -161,7 +161,7 @@ class TestOptionMigrationWs extends TestCase {
 	public function testThatMigrationTokenInConstantSettingIsValidated() {
 		define( 'AUTH0_ENV_MIGRATION_TOKEN', '__test_constant_setting__' );
 		self::$opts->set( 'migration_token', '__test_saved_setting__' );
-		$input     = [
+		$input = [
 			'migration_ws'  => 1,
 			'client_secret' => '__test_client_secret__',
 		];

--- a/tests/testOptionMigrationWs.php
+++ b/tests/testOptionMigrationWs.php
@@ -75,14 +75,16 @@ class TestOptionMigrationWs extends TestCase {
 	 * Test that turning migration endpoints off does not affect new input.
 	 */
 	public function testThatChangingMigrationToOffKeepsTokenData() {
-		self::$opts->set( 'migration_token', 'new_token' );
+		self::$opts->set( 'migration_token', 'existing_token' );
 		$input     = [
 			'migration_ws'       => 0,
-			'migration_token_id' => 'new_token_id',
+			'migration_token_id' => 'existing_token_id',
 		];
-		$old_input = [ 'migration_ws' => 1 ];
-		$validated = self::$admin->migration_ws_validation( $old_input, $input );
-		$this->assertEquals( $input, $validated );
+		$validated = self::$admin->migration_ws_validation( [], $input );
+
+		$this->assertEquals( $input['migration_ws'], $validated['migration_ws'] );
+		$this->assertEquals( $input['migration_token_id'], $validated['migration_token_id'] );
+		$this->assertEquals( 'existing_token', $validated['migration_token'] );
 	}
 
 	/**
@@ -94,9 +96,8 @@ class TestOptionMigrationWs extends TestCase {
 			'migration_ws'  => 1,
 			'client_secret' => '__test_client_secret__',
 		];
-		$old_input = [ 'migration_ws' => 0 ];
 
-		$validated = self::$admin->migration_ws_validation( $old_input, $input );
+		$validated = self::$admin->migration_ws_validation( [], $input );
 
 		$this->assertEquals( 'new_token', $validated['migration_token'] );
 		$this->assertNull( $validated['migration_token_id'] );
@@ -114,9 +115,8 @@ class TestOptionMigrationWs extends TestCase {
 			'migration_ws'  => 1,
 			'client_secret' => $client_secret,
 		];
-		$old_input = [ 'migration_ws' => 0 ];
 
-		$validated = self::$admin->migration_ws_validation( $old_input, $input );
+		$validated = self::$admin->migration_ws_validation( [], $input );
 
 		$this->assertEquals( $input['migration_ws'], $validated['migration_ws'] );
 		$this->assertEquals( $migration_token, $validated['migration_token'] );
@@ -134,9 +134,8 @@ class TestOptionMigrationWs extends TestCase {
 			'client_secret'             => JWT::urlsafeB64Encode( $client_secret ),
 			'client_secret_b64_encoded' => 1,
 		];
-		$old_input = [ 'migration_ws' => 0 ];
 
-		$validated = self::$admin->migration_ws_validation( $old_input, $input );
+		$validated = self::$admin->migration_ws_validation( [], $input );
 
 		$this->assertEquals( '__test_token_id__', $validated['migration_token_id'] );
 	}
@@ -146,9 +145,8 @@ class TestOptionMigrationWs extends TestCase {
 	 */
 	public function testThatChangingMigrationToOnGeneratesNewToken() {
 		$input     = [ 'migration_ws' => 1 ];
-		$old_input = [ 'migration_ws' => 0 ];
 
-		$validated = self::$admin->migration_ws_validation( $old_input, $input );
+		$validated = self::$admin->migration_ws_validation( [], $input );
 
 		$this->assertGreaterThan( 64, strlen( $validated['migration_token'] ) );
 		$this->assertNull( $validated['migration_token_id'] );
@@ -167,13 +165,12 @@ class TestOptionMigrationWs extends TestCase {
 			'migration_ws'  => 1,
 			'client_secret' => '__test_client_secret__',
 		];
-		$old_input = [ 'migration_ws' => 0 ];
 
 		$opts   = new WP_Auth0_Options();
 		$router = new WP_Auth0_Routes( $opts );
 		$admin  = new WP_Auth0_Admin_Advanced( $opts, $router );
 
-		$validated = $admin->migration_ws_validation( $old_input, $input );
+		$validated = $admin->migration_ws_validation( [], $input );
 
 		$this->assertNull( $validated['migration_token_id'] );
 		$this->assertEquals( $input['migration_ws'], $validated['migration_ws'] );


### PR DESCRIPTION
### Changes

- Add a check for existing token so it does not get regenerated when the endpoints are turned off, then on again (current behavior is to regenerate without warning, which could unintentionally cause login issues). 
- Add `Content-Type: application/json` header to endpoints that output JSON

**Note:** We added an internal task to add a control to regenerate this token in wp-admin. 

### Testing

- Adjusted existing tests to follow how this setting is handled
- Unable to add unit tests for header output (script `exit`s, making testing impossible)

### Checklist

* [x] All existing and new tests complete without errors
* [x] All code quality tools/guidelines in the [Contribution guide](CONTRIBUTION.md) have been run/followed
* [x] All active GitHub CI checks have passed
