### PR TITLE
Remove CSS and JS fields for new installs and ones an without existing value

### DIFF
--- a/lib/WP_Auth0_Options.php
+++ b/lib/WP_Auth0_Options.php
@@ -215,8 +215,6 @@ class WP_Auth0_Options extends WP_Auth0_Options_Generic {
 			'form_title'                => '',
 			'social_big_buttons'        => false,
 			'gravatar'                  => true,
-			'custom_css'                => '',
-			'custom_js'                 => '',
 			'username_style'            => '',
 			'primary_color'             => '',
 			'language'                  => '',

--- a/lib/admin/WP_Auth0_Admin_Appearance.php
+++ b/lib/admin/WP_Auth0_Admin_Appearance.php
@@ -177,7 +177,7 @@ class WP_Auth0_Admin_Appearance extends WP_Auth0_Admin_Generic {
 		} else {
 			$this->render_field_description(
 				__( 'Custom styles should be loaded in an external file using the instructions ', 'wp-auth0' ) .
-				$this->get_docs_link( 'cms/wordpress/troubleshoot#how-can-i-modify-the-embedded-auth0-login-form' )
+				$this->get_docs_link( 'cms/wordpress/troubleshoot#how-can-i-modify-the-embedded-auth0-login-form-' )
 			);
 		}
 
@@ -203,7 +203,7 @@ class WP_Auth0_Admin_Appearance extends WP_Auth0_Admin_Generic {
 		} else {
 			$this->render_field_description(
 				__( 'Custom JavaScript should be loaded in an external file using the instructions ', 'wp-auth0' ) .
-				$this->get_docs_link( 'cms/wordpress/troubleshoot#how-can-i-modify-the-embedded-auth0-login-form' )
+				$this->get_docs_link( 'cms/wordpress/troubleshoot#how-can-i-modify-the-embedded-auth0-login-form-' )
 			);
 		}
 	}

--- a/lib/admin/WP_Auth0_Admin_Appearance.php
+++ b/lib/admin/WP_Auth0_Admin_Appearance.php
@@ -20,7 +20,7 @@ class WP_Auth0_Admin_Appearance extends WP_Auth0_Admin_Generic {
 	 */
 	public function __construct( WP_Auth0_Options_Generic $options ) {
 		parent::__construct( $options );
-		$this->_description = __( 'Settings related to the way the login widget is shown.', 'wp-auth0' );
+		$this->_description = __( 'Change the how the embedded Auth0 login form is displayed.', 'wp-auth0' );
 	}
 
 	/**
@@ -160,6 +160,7 @@ class WP_Auth0_Admin_Appearance extends WP_Auth0_Admin_Generic {
 	/**
 	 * Render form field and description for the `custom_css` option.
 	 * IMPORTANT: Internal callback use only, do not call this function directly!
+	 * TODO: Deprecate
 	 *
 	 * @param array $args - callback args passed in from add_settings_field().
 	 *
@@ -167,13 +168,25 @@ class WP_Auth0_Admin_Appearance extends WP_Auth0_Admin_Generic {
 	 * @see add_settings_field()
 	 */
 	public function render_custom_css( $args = array() ) {
-		$this->render_textarea_field( $args['label_for'], $args['opt_name'] );
-		$this->render_field_description( __( 'Valid CSS to customize the Auth0 login form', 'wp-auth0' ) );
+		if ( $this->options->get( 'custom_css' ) ) {
+			$this->render_textarea_field( $args['label_for'], $args['opt_name'] );
+			$this->render_field_description(
+				__( 'NOTE: This field is deprecated and will be removed in the next major release. ', 'wp-auth0' ) .
+				__( 'Valid CSS to customize the Auth0 login form', 'wp-auth0' )
+			);
+		} else {
+			$this->render_field_description(
+				__( 'Custom styles should be loaded in an external file using the instructions ', 'wp-auth0' ) .
+				$this->get_docs_link( 'cms/wordpress/troubleshoot#how-can-i-modify-the-embedded-auth0-login-form' )
+			);
+		}
+
 	}
 
 	/**
 	 * Render form field and description for the `custom_js` option.
 	 * IMPORTANT: Internal callback use only, do not call this function directly!
+	 * TODO: Deprecate
 	 *
 	 * @param array $args - callback args passed in from add_settings_field().
 	 *
@@ -181,8 +194,18 @@ class WP_Auth0_Admin_Appearance extends WP_Auth0_Admin_Generic {
 	 * @see add_settings_field()
 	 */
 	public function render_custom_js( $args = array() ) {
-		$this->render_textarea_field( $args['label_for'], $args['opt_name'] );
-		$this->render_field_description( __( 'Valid JS to customize the Auth0 login form', 'wp-auth0' ) );
+		if ( $this->options->get( 'custom_js' ) ) {
+			$this->render_textarea_field( $args['label_for'], $args['opt_name'] );
+			$this->render_field_description(
+				__( 'NOTE: This field is deprecated and will be removed in the next major release. ', 'wp-auth0' ) .
+				__( 'Valid JS to customize the Auth0 login form', 'wp-auth0' )
+			);
+		} else {
+			$this->render_field_description(
+				__( 'Custom JavaScript should be loaded in an external file using the instructions ', 'wp-auth0' ) .
+				$this->get_docs_link( 'cms/wordpress/troubleshoot#how-can-i-modify-the-embedded-auth0-login-form' )
+			);
+		}
 	}
 
 	/**

--- a/tests/testOptionCustomCssJs.php
+++ b/tests/testOptionCustomCssJs.php
@@ -1,0 +1,164 @@
+<?php
+/**
+ * Contains Class TestOptionCustomCssJs.
+ *
+ * @package WP-Auth0
+ *
+ * @since 3.10.0
+ */
+
+/**
+ * Class TestOptionCustomCssJs.
+ * Tests that custom JS and CSS settings fields are displayed properly.
+ */
+class TestOptionCustomCssJs extends WP_Auth0_Test_Case {
+
+	use DomDocumentHelpers;
+
+	/**
+	 * WP_Auth0_Admin_Appearance instance.
+	 *
+	 * @var WP_Auth0_Admin_Appearance
+	 */
+	public static $admin;
+
+	/**
+	 * Run before the test suite starts.
+	 */
+	public static function setUpBeforeClass() {
+		parent::setUpBeforeClass();
+		self::$admin = new WP_Auth0_Admin_Appearance( self::$opts );
+	}
+
+	/**
+	 * Test that a textarea is present and proper documentation appears when the CSS field is populated.
+	 */
+	public function testThatTextareaIsPresentIfCssExists() {
+
+		$field_args = [
+			'label_for' => 'wpa0_custom_css',
+			'opt_name'  => 'custom_css',
+		];
+
+		self::$opts->set( $field_args['opt_name'], '__test_css_input__' );
+
+		ob_start();
+		self::$admin->render_custom_css( $field_args );
+		$field_html = ob_get_clean();
+
+		// Check for correct documentation.
+		$this->assertContains( 'This field is deprecated and will be removed', $field_html );
+		$this->assertContains( 'Valid CSS to customize the Auth0 login form', $field_html );
+
+		// Check field HTML for required attributes.
+		$input = $this->getDomListFromTagName( $field_html, 'textarea' );
+
+		// Should have exactly one textarea field.
+		$this->assertEquals( 1, $input->length );
+
+		// Check for correct value set.
+		$this->assertEquals( '__test_css_input__', $input->item( 0 )->nodeValue );
+
+		// Textarea should have the correct id attribute.
+		$this->assertEquals( $field_args['label_for'], $input->item( 0 )->getAttribute( 'id' ) );
+
+		// Textarea should have the correct name attribute.
+		$this->assertEquals(
+			self::OPTIONS_NAME . '[' . $field_args['opt_name'] . ']',
+			$input->item( 0 )->getAttribute( 'name' )
+		);
+	}
+
+	/**
+	 * Test that a textarea is not present and proper documentation appears when the CSS field is empty.
+	 */
+	public function testThatTextareaIsNotPresentIfCssEmpty() {
+
+		$field_args = [
+			'label_for' => 'wpa0_custom_css',
+			'opt_name'  => 'custom_css',
+		];
+
+		self::$opts->set( $field_args['opt_name'], '' );
+
+		ob_start();
+		self::$admin->render_custom_css( $field_args );
+		$field_html = ob_get_clean();
+
+		// Check for correct documentation.
+		$this->assertContains( 'Custom styles should be loaded in an external file', $field_html );
+		$this->assertContains( 'https://auth0.com/docs/cms/wordpress/troubleshoot', $field_html );
+
+		// Check field HTML for required attributes.
+		$input = $this->getDomListFromTagName( $field_html, 'textarea' );
+
+		// Should have no textarea field.
+		$this->assertEmpty( $input->length );
+	}
+
+	/**
+	 * Test that a textarea is present and proper documentation appears when the JS field is populated.
+	 */
+	public function testThatTextareaIsPresentIfJsExists() {
+
+		$field_args = [
+			'label_for' => 'wpa0_custom_js',
+			'opt_name'  => 'custom_js',
+		];
+
+		self::$opts->set( $field_args['opt_name'], '__test_js_input__' );
+
+		ob_start();
+		self::$admin->render_custom_js( $field_args );
+		$field_html = ob_get_clean();
+
+		// Check for correct documentation.
+		$this->assertContains( 'This field is deprecated and will be removed', $field_html );
+		$this->assertContains( 'Valid JS to customize the Auth0 login form', $field_html );
+
+		// Check field HTML for required attributes.
+		$input = $this->getDomListFromTagName( $field_html, 'textarea' );
+
+		// Should have exactly one textarea field.
+		$this->assertEquals( 1, $input->length );
+
+		// Check for correct value set.
+		$this->assertEquals( '__test_js_input__', $input->item( 0 )->nodeValue );
+
+		// Textarea should have the correct id attribute.
+		$this->assertEquals( $field_args['label_for'], $input->item( 0 )->getAttribute( 'id' ) );
+
+		// Textarea should have the correct name attribute.
+		$this->assertEquals(
+			self::OPTIONS_NAME . '[' . $field_args['opt_name'] . ']',
+			$input->item( 0 )->getAttribute( 'name' )
+		);
+	}
+
+	/**
+	 * Test that a textarea is not present and proper documentation appears when the JS field is empty.
+	 */
+	public function testThatTextareaIsNotPresentIfJsEmpty() {
+
+		$field_args = [
+			'label_for' => 'wpa0_custom_js',
+			'opt_name'  => 'custom_js',
+		];
+
+		self::$opts->set( $field_args['opt_name'], '' );
+
+		ob_start();
+		self::$admin->render_custom_js( $field_args );
+		$field_html = ob_get_clean();
+
+		// Check for correct documentation.
+		$this->assertContains( 'Custom JavaScript should be loaded in an external file', $field_html );
+		$this->assertContains( 'https://auth0.com/docs/cms/wordpress/troubleshoot', $field_html );
+
+		// Check field HTML for required attributes.
+		$input = $this->getDomListFromTagName( $field_html, 'textarea' );
+
+		// Should have no textarea field.
+		$this->assertEmpty( $input->length );
+	}
+}

--- a/tests/testWPAuth0Options.php
+++ b/tests/testWPAuth0Options.php
@@ -20,7 +20,7 @@ class TestWPAuth0Options extends WP_Auth0_Test_Case {
 	/**
 	 * Total number of options.
 	 */
-	const DEFAULT_OPTIONS_COUNT = 59;
+	const DEFAULT_OPTIONS_COUNT = 57;
 
 	/**
 	 * Test the basic options functionality.


### PR DESCRIPTION
### Changes

- New installs will not see the Custom CSS and Custom JS fields, only a message and link to upcoming documentation. 
- Installs without a value saved to these fields will see the same. 
- Installs with a value in either field will see a deprecation message. 

### Testing

* [x] This change adds unit test coverage
* [x] This change has been tested on WP 5.1.1
