### PR TITLE
Replace Rules-based settings with prompt to the dashboard [SDK-474]

### DIFF
--- a/lib/WP_Auth0_Api_Client.php
+++ b/lib/WP_Auth0_Api_Client.php
@@ -754,6 +754,11 @@ class WP_Auth0_Api_Client {
 		return $processed;
 	}
 
+	/**
+	 * TODO: Deprecate
+	 *
+	 * @codeCoverageIgnore - To be deprecated
+	 */
 	public static function update_guardian( $domain, $app_token, $factor, $enabled ) {
 		$endpoint = "https://$domain/api/v2/guardian/factors/$factor";
 

--- a/lib/WP_Auth0_Api_Operations.php
+++ b/lib/WP_Auth0_Api_Operations.php
@@ -89,8 +89,11 @@ class WP_Auth0_Api_Operations {
 		return $response->id;
 	}
 
-	// $input['geo_rule'] = ( isset( $input['geo_rule'] ) ? $input['geo_rule'] : 0 );
-	// $enable = ($old_options['geo_rule'] == null && 1 == $input['geo_rule'])
+	/**
+	 * TODO: Deprecate
+	 *
+	 * @codeCoverageIgnore - To be deprecated
+	 */
 	public function toggle_rule( $app_token, $rule_id, $rule_name, $rule_script ) {
 
 		$domain = $this->a0_options->get( 'domain' );

--- a/lib/WP_Auth0_Options.php
+++ b/lib/WP_Auth0_Options.php
@@ -209,11 +209,6 @@ class WP_Auth0_Options extends WP_Auth0_Options_Generic {
 			'password_policy'           => 'fair',
 			'sso'                       => false,
 			'singlelogout'              => false,
-			'mfa'                       => null,
-			'fullcontact'               => null,
-			'fullcontact_apikey'        => null,
-			'geo_rule'                  => null,
-			'income_rule'               => null,
 			'override_wp_avatars'       => true,
 
 			// Appearance
@@ -239,7 +234,6 @@ class WP_Auth0_Options extends WP_Auth0_Options_Generic {
 			'cdn_url_legacy'            => 'https://cdn.auth0.com/js/lock-9.2.min.js',
 			'passwordless_cdn_url'      => WPA0_LOCK_CDN_URL,
 			'lock_connections'          => '',
-			'link_auth0_users'          => null,
 			'auto_provisioning'         => false,
 			'migration_ws'              => false,
 			'migration_token'           => null,

--- a/lib/WP_Auth0_RulesLib.php
+++ b/lib/WP_Auth0_RulesLib.php
@@ -1,7 +1,16 @@
 <?php
-
+/**
+ * TODO: Deprecate
+ *
+ * @codeCoverageIgnore - Deprecated.
+ */
 class WP_Auth0_RulesLib {
 
+	/**
+	 * TODO: Deprecate
+	 *
+	 * @codeCoverageIgnore - Deprecated.
+	 */
 	public static $link_accounts = array(
 
 		'name'   => 'Account-Linking-Do-Not-Rename',
@@ -70,6 +79,11 @@ function (user, context, callback) {
 }",
 	);
 
+	/**
+	 * TODO: Deprecate
+	 *
+	 * @codeCoverageIgnore - Deprecated.
+	 */
 	public static $guardian_MFA = array(
 		'name'   => 'Multifactor-Guardian-Do-Not-Rename',
 		'script' => "
@@ -89,6 +103,11 @@ function (user, context, callback) {
 }",
 	);
 
+	/**
+	 * TODO: Deprecate
+	 *
+	 * @codeCoverageIgnore - Deprecated.
+	 */
 	public static $geo = array(
 		'name'   => 'Store-Geo-Location-Do-Not-Rename',
 		'script' => "
@@ -112,6 +131,11 @@ function (user, context, callback) {
 }",
 	);
 
+	/**
+	 * TODO: Deprecate
+	 *
+	 * @codeCoverageIgnore - Deprecated.
+	 */
 	public static $fullcontact = array(
 		'name'   => 'Enrich-profile-with-FullContact-Do-Not-Rename',
 		'script' => "
@@ -159,6 +183,11 @@ function (user, context, callback) {
 }",
 	);
 
+	/**
+	 * TODO: Deprecate
+	 *
+	 * @codeCoverageIgnore - Deprecated.
+	 */
 	public static $income = array(
 		'name'   => 'Enrich-profile-with-Zipcode-Income-Do-Not-Rename',
 		'script' => "

--- a/lib/admin/WP_Auth0_Admin_Advanced.php
+++ b/lib/admin/WP_Auth0_Admin_Advanced.php
@@ -80,13 +80,20 @@ class WP_Auth0_Admin_Advanced extends WP_Auth0_Admin_Generic {
 				'id'       => 'wpa0_cdn_url',
 				'function' => 'render_cdn_url',
 			),
-			array(
+		);
+
+		// TODO: Remove this once feature has been removed
+		if ( $this->options->get( 'link_auth0_users' ) ) {
+			$options[] = array(
 				'name'     => __( 'Link Users with Same Email', 'wp-auth0' ),
 				'opt'      => 'link_auth0_users',
 				'id'       => 'wpa0_link_auth0_users',
 				'function' => 'render_link_auth0_users',
-			),
-			array(
+			);
+		}
+
+		$options = $options + array(
+			( count( $options ) ) => array(
 				'name'     => __( 'Auto Provisioning', 'wp-auth0' ),
 				'opt'      => 'auto_provisioning',
 				'id'       => 'wpa0_auto_provisioning',
@@ -294,16 +301,20 @@ class WP_Auth0_Admin_Advanced extends WP_Auth0_Admin_Generic {
 	 * Render form field and description for the `link_auth0_users` option.
 	 * IMPORTANT: Internal callback use only, do not call this function directly!
 	 *
+	 * TODO: Deprecate
+	 *
 	 * @param array $args - callback args passed in from add_settings_field().
 	 *
 	 * @see WP_Auth0_Admin_Generic::init_option_section()
 	 * @see add_settings_field()
+	 *
+	 * @codeCoverageIgnore - To be deprecated
 	 */
 	public function render_link_auth0_users( $args = array() ) {
-		$this->render_switch( $args['label_for'], $args['opt_name'] );
 		$this->render_field_description(
-			__( 'Link accounts with the same verified e-mail address. ', 'wp-auth0' ) .
-			__( 'See the "Require Verified Email" setting above for more information on email verification', 'wp-auth0' )
+			__( 'This feature may currently be active. ', 'wp-auth0' ) .
+			__( 'Manage it with the "Account-Linking-Do-Not-Rename" Rule in the ', 'wp-auth0' ) .
+			$this->get_dashboard_link( 'rules' )
 		);
 	}
 
@@ -601,6 +612,11 @@ class WP_Auth0_Admin_Advanced extends WP_Auth0_Admin_Generic {
 		return $input;
 	}
 
+	/**
+	 * TODO: Deprecate
+	 *
+	 * @codeCoverageIgnore - To be deprecated
+	 */
 	public function link_accounts_validation( $old_options, $input ) {
 		$link_script = WP_Auth0_RulesLib::$link_accounts['script'];
 		$link_script = str_replace( 'REPLACE_WITH_YOUR_CLIENT_ID', $input['client_id'], $link_script );

--- a/lib/admin/WP_Auth0_Admin_Features.php
+++ b/lib/admin/WP_Auth0_Admin_Features.php
@@ -265,7 +265,7 @@ class WP_Auth0_Admin_Features extends WP_Auth0_Admin_Generic {
 	 */
 	public function render_mfa( $args = array() ) {
 		$this->render_field_description(
-			__( 'MFA is a method of verifying identity by requiring more than 1 piece of identifying information. ', 'wp-auth0' ) .
+			__( 'MFA is a method to verify identity by checking a second factor in addition to the password. ', 'wp-auth0' ) .
 			__( 'This provides an additional layer of security, decreasing the likelihood of unauthorized access. ', 'wp-auth0' ) .
 			__( 'To configure MFA for this site, please see this ', 'wp-auth0' ) .
 			$this->get_docs_link( 'multifactor-authentication', __( 'help page on MFA', 'wp-auth0' ) )

--- a/lib/admin/WP_Auth0_Admin_Features.php
+++ b/lib/admin/WP_Auth0_Admin_Features.php
@@ -79,37 +79,45 @@ class WP_Auth0_Admin_Features extends WP_Auth0_Admin_Generic {
 				'id'       => 'wpa0_mfa',
 				'function' => 'render_mfa',
 			),
-			array(
+		);
+
+		// TODO: Remove this once feature has been removed
+		if ( $this->options->get( 'fullcontact' ) ) {
+			$options[] = array(
 				'name'     => __( 'FullContact Integration', 'wp-auth0' ),
 				'opt'      => 'fullcontact',
 				'id'       => 'wpa0_fullcontact',
 				'function' => 'render_fullcontact',
-			),
-			array(
-				'name'     => __( 'FullContact API Key', 'wp-auth0' ),
-				'opt'      => 'fullcontact_apikey',
-				'id'       => 'wpa0_fullcontact_key',
-				'function' => 'render_fullcontact_apikey',
-			),
-			array(
+			);
+		}
+
+		// TODO: Remove this once feature has been removed
+		if ( $this->options->get( 'geo_rule' ) ) {
+			$options[] = array(
 				'name'     => __( 'Store Geolocation', 'wp-auth0' ),
 				'opt'      => 'geo_rule',
 				'id'       => 'wpa0_geo',
 				'function' => 'render_geo',
-			),
-			array(
+			);
+		}
+
+		// TODO: Remove this once feature has been removed
+		if ( $this->options->get( 'income_rule' ) ) {
+			$options[] = array(
 				'name'     => __( 'Store Zipcode Income', 'wp-auth0' ),
 				'opt'      => 'income_rule',
 				'id'       => 'wpa0_income',
 				'function' => 'render_income',
-			),
-			array(
-				'name'     => __( 'Override WordPress Avatars', 'wp-auth0' ),
-				'opt'      => 'override_wp_avatars',
-				'id'       => 'wpa0_override_wp_avatars',
-				'function' => 'render_override_wp_avatars',
-			),
+			);
+		}
+
+		$options[] = array(
+			'name'     => __( 'Override WordPress Avatars', 'wp-auth0' ),
+			'opt'      => 'override_wp_avatars',
+			'id'       => 'wpa0_override_wp_avatars',
+			'function' => 'render_override_wp_avatars',
 		);
+
 		$this->init_option_section( '', 'features', $options );
 	}
 
@@ -256,36 +264,41 @@ class WP_Auth0_Admin_Features extends WP_Auth0_Admin_Generic {
 	 * @see add_settings_field()
 	 */
 	public function render_mfa( $args = array() ) {
-		$this->render_switch( $args['label_for'], $args['opt_name'] );
 		$this->render_field_description(
-			__( 'Mark this if you want to enable multifactor authentication with Auth0 Guardian. ', 'wp-auth0' ) .
-			sprintf(
-				__( 'You can enable other MFA providers in the %s. ', 'wp-auth0' ),
-				$this->get_dashboard_link( 'multifactor' )
-			) . __( 'For more information, see our ', 'wp-auth0' ) .
+			__( 'MFA is a method of verifying identity by requiring more than 1 piece of identifying information. ', 'wp-auth0' ) .
+			__( 'This provides an additional layer of security, decreasing the likelihood of unauthorized access. ', 'wp-auth0' ) .
+			__( 'To configure MFA for this site, please see this ', 'wp-auth0' ) .
 			$this->get_docs_link( 'multifactor-authentication', __( 'help page on MFA', 'wp-auth0' ) )
 		);
+
+		// TODO: Remove this check once feature has been removed
+		if ( $this->options->get( 'mfa' ) ) {
+			$this->render_field_description(
+				__( 'This feature may currently be active. ', 'wp-auth0' ) .
+				__( 'Manage it with the "Multifactor-Guardian-Do-Not-Rename" Rule in the ', 'wp-auth0' ) .
+				$this->get_dashboard_link( 'rules' )
+			);
+		}
 	}
 
 	/**
 	 * Render form field and description for the `fullcontact` option.
 	 * IMPORTANT: Internal callback use only, do not call this function directly!
 	 *
+	 * TODO: Deprecate
+	 *
 	 * @param array $args - callback args passed in from add_settings_field().
 	 *
 	 * @see WP_Auth0_Admin_Generic::init_option_section()
 	 * @see add_settings_field()
+	 *
+	 * @codeCoverageIgnore - To be deprecated
 	 */
 	public function render_fullcontact( $args = array() ) {
-		$this->render_switch( $args['label_for'], $args['opt_name'], 'wpa0_fullcontact_key' );
 		$this->render_field_description(
-			__( 'Enriches your user profiles with the data provided by FullContact. ', 'wp-auth0' ) .
-			__( 'A valid FullContact API key is required for this to work. ', 'wp-auth0' ) .
-			__( 'For more details, see our ', 'wp-auth0' ) .
-			$this->get_docs_link(
-				'monitoring/track-signups-enrich-user-profile-generate-leads',
-				__( 'help page on tracking signups', 'wp-auth0' )
-			)
+			__( 'This feature may currently be active. ', 'wp-auth0' ) .
+			__( 'Manage it with the "Enrich-profile-with-FullContact-Do-Not-Rename" Rule in the ', 'wp-auth0' ) .
+			$this->get_dashboard_link( 'rules' )
 		);
 	}
 
@@ -293,10 +306,14 @@ class WP_Auth0_Admin_Features extends WP_Auth0_Admin_Generic {
 	 * Render form field and description for the `fullcontact_apikey` option.
 	 * IMPORTANT: Internal callback use only, do not call this function directly!
 	 *
+	 * TODO: Deprecate
+	 *
 	 * @param array $args - callback args passed in from add_settings_field().
 	 *
 	 * @see WP_Auth0_Admin_Generic::init_option_section()
 	 * @see add_settings_field()
+	 *
+	 * @codeCoverageIgnore - To be deprecated
 	 */
 	public function render_fullcontact_apikey( $args = array() ) {
 		$this->render_text_field( $args['label_for'], $args['opt_name'] );
@@ -306,15 +323,20 @@ class WP_Auth0_Admin_Features extends WP_Auth0_Admin_Generic {
 	 * Render form field and description for the `geo_rule` option.
 	 * IMPORTANT: Internal callback use only, do not call this function directly!
 	 *
+	 * TODO: Deprecate
+	 *
 	 * @param array $args - callback args passed in from add_settings_field().
 	 *
 	 * @see WP_Auth0_Admin_Generic::init_option_section()
 	 * @see add_settings_field()
+	 *
+	 * @codeCoverageIgnore - To be deprecated
 	 */
 	public function render_geo( $args = array() ) {
-		$this->render_switch( $args['label_for'], $args['opt_name'] );
 		$this->render_field_description(
-			__( 'Mark this if you want to store geolocation data based on the IP of the user logging in', 'wp-auth0' )
+			__( 'This feature may currently be active. ', 'wp-auth0' ) .
+			__( 'Manage it with the "Store-Geo-Location-Do-Not-Rename" Rule in the ', 'wp-auth0' ) .
+			$this->get_dashboard_link( 'rules' )
 		);
 	}
 
@@ -322,15 +344,20 @@ class WP_Auth0_Admin_Features extends WP_Auth0_Admin_Generic {
 	 * Render form field and description for the `income_rule` option.
 	 * IMPORTANT: Internal callback use only, do not call this function directly!
 	 *
+	 * TODO: Deprecate
+	 *
 	 * @param array $args - callback args passed in from add_settings_field().
 	 *
 	 * @see WP_Auth0_Admin_Generic::init_option_section()
 	 * @see add_settings_field()
+	 *
+	 * @codeCoverageIgnore - To be deprecated
 	 */
 	public function render_income( $args = array() ) {
-		$this->render_switch( $args['label_for'], $args['opt_name'] );
 		$this->render_field_description(
-			__( 'Mark this if you want to store projected income data based on the zipcode of the user\'s IP', 'wp-auth0' )
+			__( 'This feature may currently be active. ', 'wp-auth0' ) .
+			__( 'Manage it with the "Enrich-profile-with-Zipcode-Income-Do-Not-Rename" Rule in the ', 'wp-auth0' ) .
+			$this->get_dashboard_link( 'rules' )
 		);
 	}
 
@@ -448,6 +475,11 @@ class WP_Auth0_Admin_Features extends WP_Auth0_Admin_Generic {
 		return $input;
 	}
 
+	/**
+	 * TODO: Deprecate
+	 *
+	 * @codeCoverageIgnore - To be deprecated
+	 */
 	public function fullcontact_validation( $old_options, $input ) {
 		$fullcontact_script = WP_Auth0_RulesLib::$fullcontact['script'];
 		$fullcontact_script = str_replace( 'REPLACE_WITH_YOUR_CLIENT_ID', $input['client_id'], $fullcontact_script );
@@ -455,6 +487,11 @@ class WP_Auth0_Admin_Features extends WP_Auth0_Admin_Generic {
 		return $this->rule_validation( $old_options, $input, 'fullcontact', WP_Auth0_RulesLib::$fullcontact['name'] . '-' . get_auth0_curatedBlogName(), $fullcontact_script );
 	}
 
+	/**
+	 * TODO: Deprecate
+	 *
+	 * @codeCoverageIgnore - To be deprecated
+	 */
 	public function mfa_validation( $old_options, $input ) {
 
 		if ( ! isset( $input['mfa'] ) ) {
@@ -473,12 +510,22 @@ class WP_Auth0_Admin_Features extends WP_Auth0_Admin_Generic {
 		return $this->rule_validation( $old_options, $input, 'mfa', WP_Auth0_RulesLib::$guardian_MFA['name'] . '-' . get_auth0_curatedBlogName(), $mfa_script );
 	}
 
+	/**
+	 * TODO: Deprecate
+	 *
+	 * @codeCoverageIgnore - To be deprecated
+	 */
 	public function georule_validation( $old_options, $input ) {
 		$geo_script = WP_Auth0_RulesLib::$geo['script'];
 		$geo_script = str_replace( 'REPLACE_WITH_YOUR_CLIENT_ID', $input['client_id'], $geo_script );
 		return $this->rule_validation( $old_options, $input, 'geo_rule', WP_Auth0_RulesLib::$geo['name'] . '-' . get_auth0_curatedBlogName(), $geo_script );
 	}
 
+	/**
+	 * TODO: Deprecate
+	 *
+	 * @codeCoverageIgnore - To be deprecated
+	 */
 	public function incomerule_validation( $old_options, $input ) {
 		$income_script = WP_Auth0_RulesLib::$income['script'];
 		$income_script = str_replace( 'REPLACE_WITH_YOUR_CLIENT_ID', $input['client_id'], $income_script );

--- a/lib/admin/WP_Auth0_Admin_Generic.php
+++ b/lib/admin/WP_Auth0_Admin_Generic.php
@@ -97,6 +97,11 @@ class WP_Auth0_Admin_Generic {
 		);
 	}
 
+	/**
+	 * TODO: Deprecate
+	 *
+	 * @codeCoverageIgnore - To be deprecated
+	 */
 	protected function rule_validation( $old_options, $input, $key, $rule_name, $rule_script ) {
 		$input[ $key ] = ( isset( $input[ $key ] ) ? $input[ $key ] : null );
 

--- a/tests/testWPAuth0Options.php
+++ b/tests/testWPAuth0Options.php
@@ -20,7 +20,7 @@ class TestWPAuth0Options extends WP_Auth0_Test_Case {
 	/**
 	 * Total number of options.
 	 */
-	const DEFAULT_OPTIONS_COUNT = 66;
+	const DEFAULT_OPTIONS_COUNT = 60;
 
 	/**
 	 * Test the basic options functionality.


### PR DESCRIPTION
### Changes

There are currently several settings that attempt to create/activate/deactivate Rules in the Auth0 dashboard:

- Features > Multifactor Authentication Multifactor-Guardian-Do-Not-Rename
- Features > Fullcontact integration Enrich-profile-with-FullContact-Do-Not-Rename
- Features > Store Geolocation Store-Geo-Location-Do-Not-Rename
- Features > Store Zipcode Income Enrich-profile-with-Zipcode-Income-Do-Not-Rename
- Advanced > Link Users with Same Email Account-Linking-Do-Not-Rename

These require a valid API token or a client credentials grant (not implemented for these settings currently) and often fail because the Auth0 state is different than the WP admin one. It also makes changes for the whole tenant rather than just the WP site, which could cause issues.

This PR removes this settings for sites where the above features is currently turned off. If the feature is marked as on, there is a prompt added to manage it in the dashboard. 