### PR TITLE
Change ULP setting to be on by default

### DIFF
--- a/lib/WP_Auth0_Options.php
+++ b/lib/WP_Auth0_Options.php
@@ -244,7 +244,7 @@ class WP_Auth0_Options extends WP_Auth0_Options_Generic {
 			'migration_token'           => null,
 			'migration_ips_filter'      => false,
 			'migration_ips'             => null,
-			'auto_login'                => 0,
+			'auto_login'                => 1,
 			'auto_login_method'         => '',
 			'auth0_implicit_workflow'   => false,
 			'valid_proxy_ip'            => null,


### PR DESCRIPTION
This PR changes the Universal Login Page setting to be on when the site is first installed. This will not change anything for existing sites. 
