### PR TITLE
Do not update Auth0 Application when SSO is turned on

### DIFF
--- a/lib/WP_Auth0_Api_Client.php
+++ b/lib/WP_Auth0_Api_Client.php
@@ -303,6 +303,7 @@ class WP_Auth0_Api_Client {
 			'name'                => $name,
 			'app_type'            => 'regular_web',
 
+			// Callback URLs for Auth Code and Hybrid/Implicit
 			'callbacks'           => array(
 				$options->get_wp_auth0_url(),
 			),
@@ -320,10 +321,14 @@ class WP_Auth0_Api_Client {
 				wp_login_url(),
 			),
 
+			// Advanced > Grant Types
 			'grant_types'         => self::get_client_grant_types(),
 			'jwt_configuration'   => array(
 				'alg' => self::DEFAULT_CLIENT_ALG,
 			),
+
+			// "Use Auth0 to do Single Sign On"
+			'sso'                 => true,
 		);
 
 		$response = wp_remote_post(

--- a/lib/WP_Auth0_Api_Client.php
+++ b/lib/WP_Auth0_Api_Client.php
@@ -323,6 +323,8 @@ class WP_Auth0_Api_Client {
 
 			// Advanced > Grant Types
 			'grant_types'         => self::get_client_grant_types(),
+
+			// Advanced > OAuth > JsonWebToken Signature Algorithm
 			'jwt_configuration'   => array(
 				'alg' => self::DEFAULT_CLIENT_ALG,
 			),

--- a/lib/WP_Auth0_Options.php
+++ b/lib/WP_Auth0_Options.php
@@ -207,9 +207,9 @@ class WP_Auth0_Options extends WP_Auth0_Options_Generic {
 
 			// Features
 			'password_policy'           => 'fair',
-			'sso'                       => false,
-			'singlelogout'              => false,
-			'override_wp_avatars'       => true,
+			'sso'                       => 0,
+			'singlelogout'              => 0,
+			'override_wp_avatars'       => 1,
 
 			// Appearance
 			'icon_url'                  => '',

--- a/lib/admin/WP_Auth0_Admin_Advanced.php
+++ b/lib/admin/WP_Auth0_Admin_Advanced.php
@@ -12,7 +12,6 @@ class WP_Auth0_Admin_Advanced extends WP_Auth0_Admin_Generic {
 	protected $actions_middlewares = array(
 		'basic_validation',
 		'migration_ws_validation',
-		'link_accounts_validation',
 		'loginredirection_validation',
 	);
 

--- a/lib/admin/WP_Auth0_Admin_Features.php
+++ b/lib/admin/WP_Auth0_Admin_Features.php
@@ -11,12 +11,7 @@ class WP_Auth0_Admin_Features extends WP_Auth0_Admin_Generic {
 
 	protected $actions_middlewares = array(
 		'basic_validation',
-		'georule_validation',
-		'sso_validation',
 		'security_validation',
-		'incomerule_validation',
-		'fullcontact_validation',
-		'mfa_validation',
 	);
 
 	/**
@@ -378,9 +373,11 @@ class WP_Auth0_Admin_Features extends WP_Auth0_Admin_Generic {
 	}
 
 	public function basic_validation( $old_options, $input ) {
-		// SLO will be turned off in WP_Auth0_Admin_Features::sso_validation() if SSO is not on.
-		$input['singlelogout']        = ( isset( $input['singlelogout'] ) ? $input['singlelogout'] : 0 );
-		$input['override_wp_avatars'] = ( isset( $input['override_wp_avatars'] ) ? $input['override_wp_avatars'] : 0 );
+		$input['sso'] = ! empty( $input['sso'] ) ? 1 : 0;
+
+		// Turn SLO off if SSO is off.
+		$input['singlelogout']        = ( ! empty( $input['singlelogout'] ) && $input['sso'] ) ? 1 : 0;
+		$input['override_wp_avatars'] = ! empty( $input['override_wp_avatars'] ) ? 1 : 0;
 
 		return $input;
 	}
@@ -388,11 +385,16 @@ class WP_Auth0_Admin_Features extends WP_Auth0_Admin_Generic {
 	/**
 	 * Update the Auth0 Application if SSO is turned on and disable SLO if it is turned off.
 	 *
+	 * TODO: Deprecate
+	 *
 	 * @param array $old_options - option values before saving.
 	 * @param array $input - new option values being saved.
 	 *
 	 * @return array
+	 *
+	 * @codeCoverageIgnore - To be deprecated
 	 */
+
 	public function sso_validation( $old_options, $input ) {
 		$input['sso'] = ( isset( $input['sso'] ) ? $input['sso'] : 0 );
 		$is_sso       = ! empty( $input['sso'] );

--- a/lib/admin/WP_Auth0_Admin_Features.php
+++ b/lib/admin/WP_Auth0_Admin_Features.php
@@ -373,11 +373,12 @@ class WP_Auth0_Admin_Features extends WP_Auth0_Admin_Generic {
 	}
 
 	public function basic_validation( $old_options, $input ) {
-		$input['sso'] = ! empty( $input['sso'] ) ? 1 : 0;
+		$input['sso'] = empty( $input['sso'] ) ? 0 : 1;
 
 		// Turn SLO off if SSO is off.
-		$input['singlelogout']        = ! empty( $input['singlelogout'] ) && $input['sso'] ? 1 : 0;
-		$input['override_wp_avatars'] = ! empty( $input['override_wp_avatars'] ) ? 1 : 0;
+		$input['singlelogout'] = empty( $input['singlelogout'] ) || empty( $input['sso'] ) ? 0 : 1;
+
+		$input['override_wp_avatars'] = empty( $input['override_wp_avatars'] ) ? 0 : 1;
 
 		return $input;
 	}

--- a/lib/admin/WP_Auth0_Admin_Features.php
+++ b/lib/admin/WP_Auth0_Admin_Features.php
@@ -376,7 +376,7 @@ class WP_Auth0_Admin_Features extends WP_Auth0_Admin_Generic {
 		$input['sso'] = ! empty( $input['sso'] ) ? 1 : 0;
 
 		// Turn SLO off if SSO is off.
-		$input['singlelogout']        = ( ! empty( $input['singlelogout'] ) && $input['sso'] ) ? 1 : 0;
+		$input['singlelogout']        = ! empty( $input['singlelogout'] ) && $input['sso'] ? 1 : 0;
 		$input['override_wp_avatars'] = ! empty( $input['override_wp_avatars'] ) ? 1 : 0;
 
 		return $input;

--- a/tests/testOptionPasswordPolicy.php
+++ b/tests/testOptionPasswordPolicy.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Contains Class TestAdminFeatures.
+ * Contains Class TestOptionPasswordPolicy.
  *
  * @package WP-Auth0
  *
@@ -8,9 +8,9 @@
  */
 
 /**
- * Class TestAdminFeatures.
+ * Class TestOptionPasswordPolicy.
  */
-class TestAdminFeatures extends WP_Auth0_Test_Case {
+class TestOptionPasswordPolicy extends WP_Auth0_Test_Case {
 
 	use HttpHelpers;
 

--- a/tests/testOptionSsoSlo.php
+++ b/tests/testOptionSsoSlo.php
@@ -1,0 +1,188 @@
+<?php
+/**
+ * Contains Class TestOptionSsoSlo.
+ *
+ * @package WP-Auth0
+ *
+ * @since 3.10.0
+ */
+
+/**
+ * Class TestOptionSsoSlo.
+ * Tests that Features > SSO and SLO function properly.
+ */
+class TestOptionSsoSlo extends WP_Auth0_Test_Case {
+
+	use DomDocumentHelpers;
+
+	/**
+	 * WP_Auth0_Admin_Features instance.
+	 *
+	 * @var WP_Auth0_Admin_Features
+	 */
+	public static $admin;
+
+	/**
+	 * Run before the test suite starts.
+	 */
+	public static function setUpBeforeClass() {
+		parent::setUpBeforeClass();
+		self::$admin = new WP_Auth0_Admin_Features( self::$opts );
+	}
+
+	/**
+	 * Test the input HTML for the custom domain setting.
+	 */
+	public function testSsoFieldOutput() {
+		$field_args = [
+			'label_for' => 'wpa0_sso',
+			'opt_name'  => 'sso',
+		];
+
+		// Get the field HTML.
+		ob_start();
+		self::$admin->render_sso( $field_args );
+		$field_html = ob_get_clean();
+
+		// Check field HTML for required attributes.
+		$input = $this->getDomListFromTagName( $field_html, 'input' );
+
+		// Should only have one input field.
+		$this->assertEquals( 1, $input->length );
+
+		// Input should have the correct id attribute.
+		$this->assertEquals( $field_args['label_for'], $input->item( 0 )->getAttribute( 'id' ) );
+
+		// Input should have the correct name attribute.
+		$this->assertEquals(
+			self::OPTIONS_NAME . '[' . $field_args['opt_name'] . ']',
+			$input->item( 0 )->getAttribute( 'name' )
+		);
+
+		// Input should be a checkbox.
+		$this->assertEquals( 'checkbox', $input->item( 0 )->getAttribute( 'type' ) );
+
+		// Input should reference SLO field.
+		$this->assertEquals( 'wpa0_singlelogout', $input->item( 0 )->getAttribute( 'data-expand' ) );
+
+		// Check that saving a custom domain appears in the field value.
+		self::$opts->set( $field_args['opt_name'], 1 );
+		$this->assertEquals( 1, self::$opts->get( $field_args['opt_name'] ) );
+
+		// Get the field HTML.
+		ob_start();
+		self::$admin->render_sso( $field_args );
+		$field_html = ob_get_clean();
+
+		$input = $this->getDomListFromTagName( $field_html, 'input' );
+		$this->assertEquals( 1, $input->item( 0 )->getAttribute( 'value' ) );
+	}
+
+	/**
+	 * Test the input HTML for the custom domain setting.
+	 */
+	public function testSloFieldOutput() {
+		$field_args = [
+			'label_for' => 'wpa0_singlelogout',
+			'opt_name'  => 'singlelogout',
+		];
+
+		// Get the field HTML.
+		ob_start();
+		self::$admin->render_singlelogout( $field_args );
+		$field_html = ob_get_clean();
+
+		// Check field HTML for required attributes.
+		$input = $this->getDomListFromTagName( $field_html, 'input' );
+
+		// Should only have one input field.
+		$this->assertEquals( 1, $input->length );
+
+		// Input should have the correct id attribute.
+		$this->assertEquals( $field_args['label_for'], $input->item( 0 )->getAttribute( 'id' ) );
+
+		// Input should have the correct name attribute.
+		$this->assertEquals(
+			self::OPTIONS_NAME . '[' . $field_args['opt_name'] . ']',
+			$input->item( 0 )->getAttribute( 'name' )
+		);
+
+		// Input should be a checkbox.
+		$this->assertEquals( 'checkbox', $input->item( 0 )->getAttribute( 'type' ) );
+
+		// Check that saving a custom domain appears in the field value.
+		self::$opts->set( $field_args['opt_name'], 1 );
+		$this->assertEquals( 1, self::$opts->get( $field_args['opt_name'] ) );
+
+		// Get the field HTML.
+		ob_start();
+		self::$admin->render_sso( $field_args );
+		$field_html = ob_get_clean();
+
+		$input = $this->getDomListFromTagName( $field_html, 'input' );
+		$this->assertEquals( 1, $input->item( 0 )->getAttribute( 'value' ) );
+	}
+
+	public function testThatSsoIsValidatedOnSave() {
+		$validated = self::$admin->basic_validation( [], [ 'sso' => false ] );
+		$this->assertEquals( 0, $validated['sso'] );
+
+		$validated = self::$admin->basic_validation( [], [ 'sso' => 0 ] );
+		$this->assertEquals( 0, $validated['sso'] );
+
+		$validated = self::$admin->basic_validation( [], [ 'sso' => 1 ] );
+		$this->assertEquals( 1, $validated['sso'] );
+
+		$validated = self::$admin->basic_validation( [], [ 'sso' => uniqid() ] );
+		$this->assertEquals( 1, $validated['sso'] );
+	}
+
+	public function testThatSloIsValidatedOnSave() {
+		$validated = self::$admin->basic_validation(
+			[],
+			[
+				'sso'          => 1,
+				'singlelogout' => false,
+			]
+		);
+		$this->assertEquals( 0, $validated['singlelogout'] );
+
+		$validated = self::$admin->basic_validation(
+			[],
+			[
+				'sso'          => 1,
+				'singlelogout' => 0,
+			]
+		);
+		$this->assertEquals( 0, $validated['singlelogout'] );
+
+		$validated = self::$admin->basic_validation(
+			[],
+			[
+				'sso'          => 1,
+				'singlelogout' => 1,
+			]
+		);
+		$this->assertEquals( 1, $validated['singlelogout'] );
+
+		$validated = self::$admin->basic_validation(
+			[],
+			[
+				'sso'          => 1,
+				'singlelogout' => uniqid(),
+			]
+		);
+		$this->assertEquals( 1, $validated['singlelogout'] );
+	}
+
+	public function testThatSloIsTurnedOffIfSsoIsOff() {
+		$validated = self::$admin->basic_validation(
+			[],
+			[
+				'sso'          => 0,
+				'singlelogout' => 1,
+			]
+		);
+		$this->assertEquals( 0, $validated['singlelogout'] );
+	}
+}

--- a/tests/testOptionSsoSlo.php
+++ b/tests/testOptionSsoSlo.php
@@ -123,7 +123,13 @@ class TestOptionSsoSlo extends WP_Auth0_Test_Case {
 		$this->assertEquals( 1, $input->item( 0 )->getAttribute( 'value' ) );
 	}
 
+	/**
+	 * Test that SSO is validated properly on save
+	 */
 	public function testThatSsoIsValidatedOnSave() {
+		$validated = self::$admin->basic_validation( [], [] );
+		$this->assertEquals( 0, $validated['sso'] );
+
 		$validated = self::$admin->basic_validation( [], [ 'sso' => false ] );
 		$this->assertEquals( 0, $validated['sso'] );
 
@@ -137,7 +143,15 @@ class TestOptionSsoSlo extends WP_Auth0_Test_Case {
 		$this->assertEquals( 1, $validated['sso'] );
 	}
 
+	/**
+	 * Test that SSO is validated properly on save.
+	 * SSO must be on for SLO to validate to anything except false.
+	 * See testThatSloIsTurnedOffIfSsoIsOff for tests regarding that behavior.
+	 */
 	public function testThatSloIsValidatedOnSave() {
+		$validated = self::$admin->basic_validation( [], [ 'sso' => 1 ] );
+		$this->assertEquals( 0, $validated['singlelogout'] );
+
 		$validated = self::$admin->basic_validation(
 			[],
 			[
@@ -175,6 +189,9 @@ class TestOptionSsoSlo extends WP_Auth0_Test_Case {
 		$this->assertEquals( 1, $validated['singlelogout'] );
 	}
 
+	/**
+	 * Test that SLO is turned off if SSO is off.
+	 */
 	public function testThatSloIsTurnedOffIfSsoIsOff() {
 		$validated = self::$admin->basic_validation(
 			[],


### PR DESCRIPTION
### Changes

- Remove Auth0 Application update from SSO validation middleware
- Add SSO on to Application created process during setup wizard
- Set Features tab defaults to `int` to match validation
- Remove other deprecated middleware

### Testing

* [x] This change adds unit test coverage
