### PR TITLE
Better Management API token handling

### DIFF
--- a/lib/api/WP_Auth0_Api_Abstract.php
+++ b/lib/api/WP_Auth0_Api_Abstract.php
@@ -54,20 +54,6 @@ abstract class WP_Auth0_Api_Abstract {
 	protected $api_client_creds;
 
 	/**
-	 * API token from plugin settings or Client Credentials call.
-	 *
-	 * @var string
-	 */
-	protected $api_token;
-
-	/**
-	 * Decoded API token from plugin settings.
-	 *
-	 * @var object
-	 */
-	protected $api_token_decoded;
-
-	/**
 	 * API path.
 	 *
 	 * @var string
@@ -180,47 +166,35 @@ abstract class WP_Auth0_Api_Abstract {
 	 */
 	protected function set_bearer( $scope ) {
 
-		$this->api_token = wp_cache_get( self::CACHE_KEY, WPA0_CACHE_GROUP );
-		if ( ! $this->api_token ) {
-			$this->api_token = $this->options->get( 'auth0_app_token' ); // REMOVE
-		}
+		$api_token = WP_Auth0_Api_Client_Credentials::get_stored_token();
 
-		if ( $this->api_token ) {
-			try {
-				$this->api_token_decoded = $this->decode_jwt( $this->api_token );
-			} catch ( Exception $e ) {
-				// If we can't decode the token, try a client credentials grant below.
-				$this->api_token = null;
-			}
-		}
-
-		// Could not decode the stored API token or none was found so try to get one via API.
-		if ( ! $this->api_token_decoded && $this->api_client_creds instanceof WP_Auth0_Api_Client_Credentials ) {
-			$this->api_token         = $this->api_client_creds->call();
-			$this->api_token_decoded = $this->api_client_creds->get_token_decoded();
+		// No stored API token so need to get a new one.
+		if ( ! $api_token && $this->api_client_creds instanceof WP_Auth0_Api_Client_Credentials ) {
+			$api_token = $this->api_client_creds->call();
 		}
 
 		// No token to use, error recorded in previous steps.
-		if ( ! $this->api_token_decoded ) {
-			wp_cache_delete( self::CACHE_KEY, WPA0_CACHE_GROUP );
+		if ( ! $api_token ) {
 			return false;
+		}
+
+		if ( WP_Auth0_Api_Client_Credentials::check_stored_scope( $scope ) ) {
+			// Scope exists, add to the header and cache.
+			$this->add_header( 'Authorization', 'Bearer ' . $api_token );
+			return true;
 		}
 
 		// API token is missing the required scope.
-		if ( ! $this->api_token_has_scope( $scope ) ) {
-			WP_Auth0_ErrorManager::insert_auth0_error(
-				__METHOD__,
-				// translators: The $scope var here is a machine term and should not be translated.
-				sprintf( __( 'API token does not include the scope %s.', 'wp-auth0' ), $scope )
-			);
-			wp_cache_delete( self::CACHE_KEY, WPA0_CACHE_GROUP );
-			return false;
-		}
+		WP_Auth0_ErrorManager::insert_auth0_error(
+			__METHOD__,
+			// translators: The $scope var here is a machine term and should not be translated.
+			sprintf( __( 'API token does not include the scope %s.', 'wp-auth0' ), $scope )
+		);
 
-		// Scope exists, add to the header and cache.
-		$this->add_header( 'Authorization', 'Bearer ' . $this->api_token );
-		wp_cache_set( self::CACHE_KEY, $this->api_token, WPA0_CACHE_GROUP );
-		return true;
+		// Delete the stored token so we can try again.
+		WP_Auth0_Api_Client_Credentials::delete_store();
+		return false;
+
 	}
 
 	/**
@@ -383,7 +357,9 @@ abstract class WP_Auth0_Api_Abstract {
 	}
 
 	/**
-	 * Decode an Auth0 Management API token.
+	 * Decode an RS256 Auth0 Management API token.
+	 *
+	 * TODO: Deprecate
 	 *
 	 * @param string $token - API JWT to decode.
 	 *
@@ -395,12 +371,13 @@ abstract class WP_Auth0_Api_Abstract {
 	 * @throws BeforeValidException         Provided JWT used before it's eligible as defined by 'nbf'.
 	 * @throws BeforeValidException         Provided JWT used before it's been created as defined by 'iat'.
 	 * @throws ExpiredException             Provided JWT has since expired, as defined by the 'exp' claim.
+	 *
+	 * @codeCoverageIgnore - To be deprecated.
 	 */
 	protected function decode_jwt( $token ) {
 		return JWT::decode(
 			$token,
-			$this->options->get_client_secret_as_key(),
-			// Management API tokens are always RS256.
+			WP_Auth0_Api_Client::JWKfetch( $this->domain ),
 			array( 'RS256' )
 		);
 	}
@@ -427,18 +404,6 @@ abstract class WP_Auth0_Api_Abstract {
 		$this->response_body = wp_remote_retrieve_body( $this->response );
 
 		return $this;
-	}
-
-	/**
-	 * Check the stored API token for a specific scope.
-	 *
-	 * @param string $scope - API token scope to check for.
-	 *
-	 * @return bool
-	 */
-	private function api_token_has_scope( $scope ) {
-		$scopes = explode( ' ', $this->api_token_decoded->scope );
-		return ! empty( $scopes ) && in_array( $scope, $scopes );
 	}
 
 	/**

--- a/lib/api/WP_Auth0_Api_Abstract.php
+++ b/lib/api/WP_Auth0_Api_Abstract.php
@@ -54,6 +54,22 @@ abstract class WP_Auth0_Api_Abstract {
 	protected $api_client_creds;
 
 	/**
+	 * API token from plugin settings or Client Credentials call.
+	 * TODO: Deprecate
+	 *
+	 * @var string
+	 */
+	protected $api_token;
+
+	/**
+	 * Decoded API token from plugin settings.
+	 * TODO: Deprecate
+	 *
+	 * @var object
+	 */
+	protected $api_token_decoded;
+
+	/**
 	 * API path.
 	 *
 	 * @var string
@@ -197,7 +213,6 @@ abstract class WP_Auth0_Api_Abstract {
 		// Delete the stored token so we can try again.
 		WP_Auth0_Api_Client_Credentials::delete_store();
 		return false;
-
 	}
 
 	/**
@@ -361,7 +376,6 @@ abstract class WP_Auth0_Api_Abstract {
 
 	/**
 	 * Decode an RS256 Auth0 Management API token.
-	 *
 	 * TODO: Deprecate
 	 *
 	 * @param string $token - API JWT to decode.

--- a/lib/api/WP_Auth0_Api_Abstract.php
+++ b/lib/api/WP_Auth0_Api_Abstract.php
@@ -187,8 +187,11 @@ abstract class WP_Auth0_Api_Abstract {
 		// API token is missing the required scope.
 		WP_Auth0_ErrorManager::insert_auth0_error(
 			__METHOD__,
-			// translators: The $scope var here is a machine term and should not be translated.
-			sprintf( __( 'API token does not include the scope %s.', 'wp-auth0' ), $scope )
+			new WP_Error(
+				'insufficient_scope',
+				// translators: The $scope var here is a machine term and should not be translated.
+				sprintf( __( 'API token does not include the scope %s.', 'wp-auth0' ), $scope )
+			)
 		);
 
 		// Delete the stored token so we can try again.

--- a/lib/api/WP_Auth0_Api_Client_Credentials.php
+++ b/lib/api/WP_Auth0_Api_Client_Credentials.php
@@ -14,8 +14,6 @@ class WP_Auth0_Api_Client_Credentials extends WP_Auth0_Api_Abstract {
 
 	/**
 	 * Default value to return on failure.
-	 *
-	 * @var null
 	 */
 	const RETURN_ON_FAILURE = null;
 
@@ -31,6 +29,7 @@ class WP_Auth0_Api_Client_Credentials extends WP_Auth0_Api_Abstract {
 
 	/**
 	 * Decoded token received.
+	 * TODO: Deprecate
 	 *
 	 * @var null|object
 	 */
@@ -61,7 +60,6 @@ class WP_Auth0_Api_Client_Credentials extends WP_Auth0_Api_Abstract {
 
 	/**
 	 * Return the decoded API token received.
-	 *
 	 * TODO: Deprecate
 	 *
 	 * @return null|object
@@ -98,7 +96,7 @@ class WP_Auth0_Api_Client_Credentials extends WP_Auth0_Api_Abstract {
 		}
 
 		// Set the transient to expire 1 minute before the token does.
-		$expires_in  = isset( $response_body->expires_in ) ? absint( $response_body->expires_in ) : HOUR_IN_SECONDS;
+		$expires_in  = ! empty( $response_body->expires_in ) ? absint( $response_body->expires_in ) : HOUR_IN_SECONDS;
 		$expires_in -= MINUTE_IN_SECONDS;
 
 		// Store the token and scope to check when used.

--- a/lib/api/WP_Auth0_Api_Client_Credentials.php
+++ b/lib/api/WP_Auth0_Api_Client_Credentials.php
@@ -107,7 +107,7 @@ class WP_Auth0_Api_Client_Credentials extends WP_Auth0_Api_Abstract {
 	}
 
 	/**
-	 * Get the stored API token from a transient.
+	 * Get the stored access token from a transient.
 	 *
 	 * @return string
 	 */
@@ -116,7 +116,7 @@ class WP_Auth0_Api_Client_Credentials extends WP_Auth0_Api_Abstract {
 	}
 
 	/**
-	 * Delete the stored API token and scope from transients.
+	 * Delete the stored access token and scope from transients.
 	 */
 	public static function delete_store() {
 		delete_transient( self::TOKEN_TRANSIENT_KEY );
@@ -124,15 +124,15 @@ class WP_Auth0_Api_Client_Credentials extends WP_Auth0_Api_Abstract {
 	}
 
 	/**
-	 * Check the stored API token scope for a specific scope.
+	 * Check a single scope against the scope of the stored access token.
 	 *
-	 * @param string $scope - Scope to check for.
+	 * @param string $scope - Single scope to check for.
 	 *
 	 * @return bool
 	 */
 	public static function check_stored_scope( $scope ) {
 		$stored_scope = get_transient( self::SCOPE_TRANSIENT_KEY );
 		$scopes       = explode( ' ', $stored_scope );
-		return ! empty( $scopes ) && in_array( $scope, $scopes );
+		return in_array( $scope, $scopes );
 	}
 }

--- a/lib/profile/WP_Auth0_Profile_Delete_Data.php
+++ b/lib/profile/WP_Auth0_Profile_Delete_Data.php
@@ -59,11 +59,11 @@ class WP_Auth0_Profile_Delete_Data {
 		<table class="form-table">
 			<tr>
 				<th>
-					<label><?php _e( 'Delete Auth0 Data' ); ?></label>
+					<label><?php _e( 'Delete Auth0 Data', 'wp-auth0' ); ?></label>
 				</th>
 				<td>
 					<input type="button" id="auth0_delete_data" class="button button-secondary"
-								 value="<?php _e( 'Delete Auth0 Data', 'wp-auth0' ); ?>" />
+						value="<?php _e( 'Delete Auth0 Data', 'wp-auth0' ); ?>" />
 				</td>
 			</tr>
 		</table>

--- a/lib/profile/WP_Auth0_Profile_Delete_Mfa.php
+++ b/lib/profile/WP_Auth0_Profile_Delete_Mfa.php
@@ -74,11 +74,11 @@ class WP_Auth0_Profile_Delete_Mfa {
 		<table class="form-table">
 			<tr>
 				<th>
-					<label><?php _e( 'Delete MFA Provider' ); ?></label>
+					<label><?php _e( 'Delete MFA Provider', 'wp-auth0' ); ?></label>
 				</th>
 				<td>
 					<input type="button" id="auth0_delete_mfa" class="button button-secondary"
-						   value="<?php _e( 'Delete MFA Provider' ); ?>" />
+						value="<?php _e( 'Delete MFA Provider', 'wp-auth0' ); ?>" />
 				</td>
 			</tr>
 		</table>

--- a/tests/testApiChangeEmail.php
+++ b/tests/testApiChangeEmail.php
@@ -153,6 +153,23 @@ class TestApiChangeEmail extends WP_Auth0_Test_Case {
 	}
 
 	/**
+	 * Test that the bearer setting succeeds if there is a token stored with the correct scope.
+	 */
+	public function testThatSetBearerFailsWithInsufficientScope() {
+		$this->startHttpMocking();
+
+		set_transient( 'auth0_api_token', uniqid() );
+		set_transient( 'auth0_api_token_scope', 'read:users' );
+
+		$api = new WP_Auth0_Api_Change_Email( self::$opts, self::$api_client_creds );
+		$this->assertFalse( $api->call( uniqid(), uniqid() ) );
+
+		$log = self::$error_log->get();
+		$this->assertCount( 1, $log );
+		$this->assertEquals( 'insufficient_scope', $log[0]['code'] );
+	}
+
+	/**
 	 * Test that set bearer fails if there is no stored token and a CC grant fails.
 	 */
 	public function testThatSetBearerFailsWhenCannotGetToken() {

--- a/tests/testApiChangeEmail.php
+++ b/tests/testApiChangeEmail.php
@@ -139,9 +139,9 @@ class TestApiChangeEmail extends WP_Auth0_Test_Case {
 	}
 
 	/**
-	 * Test that the bearer setting succeeds if there is a token stored with the correct scope.
+	 * Test that the API call succeeds if there is a token stored with the correct scope.
 	 */
-	public function testThatSetBearerSucceedsWithStoredToken() {
+	public function testThatApiCallSucceedsWithStoredToken() {
 		$this->startHttpMocking();
 
 		set_transient( 'auth0_api_token', uniqid() );
@@ -153,9 +153,9 @@ class TestApiChangeEmail extends WP_Auth0_Test_Case {
 	}
 
 	/**
-	 * Test that the bearer setting succeeds if there is a token stored with the correct scope.
+	 * Test that the API call fails if there is a token stored with insufficient scope.
 	 */
-	public function testThatSetBearerFailsWithInsufficientScope() {
+	public function testThatApiCallFailsWithInsufficientScope() {
 		$this->startHttpMocking();
 
 		set_transient( 'auth0_api_token', uniqid() );

--- a/tests/testApiChangePassword.php
+++ b/tests/testApiChangePassword.php
@@ -13,7 +13,7 @@
  */
 class TestApiChangePassword extends WP_Auth0_Test_Case {
 
-	use httpHelpers {
+	use HttpHelpers {
 		httpMock as protected httpMockDefault;
 	}
 

--- a/tests/testApiClientCredentials.php
+++ b/tests/testApiClientCredentials.php
@@ -122,4 +122,49 @@ class TestApiClientCredentials extends WP_Auth0_Test_Case {
 		$log = self::$error_log->get();
 		$this->assertCount( 0, $log );
 	}
+
+	/**
+	 * Test that the stored token is returned, if present.
+	 */
+	public function testThatGetStoredTokenReturnsCorrectly() {
+		$this->assertFalse( WP_Auth0_Api_Client_Credentials::get_stored_token() );
+
+		$token = uniqid();
+		set_transient( 'auth0_api_token', $token );
+		$this->assertEquals( $token, WP_Auth0_Api_Client_Credentials::get_stored_token() );
+	}
+
+	/**
+	 * Test that the stored token data is deleted.
+	 */
+	public function testThatDeleteStoreRemovesTokenData() {
+		$token = uniqid();
+		set_transient( 'auth0_api_token', $token );
+		$this->assertEquals( $token, get_transient( 'auth0_api_token' ) );
+
+		$scope = uniqid();
+		set_transient( 'auth0_api_token_scope', $scope );
+		$this->assertEquals( $scope, get_transient( 'auth0_api_token_scope' ) );
+
+		WP_Auth0_Api_Client_Credentials::delete_store();
+
+		$this->assertFalse( get_transient( 'auth0_api_token' ) );
+		$this->assertFalse( get_transient( 'auth0_api_token_scope' ) );
+	}
+
+	/**
+	 * Test that the stored scope data is checked against a passed-in value.
+	 */
+	public function testThatCheckStoredScopeChecksScopeCorrectly() {
+		$this->assertFalse( WP_Auth0_Api_Client_Credentials::check_stored_scope( 'scope:none' ) );
+
+		set_transient( 'auth0_api_token_scope', 'scope:one' );
+		$this->assertTrue( WP_Auth0_Api_Client_Credentials::check_stored_scope( 'scope:one' ) );
+		$this->assertFalse( WP_Auth0_Api_Client_Credentials::check_stored_scope( 'scope:two' ) );
+
+		set_transient( 'auth0_api_token_scope', 'scope:one scope:two' );
+		$this->assertTrue( WP_Auth0_Api_Client_Credentials::check_stored_scope( 'scope:one' ) );
+		$this->assertTrue( WP_Auth0_Api_Client_Credentials::check_stored_scope( 'scope:two' ) );
+		$this->assertFalse( WP_Auth0_Api_Client_Credentials::check_stored_scope( 'scope:three' ) );
+	}
 }

--- a/tests/testApiClientCredentials.php
+++ b/tests/testApiClientCredentials.php
@@ -13,9 +13,7 @@
  */
 class TestApiClientCredentials extends WP_Auth0_Test_Case {
 
-	use HttpHelpers {
-		httpMock as protected httpMockDefault;
-	}
+	use HttpHelpers;
 
 	/**
 	 * Run after each test.
@@ -114,30 +112,14 @@ class TestApiClientCredentials extends WP_Auth0_Test_Case {
 		$this->startHttpMocking();
 		$api_client_creds = new WP_Auth0_Api_Client_Credentials( self::$opts );
 
-		$this->http_request_type = 'access_token';
+		$this->http_request_type = 'success_access_token';
 		$timeout                 = time() + 1000;
 		$this->assertEquals( '__test_access_token__', $api_client_creds->call() );
 		$this->assertEquals( '__test_access_token__', get_transient( 'auth0_api_token' ) );
-		$this->assertEquals( 'test:scope', get_transient( 'auth0_api_token_scope' ) );
+		$this->assertEquals( 'update:users', get_transient( 'auth0_api_token_scope' ) );
 		$this->assertLessThan( $timeout, (int) get_transient( '_transient_timeout_auth0_api_token_scope' ) );
 		$this->assertLessThan( $timeout, (int) get_transient( '_transient_timeout_auth0_api_token' ) );
 		$log = self::$error_log->get();
 		$this->assertCount( 0, $log );
-	}
-
-	/**
-	 * Specific mock API responses for this suite.
-	 *
-	 * @return array|null|WP_Error
-	 */
-	public function httpMock() {
-		switch ( $this->getResponseType() ) {
-			case 'access_token':
-				return [
-					'body'     => '{"access_token":"__test_access_token__","scope":"test:scope","expires_in":1000}',
-					'response' => [ 'code' => 200 ],
-				];
-		}
-		return $this->httpMockDefault();
 	}
 }

--- a/tests/testApiDeleteMfa.php
+++ b/tests/testApiDeleteMfa.php
@@ -13,7 +13,7 @@
  */
 class TestApiDeleteMfa extends WP_Auth0_Test_Case {
 
-	use httpHelpers {
+	use HttpHelpers {
 		httpMock as protected httpMockDefault;
 	}
 

--- a/tests/testApiJobsVerification.php
+++ b/tests/testApiJobsVerification.php
@@ -13,7 +13,7 @@
  */
 class TestApiJobsVerification extends WP_Auth0_Test_Case {
 
-	use httpHelpers {
+	use HttpHelpers {
 		httpMock as protected httpMockDefault;
 	}
 

--- a/tests/testInitialSetupConsent.php
+++ b/tests/testInitialSetupConsent.php
@@ -12,7 +12,7 @@
  */
 class TestInitialSetupConsent extends WP_Auth0_Test_Case {
 
-	use httpHelpers {
+	use HttpHelpers {
 		httpMock as protected httpMockDefault;
 	}
 

--- a/tests/testProfileChangePassword.php
+++ b/tests/testProfileChangePassword.php
@@ -20,7 +20,7 @@ class TestProfileChangePassword extends WP_Auth0_Test_Case {
 
 	use UsersHelper;
 
-	use httpHelpers;
+	use HttpHelpers;
 
 	/**
 	 * WP_Auth0_Options instance.

--- a/tests/traits/httpHelpers.php
+++ b/tests/traits/httpHelpers.php
@@ -85,6 +85,8 @@ trait HttpHelpers {
 	 * @param string|null $url - Remote URL.
 	 *
 	 * @return array|WP_Error
+	 *
+	 * @throws Exception - If set to halt on response.
 	 */
 	public function httpMock( $response_type = null, array $args = null, $url = null ) {
 		switch ( $response_type ?: $this->getResponseType() ) {
@@ -146,6 +148,12 @@ trait HttpHelpers {
 						"enabled_clients":["TEST_CLIENT_ID"],
 						"options":{"passwordPolicy":"poor"}
 					}]',
+					'response' => [ 'code' => 200 ],
+				];
+
+			case 'success_access_token':
+				return [
+					'body'     => '{"access_token":"__test_access_token__","scope":"update:users","expires_in":1000}',
 					'response' => [ 'code' => 200 ],
 				];
 


### PR DESCRIPTION
### Changes

- Remove Management API access token validation 
- Store new API tokens and scope in transients

### References

Closes #631

### Testing

- [Failing tests commit](https://github.com/auth0/wp-auth0/pull/632/commits/56f9c236a26eca97eb003253a191da03790750d5)
- [More failing tests commit](https://github.com/auth0/wp-auth0/pull/632/commits/c1b56f675cc9da00bf9827fc45d289509ab017bd)
- [Functionality changes commit](https://github.com/auth0/wp-auth0/pull/632/commits/61533780e7be345fe18381cfe617b25d8f90d551)
- [Passing tests commit](https://github.com/auth0/wp-auth0/pull/632/commits/c3ba87abcfc54b1d91afa49af6ee2a25c7affb67)

* [x] This change adds unit test coverage
* [x] This change has been tested on the latest version of WP

### Checklist

* [x] I read [Auth0's general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)?
* [x] I read [Auth0's code of conduct guidelines](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
* [x] All existing and new tests complete without errors
* [x] All code quality tools/guidelines in the [Contribution guide](CONTRIBUTION.md) have been run/followed
* [x] All active GitHub CI checks have passed
