### PR TITLE
Deprecations for ip_range setting

### DIFF
--- a/lib/WP_Auth0_Ip_Check.php
+++ b/lib/WP_Auth0_Ip_Check.php
@@ -205,12 +205,14 @@ class WP_Auth0_Ip_Check {
 		return $ip >= $from && $ip <= $to;
 	}
 
-	// phpcs:disable
+	/*
+	 * DEPRECATED
+	 */
 
 	/**
-	 * TODO: Deprecate, not used. Also remove related setting.
+	 * @deprecated - 3.9.0, unused
 	 *
-	 * @codeCoverageIgnore
+	 * @codeCoverageIgnore - Deprecated
 	 */
 	public function init() {
 		if ( ! WP_Auth0_Options::Instance()->get( 'ip_range_check' ) || is_admin() ) {
@@ -221,9 +223,9 @@ class WP_Auth0_Ip_Check {
 	}
 
 	/**
-	 * TODO: Deprecate, not used.
+	 * @deprecated - 3.9.0, unused
 	 *
-	 * @codeCoverageIgnore
+	 * @codeCoverageIgnore - Deprecated
 	 */
 	public function check_activate( $val, $key ) {
 		if ( 'active' !== $key ) {
@@ -234,9 +236,9 @@ class WP_Auth0_Ip_Check {
 	}
 
 	/**
-	 * TODO: Deprecate, not used.
+	 * @deprecated - 3.9.0, unused
 	 *
-	 * @codeCoverageIgnore
+	 * @codeCoverageIgnore - Deprecated
 	 */
 	private function validate_ip() {
 		$ranges = $this->get_ranges();
@@ -253,9 +255,9 @@ class WP_Auth0_Ip_Check {
 	}
 
 	/**
-	 * TODO: Deprecate, not used. Also remove related setting.
+	 * @deprecated - 3.9.0, unused
 	 *
-	 * @codeCoverageIgnore
+	 * @codeCoverageIgnore - Deprecated
 	 */
 	private function get_ranges() {
 		$data = WP_Auth0_Options::Instance()->get( 'ip_ranges' );
@@ -282,6 +284,4 @@ class WP_Auth0_Ip_Check {
 
 		return $ranges;
 	}
-
-	// phpcs:enable
 }

--- a/lib/admin/WP_Auth0_Admin_Advanced.php
+++ b/lib/admin/WP_Auth0_Admin_Advanced.php
@@ -426,44 +426,6 @@ class WP_Auth0_Admin_Advanced extends WP_Auth0_Admin_Generic {
 	}
 
 	/**
-	 * Render form field and description for the `ip_range_check` option.
-	 * IMPORTANT: Internal callback use only, do not call this function directly!
-	 *
-	 * TODO: Deprecate, not used
-	 *
-	 * @param array $args - callback args passed in from add_settings_field().
-	 *
-	 * @see WP_Auth0_Admin_Generic::init_option_section()
-	 * @see add_settings_field()
-	 *
-	 * @codeCoverageIgnore - Deprecated
-	 */
-	public function render_ip_range_check( $args = array() ) {
-		$this->render_switch( $args['label_for'], $args['opt_name'], 'wpa0_ip_ranges' );
-	}
-
-	/**
-	 * Render form field and description for the `ip_ranges` option.
-	 * IMPORTANT: Internal callback use only, do not call this function directly!
-	 *
-	 * TODO: Deprecate, not used
-	 *
-	 * @param array $args - callback args passed in from add_settings_field().
-	 *
-	 * @see WP_Auth0_Admin_Generic::init_option_section()
-	 * @see add_settings_field()
-	 *
-	 * @codeCoverageIgnore - Deprecated
-	 */
-	public function render_ip_ranges( $args = array() ) {
-		$this->render_textarea_field( $args['label_for'], $args['opt_name'] );
-		$this->render_field_description(
-			__( 'Only one range per line! Range format should be as follows (spaces ignored): ', 'wp-auth0' ) .
-			__( '<br><code>xx.xx.xx.xx - yy.yy.yy.yy</code>', 'wp-auth0' )
-		);
-	}
-
-	/**
 	 * Render form field and description for the `valid_proxy_ip` option.
 	 * IMPORTANT: Internal callback use only, do not call this function directly!
 	 *
@@ -701,6 +663,44 @@ class WP_Auth0_Admin_Advanced extends WP_Auth0_Admin_Generic {
 	/*
 	 * DEPRECATED
 	 */
+
+	/**
+	 * Render form field and description for the `ip_range_check` option.
+	 * IMPORTANT: Internal callback use only, do not call this function directly!
+	 *
+	 * @deprecated - 3.9.0, unused
+	 *
+	 * @param array $args - callback args passed in from add_settings_field().
+	 *
+	 * @see WP_Auth0_Admin_Generic::init_option_section()
+	 * @see add_settings_field()
+	 *
+	 * @codeCoverageIgnore - Deprecated
+	 */
+	public function render_ip_range_check( $args = array() ) {
+		$this->render_switch( $args['label_for'], $args['opt_name'], 'wpa0_ip_ranges' );
+	}
+
+	/**
+	 * Render form field and description for the `ip_ranges` option.
+	 * IMPORTANT: Internal callback use only, do not call this function directly!
+	 *
+	 * @deprecated - 3.9.0, unused
+	 *
+	 * @param array $args - callback args passed in from add_settings_field().
+	 *
+	 * @see WP_Auth0_Admin_Generic::init_option_section()
+	 * @see add_settings_field()
+	 *
+	 * @codeCoverageIgnore - Deprecated
+	 */
+	public function render_ip_ranges( $args = array() ) {
+		$this->render_textarea_field( $args['label_for'], $args['opt_name'] );
+		$this->render_field_description(
+			__( 'Only one range per line! Range format should be as follows (spaces ignored): ', 'wp-auth0' ) .
+			__( '<br><code>xx.xx.xx.xx - yy.yy.yy.yy</code>', 'wp-auth0' )
+		);
+	}
 
 	/**
 	 * Render form field and description for the `social_twitter_key` option.


### PR DESCRIPTION
### Changes

Docblock deprecation notices for:

- `\WP_Auth0_Ip_Check::init`
- `\WP_Auth0_Ip_Check::check_activate`
- `\WP_Auth0_Ip_Check::validate_ip`
- `\WP_Auth0_Ip_Check::get_ranges`
- `\WP_Auth0_Admin_Advanced::render_ip_range_check`
- `\WP_Auth0_Admin_Advanced::render_ip_ranges`