### PR TITLE
Deprecate WP JWT Auth plugin configuration

### DIFF
--- a/lib/WP_Auth0_Configure_JWTAUTH.php
+++ b/lib/WP_Auth0_Configure_JWTAUTH.php
@@ -1,9 +1,17 @@
 <?php
 
+/**
+ * Class WP_Auth0_Configure_JWTAUTH
+ *
+ * @deprecated 3.10.0, plugin is deprecated and removed from the WP plugin repo.
+ */
 class WP_Auth0_Configure_JWTAUTH {
 
 	protected $a0_options;
 
+	/**
+	 * @deprecated 3.10.0, plugin is deprecated and removed from the WP plugin repo.
+	 */
 	public function __construct( WP_Auth0_Options $a0_options ) {
 		$this->a0_options = $a0_options;
 	}
@@ -66,6 +74,11 @@ class WP_Auth0_Configure_JWTAUTH {
 
 	}
 
+	/**
+	 * @deprecated 3.10.0, plugin is deprecated and removed from the WP plugin repo.
+	 *
+	 * @return bool
+	 */
 	public static function is_jwt_auth_enabled() {
 		if ( ! function_exists( 'is_plugin_active' ) ) {
 			require_once ABSPATH . 'wp-admin/includes/plugin.php';
@@ -74,6 +87,11 @@ class WP_Auth0_Configure_JWTAUTH {
 		return is_plugin_active( 'wp-jwt-auth/JWT_AUTH.php' );
 	}
 
+	/**
+	 * @deprecated 3.10.0, plugin is deprecated and removed from the WP plugin repo.
+	 *
+	 * @return bool
+	 */
 	public static function is_jwt_configured() {
 		$options = WP_Auth0_Options::Instance();
 		return (

--- a/lib/admin/WP_Auth0_Admin_Advanced.php
+++ b/lib/admin/WP_Auth0_Admin_Advanced.php
@@ -535,6 +535,8 @@ class WP_Auth0_Admin_Advanced extends WP_Auth0_Admin_Generic {
 	 * Render form field and description for the `jwt_auth_integration` option.
 	 * IMPORTANT: Internal callback use only, do not call this function directly!
 	 *
+	 * @deprecated 3.10.0, plugin is deprecated and removed from the WP plugin repo.
+	 *
 	 * @param array $args - callback args passed in from add_settings_field().
 	 *
 	 * @see WP_Auth0_Admin_Generic::init_option_section()
@@ -542,7 +544,10 @@ class WP_Auth0_Admin_Advanced extends WP_Auth0_Admin_Generic {
 	 */
 	public function render_jwt_auth_integration( $args = array() ) {
 		$this->render_switch( $args['label_for'], $args['opt_name'] );
-		$this->render_field_description( __( 'This will enable the JWT Auth Users Repository override', 'wp-auth0' ) );
+		$this->render_field_description(
+			__( 'This setting is deprecated and will be removed in the next major version. ', 'wp-auth0' ) .
+			__( 'This will enable the JWT Auth Users Repository override', 'wp-auth0' )
+		);
 	}
 
 	public function basic_validation( $old_options, $input ) {

--- a/templates/configure-jwt-auth.php
+++ b/templates/configure-jwt-auth.php
@@ -6,6 +6,11 @@
 
 		<h1><?php _e( 'JWT Auth authentication', 'wp-auth0' ); ?></h1>
 
+		<p>
+			<?php _e( 'NOTE: The WP JWT Auth plugin is deprecated.', 'wp-auth0' ); ?>
+			<?php _e( 'This page will be removed in the next major version.', 'wp-auth0' ); ?>
+		</p>
+
 		<?php if ( ! $ready ) { ?>
 			<form action="options.php" method="post">
 				<input type="hidden" name="action" value="wpauth0_configure_jwt" />

--- a/tests/testWPAuth0Options.php
+++ b/tests/testWPAuth0Options.php
@@ -20,7 +20,7 @@ class TestWPAuth0Options extends WP_Auth0_Test_Case {
 	/**
 	 * Total number of options.
 	 */
-	const DEFAULT_OPTIONS_COUNT = 57;
+	const DEFAULT_OPTIONS_COUNT = 55;
 
 	/**
 	 * Test the basic options functionality.


### PR DESCRIPTION
### Changes

Deprecate all settings related to the WP JWT Auth plugin.

### References

[Removed WP JWT Auth plugin](https://wordpress.org/plugins/wp-jwt-auth/)