### PR TITLE
add auto-redirect if it is set for woocommerce pages too

### DIFF
--- a/WP_Auth0.php
+++ b/WP_Auth0.php
@@ -144,7 +144,7 @@ class WP_Auth0 {
 		$configure_jwt_auth = new WP_Auth0_Configure_JWTAUTH( $this->a0_options );
 		$configure_jwt_auth->init();
 
-		$woocommerce_override = new WP_Auth0_WooCommerceOverrides( $this );
+		$woocommerce_override = new WP_Auth0_WooCommerceOverrides( $this, $this->a0_options );
 		$woocommerce_override->init();
 
 		$users_exporter = new WP_Auth0_Export_Users( $this->db_manager );

--- a/lib/WP_Auth0_WooCommerceOverrides.php
+++ b/lib/WP_Auth0_WooCommerceOverrides.php
@@ -3,9 +3,13 @@
 class WP_Auth0_WooCommerceOverrides {
 	protected $plugin;
 
-	public function __construct( WP_Auth0 $plugin, $options ) {
+	public function __construct( WP_Auth0 $plugin, $options=null ) {
 		$this->plugin = $plugin;
-		$this->options = $options;
+		if ($options == null) {
+			$this->options = \WP_Auth0_Options::Instance();
+		} else {
+			$this->options = $options;
+		}
 	}
 
 	public function init() {
@@ -13,21 +17,21 @@ class WP_Auth0_WooCommerceOverrides {
 		add_filter( 'woocommerce_before_customer_login_form', array( $this, 'override_woocommerce_login_form' ) );
 	}
 
-	private function render_login_form( $redirect ) {
+	private function render_login_form( $redirectPage ) {
 		$this->plugin->render_auth0_login_css();
 		if ($this->options->get('auto_login',false)) {
-			$redirection_after = site_url( $redirect );
 			// Redirecting to Wordpress login area
-			$loginUrl = wp_login_url( $redirection_after );
+			$redirectUrl = get_permalink( wc_get_page_id( $redirectPage ) );
+			$loginUrl = wp_login_url( $redirectUrl );
 	
-			echo '<a class="button button-primary" href="'.$loginUrl.'">Login</a>';
+			printf("<a class='button' href='%s'>%s</a>", $loginUrl, translate( 'Login', 'wp-auth0' ));
 		} else {
 			echo $this->plugin->shortcode( array() );
 		}
 	}
 
 	public function override_woocommerce_checkout_login_form( $html ) {
-		$this->render_login_form('/checkout/');
+		$this->render_login_form('checkout');
 
 		if ( isset( $_GET['wle'] ) ) {
 			echo '<style>.woocommerce-checkout .woocommerce-info{display:block;}</style>';
@@ -35,6 +39,6 @@ class WP_Auth0_WooCommerceOverrides {
 	}
 
 	public function override_woocommerce_login_form( $html ) {
-		$this->render_login_form('/my-account/');
+		$this->render_login_form('myaccount');
 	} 
 }

--- a/lib/WP_Auth0_WooCommerceOverrides.php
+++ b/lib/WP_Auth0_WooCommerceOverrides.php
@@ -1,11 +1,11 @@
 <?php
 
 class WP_Auth0_WooCommerceOverrides {
-
 	protected $plugin;
 
-	public function __construct( WP_Auth0 $plugin ) {
+	public function __construct( WP_Auth0 $plugin, $options ) {
 		$this->plugin = $plugin;
+		$this->options = $options;
 	}
 
 	public function init() {
@@ -13,8 +13,21 @@ class WP_Auth0_WooCommerceOverrides {
 		add_filter( 'woocommerce_before_customer_login_form', array( $this, 'override_woocommerce_login_form' ) );
 	}
 
+	private function render_login_form( $redirect ) {
+		$this->plugin->render_auth0_login_css();
+		if ($this->options->get('auto_login',false)) {
+			$redirection_after = site_url( $redirect );
+			// Redirecting to Wordpress login area
+			$loginUrl = wp_login_url( $redirection_after );
+	
+			echo '<a class="button button-primary" href="'.$loginUrl.'">Login</a>';
+		} else {
+			echo $this->plugin->shortcode( array() );
+		}
+	}
+
 	public function override_woocommerce_checkout_login_form( $html ) {
-		$this->override_woocommerce_login_form( $html );
+		$this->render_login_form('/checkout/');
 
 		if ( isset( $_GET['wle'] ) ) {
 			echo '<style>.woocommerce-checkout .woocommerce-info{display:block;}</style>';
@@ -22,8 +35,6 @@ class WP_Auth0_WooCommerceOverrides {
 	}
 
 	public function override_woocommerce_login_form( $html ) {
-		$this->plugin->render_auth0_login_css();
-		echo $this->plugin->shortcode( array() );
-	}
-
+		$this->render_login_form('/my-account/');
+	} 
 }


### PR DESCRIPTION
### Changes

Please describe both what is changing and why this is important. Include:

- Endpoints added, deleted, deprecated, or changed
Changed the overrides for the woocommerce login forms
- Classes and methods added, deleted, deprecated, or changed
Updated the WP_Auth0 main plugin to pass options to the woocommerce overrides class
Updated the woocommerce overrides class to create a login button instead of login form if auto login is enabled.
- Screenshots of new or changed UI, if applicable
- A summary of usage if this is a new feature or change to a public API (this should also be added to relevant documentation once released)
Should mention this in the new docs

### Testing

Please describe how this can be tested by reviewers. Tests must be added for new functionality and existing tests should complete without errors. 

I tested this by creating a woocommerce themed wordpress site.
I enabled Login by Auth0
Make sure that the "allow users to login on checkout" is enabled for the woocommerce accounts settings.

Try both navigating to /my-account and /checkout (note you have to create a product and add it to your cart to get to checkout).

If you are not logged in, you should now get a Login button, if you click the button, it redirects you to wp-login with the appropriate redirect_to set.

### Checklist

* [x] I read [Auth0's general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)?
* [x] I read [Auth0's code of conduct guidelines](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
* [ ] All existing and new tests complete without errors
* [ ] All code quality tools/guidelines in the [Contribution guide](CONTRIBUTION.md) have been run/followed
* [ ] All relevant assets have been compiled as directed in the [Contribution guide](CONTRIBUTION.md), if applicable
* [ ] All active GitHub CI checks have passed
