### PR TITLE
Remove automatic client grant creation

### DIFF
--- a/WP_Auth0.php
+++ b/WP_Auth0.php
@@ -441,11 +441,6 @@ class WP_Auth0 {
 		delete_option( 'widget_wp_auth0_widget' );
 		delete_option( 'widget_wp_auth0_social_amplification_widget' );
 
-		delete_option( 'wp_auth0_client_grant_failed' );
-		delete_option( 'wp_auth0_client_grant_success' );
-		delete_option( 'wp_auth0_grant_types_failed' );
-		delete_option( 'wp_auth0_grant_types_success' );
-
 		delete_transient( WPA0_JWKS_CACHE_TRANSIENT_NAME );
 	}
 

--- a/lib/admin/WP_Auth0_Admin_Basic.php
+++ b/lib/admin/WP_Auth0_Admin_Basic.php
@@ -335,19 +335,6 @@ class WP_Auth0_Admin_Basic extends WP_Auth0_Admin_Generic {
 			? $input['auth0_app_token'] // TO BE DEPRECATED
 			: $old_options['auth0_app_token'] ); // TO BE DEPRECATED
 
-		// If we have an app token, get and store the audience
-		if ( ! empty( $input['auth0_app_token'] ) ) { // NEED TO ADDRESS
-			$db_manager = new WP_Auth0_DBManager( WP_Auth0_Options::Instance() );
-
-			if ( get_option( 'wp_auth0_client_grant_failed' ) ) {
-				$db_manager->install_db( 16, $input['auth0_app_token'] ); // NEED TO ADDRESS
-			}
-
-			if ( get_option( 'wp_auth0_grant_types_failed' ) ) {
-				$db_manager->install_db( 17, $input['auth0_app_token'] ); // NEED TO ADDRESS
-			}
-		}
-
 		if ( empty( $input['domain'] ) ) {
 			$this->add_validation_error( __( 'You need to specify a domain', 'wp-auth0' ) );
 		}

--- a/tests/testWPAuth0DbMigrations.php
+++ b/tests/testWPAuth0DbMigrations.php
@@ -95,6 +95,12 @@ class TestWPAuth0DbMigrations extends WP_Auth0_Test_Case {
 		self::$opts->set( 'passwordless_cdn_url', uniqid() );
 		self::$opts->set( 'cdn_url_legacy', uniqid() );
 
+		// Set options to be deleted.
+		update_option( 'wp_auth0_client_grant_failed', 1 );
+		update_option( 'wp_auth0_grant_types_failed', 1 );
+		update_option( 'wp_auth0_client_grant_success', 1 );
+		update_option( 'wp_auth0_grant_types_success', 1 );
+
 		// Run the update.
 		$db_manager->install_db( $test_version, null );
 
@@ -106,6 +112,12 @@ class TestWPAuth0DbMigrations extends WP_Auth0_Test_Case {
 		$this->assertNull( self::$opts->get( 'auth0js-cdn' ) );
 		$this->assertNull( self::$opts->get( 'passwordless_cdn_url' ) );
 		$this->assertNull( self::$opts->get( 'cdn_url_legacy' ) );
+
+		// Check that unused options were removed.
+		$this->assertFalse( get_option( 'wp_auth0_client_grant_failed' ) );
+		$this->assertFalse( get_option( 'wp_auth0_grant_types_failed' ) );
+		$this->assertFalse( get_option( 'wp_auth0_client_grant_success' ) );
+		$this->assertFalse( get_option( 'wp_auth0_grant_types_success' ) );
 
 		// Check that unused settings were removed.
 		$updated_options = get_option( self::$opts->get_options_name() );


### PR DESCRIPTION
### Changes

In version 3.5.0 and 3.5.1, a Client Credentials grant was automatically created between the WP site and the Management API to retrieve user data. This could only happen if a valid API access token was already saved in the setting page. This grant is no longer required for the plugin to function properly and uncommon for sites that have been live for longer than the token expiration (24 hours be default). 

The number of sites that could use this automatic update was small to begin with and the number of sites that are running < 3.5.x are down to 8% ([plugin stats](https://wordpress.org/plugins/auth0/advanced/)).

This PR removes the automatic check and attempted fix in preparation for removing the admin-stored API token. Sites that update from < 3.5 will still receive user data via the ID token and updates that did not function before the update (user email and password updates, email verification resending) will continue to not function but log a clear error message. 

This PR also deprecates the methods that would display an admin message if the process failed. 

### Testing

* [x] This change adds unit test coverage

### Checklist

* [x] I read [Auth0's general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)?
* [x] I read [Auth0's code of conduct guidelines](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
* [x] All existing and new tests complete without errors
* [x] All code quality tools/guidelines in the [Contribution guide](CONTRIBUTION.md) have been run/followed
* [x] All active GitHub CI checks have passed
