### PR TITLE
Autoload traits and suppress log output in tests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,15 +30,18 @@
     },
     "minimum-stability": "stable",
     "scripts": {
-        "compat": "vendor/bin/phpcs --standard=phpcs-compat-ruleset.xml .",
+        "compat": "\"vendor/bin/phpcs\" --standard=phpcs-compat-ruleset.xml .",
         "phpcs": "\"vendor/bin/phpcs\"",
-        "phpcs-tests": "./vendor/bin/phpcs --standard=phpcs-test-ruleset.xml -s ./tests/",
+        "phpcs-tests": "\"vendor/bin/phpcs\" --standard=phpcs-test-ruleset.xml -s ./tests/",
         "phpcbf": "\"vendor/bin/phpcbf\"",
-        "phpcbf-tests": "./vendor/bin/phpcbf --standard=phpcs-test-ruleset.xml -s ./tests/",
-        "sniffs": "vendor/bin/phpcs --standard=phpcs-ruleset.xml -e",
+        "phpcbf-tests": "\"vendor/bin/phpcbf\" --standard=phpcs-test-ruleset.xml -s ./tests/",
+        "sniffs": "\"vendor/bin/phpcs\" --standard=phpcs-ruleset.xml -e",
         "test": "\"vendor/bin/phpunit\" --coverage-text",
         "test-group": "\"vendor/bin/phpunit\" --coverage-text --group",
-        "test-ci": "vendor/bin/phpunit --debug --coverage-clover=coverage.xml",
+        "test-ci": "\"vendor/bin/phpunit\" --debug --coverage-clover=coverage.xml",
         "pre-commit": [ "@compat", "@phpcbf", "@phpcbf-tests", "@phpcs-tests", "@test" ]
+    },
+    "autoload": {
+        "classmap": ["tests/classes/", "tests/traits/"]
     }
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -5,6 +5,7 @@
  * @package WP-Auth0
  */
 
+ini_set( 'error_log', '/dev/null' );
 echo 'PHP version: ' . phpversion() . "\n";
 
 $_tests_dir = getenv( 'WP_TESTS_DIR' );
@@ -36,15 +37,4 @@ if ( ! file_exists( $_tests_dir . '/includes/bootstrap.php' ) ) {
 }
 
 require $_tests_dir . '/includes/bootstrap.php';
-
 require dirname( __FILE__ ) . '/../vendor/autoload.php';
-
-// TODO: Move these to an autoloader.
-require dirname( __FILE__ ) . '/classes/Test_WP_Auth0_Api_Abstract.php';
-require dirname( __FILE__ ) . '/classes/WP_Auth0_Test_Case.php';
-require dirname( __FILE__ ) . '/traits/ajaxHelpers.php';
-require dirname( __FILE__ ) . '/traits/domDocumentHelpers.php';
-require dirname( __FILE__ ) . '/traits/hookHelpers.php';
-require dirname( __FILE__ ) . '/traits/httpHelpers.php';
-require dirname( __FILE__ ) . '/traits/redirectHelpers.php';
-require dirname( __FILE__ ) . '/traits/usersHelper.php';

--- a/tests/classes/WP_Auth0_Test_Case.php
+++ b/tests/classes/WP_Auth0_Test_Case.php
@@ -10,7 +10,7 @@
 /**
  * Class WP_Auth0_Test_Case
  */
-class WP_Auth0_Test_Case extends \PHPUnit\Framework\TestCase {
+abstract class WP_Auth0_Test_Case extends \PHPUnit\Framework\TestCase {
 
 	const TEST_DOMAIN = 'test.domain.com';
 

--- a/tests/testConstantSettings.php
+++ b/tests/testConstantSettings.php
@@ -13,7 +13,7 @@
  */
 class TestConstantSettings extends WP_Auth0_Test_Case {
 
-	use domDocumentHelpers;
+	use DomDocumentHelpers;
 
 	/**
 	 * Default constant setting prefix.

--- a/tests/testCustomDomains.php
+++ b/tests/testCustomDomains.php
@@ -12,7 +12,7 @@
  */
 class TestCustomDomains extends WP_Auth0_Test_Case {
 
-	use domDocumentHelpers;
+	use DomDocumentHelpers;
 
 	/**
 	 * Test the input HTML for the custom domain setting.

--- a/tests/testRequiredEmail.php
+++ b/tests/testRequiredEmail.php
@@ -13,7 +13,7 @@
  */
 class TestRequiredEmail extends WP_Auth0_Test_Case {
 
-	use domDocumentHelpers;
+	use DomDocumentHelpers;
 
 	/**
 	 * Instance of WP_Auth0_Admin_Advanced.


### PR DESCRIPTION
### Changes

Test suite changes only:

- Autoload traits and classes for test suite
- Pipe `error_log` output to `/dev/null` instead of `STDOUT`
- Minor composer script changes

### Testing

No changes to test coverage. 

