### PR TITLE
clarify that custom sign up fields should be an array

### DIFF
--- a/lib/admin/WP_Auth0_Admin_Advanced.php
+++ b/lib/admin/WP_Auth0_Admin_Advanced.php
@@ -481,7 +481,7 @@ class WP_Auth0_Admin_Advanced extends WP_Auth0_Admin_Generic {
 	public function render_custom_signup_fields( $args = array() ) {
 		$this->render_textarea_field( $args['label_for'], $args['opt_name'] );
 		$this->render_field_description(
-			__( 'Valid JSON for additional signup fields in the Auth0 signup form. ', 'wp-auth0' ) .
+			__( 'Valid array of JSON objects for additional signup fields in the Auth0 signup form. ', 'wp-auth0' ) .
 			$this->get_docs_link(
 				'libraries/lock/v11/configuration#additionalsignupfields-array-',
 				__( 'More information and examples', 'wp-auth0' )


### PR DESCRIPTION
### Changes

- Change the description of "Custom Signup Fields" to mention that this should be an array of JSON objects rather than a JSON. 

### References

- https://auth0.com/docs/libraries/lock/v11/configuration#additionalsignupfields-array-
- https://auth0.com/docs/cms/wordpress/configuration#advanced
- 