### PR TITLE
Do not store the API token on install

### DIFF
--- a/lib/WP_Auth0_Api_Client.php
+++ b/lib/WP_Auth0_Api_Client.php
@@ -175,6 +175,7 @@ class WP_Auth0_Api_Client {
 	}
 
 	/**
+	 * TODO: Deprecate
 	 *
 	 * @param string $domain - tenant domain
 	 * @param string $access_token - access token with at least `openid` scope
@@ -251,6 +252,7 @@ class WP_Auth0_Api_Client {
 
 	/**
 	 * Get a single client via the Management API
+	 * TODO: Deprecate
 	 *
 	 * @see https://auth0.com/docs/api/management/v2#!/Clients/get_clients_by_id
 	 *
@@ -356,6 +358,9 @@ class WP_Auth0_Api_Client {
 		return json_decode( $response['body'] );
 	}
 
+	/**
+	 * TODO: Deprecate
+	 */
 	public static function update_client( $domain, $app_token, $client_id, $sso, $payload = array() ) {
 
 		$endpoint = "https://$domain/api/v2/clients/$client_id";
@@ -389,6 +394,9 @@ class WP_Auth0_Api_Client {
 		return json_decode( $response['body'] );
 	}
 
+	/**
+	 * TODO: Deprecate
+	 */
 	public static function create_rule( $domain, $app_token, $name, $script, $enabled = true ) {
 		$payload = array(
 			'name'    => $name,
@@ -428,6 +436,9 @@ class WP_Auth0_Api_Client {
 		return json_decode( $response['body'] );
 	}
 
+	/**
+	 * TODO: Deprecate
+	 */
 	public static function delete_rule( $domain, $app_token, $id ) {
 
 		$endpoint = "https://$domain/api/v2/rules/$id";
@@ -584,6 +595,9 @@ class WP_Auth0_Api_Client {
 		return json_decode( $response['body'] );
 	}
 
+	/**
+	 * TODO: Deprecate
+	 */
 	public static function get_connection( $domain, $app_token, $id ) {
 		$endpoint = "https://$domain/api/v2/connections/$id";
 
@@ -672,6 +686,9 @@ class WP_Auth0_Api_Client {
 		return json_decode( $response['body'] );
 	}
 
+	/**
+	 * TODO: Deprecate
+	 */
 	public static function update_user( $domain, $app_token, $id, $payload ) {
 		$endpoint = "https://$domain/api/v2/users/$id";
 

--- a/lib/initial-setup/WP_Auth0_InitialSetup_Consent.php
+++ b/lib/initial-setup/WP_Auth0_InitialSetup_Consent.php
@@ -3,7 +3,7 @@
 class WP_Auth0_InitialSetup_Consent {
 
 	protected $domain = 'auth0.auth0.com';
-
+	protected $access_token;
 	protected $a0_options;
 	protected $state;
 	protected $hasInternetConnection = true;
@@ -28,12 +28,10 @@ class WP_Auth0_InitialSetup_Consent {
 	 */
 	public function callback_with_token( $domain, $access_token, $type, $hasInternetConnection = true ) {
 
-		$this->a0_options->set( 'auth0_app_token', $access_token ); // NEED TO ADDRESS
 		$this->a0_options->set( 'domain', $domain );
-
+		$this->access_token          = $access_token;
+		$this->state                 = $type;
 		$this->hasInternetConnection = $hasInternetConnection;
-
-		$this->state = $type;
 
 		if ( ! in_array( $this->state, array( 'social', 'enterprise' ) ) ) {
 			wp_redirect( admin_url( 'admin.php?page=wpa0-setup&error=invalid_state' ) );
@@ -111,7 +109,6 @@ class WP_Auth0_InitialSetup_Consent {
 	public function consent_callback( $name ) {
 
 		$domain    = $this->a0_options->get( 'domain' );
-		$app_token = $this->a0_options->get( 'auth0_app_token' ); // NEED TO ADDRESS
 		$client_id = trim( $this->a0_options->get( 'client_id' ) );
 
 		/*
@@ -123,7 +120,7 @@ class WP_Auth0_InitialSetup_Consent {
 		if ( empty( $client_id ) ) {
 			$should_create_and_update_connection = true;
 
-			$client_response = WP_Auth0_Api_Client::create_client( $domain, $app_token, $name );
+			$client_response = WP_Auth0_Api_Client::create_client( $domain, $this->access_token, $name );
 
 			if ( $client_response === false ) {
 				wp_redirect( admin_url( 'admin.php?page=wpa0&error=cant_create_client' ) );
@@ -144,7 +141,7 @@ class WP_Auth0_InitialSetup_Consent {
 		$connection_exists     = false;
 		$connection_pwd_policy = null;
 
-		$connections = WP_Auth0_Api_Client::search_connection( $domain, $app_token, 'auth0' );
+		$connections = WP_Auth0_Api_Client::search_connection( $domain, $this->access_token, 'auth0' );
 
 		if ( $should_create_and_update_connection && ! empty( $connections ) && is_array( $connections ) ) {
 			foreach ( $connections as $connection ) {
@@ -166,7 +163,7 @@ class WP_Auth0_InitialSetup_Consent {
 				// Different Connection, update to remove the Application created above.
 				$u_connection                  = clone $connection;
 				$u_connection->enabled_clients = array_diff( $u_connection->enabled_clients, array( $client_id ) );
-				WP_Auth0_Api_Client::update_connection( $domain, $app_token, $u_connection->id, $u_connection );
+				WP_Auth0_Api_Client::update_connection( $domain, $this->access_token, $u_connection->id, $u_connection );
 			}
 		}
 
@@ -176,7 +173,7 @@ class WP_Auth0_InitialSetup_Consent {
 				$migration_token = JWT::urlsafeB64Encode( openssl_random_pseudo_bytes( 64 ) );
 				$operations      = new WP_Auth0_Api_Operations( $this->a0_options );
 				$response        = $operations->create_wordpress_connection(
-					$this->a0_options->get( 'auth0_app_token' ), // NEED TO ADDRESS
+					$this->access_token,
 					$this->hasInternetConnection,
 					'fair',
 					$migration_token
@@ -200,7 +197,7 @@ class WP_Auth0_InitialSetup_Consent {
 		 * Create Client Grant
 		 */
 
-		$grant_response = WP_Auth0_Api_Client::create_client_grant( $app_token, $client_id );
+		$grant_response = WP_Auth0_Api_Client::create_client_grant( $this->access_token, $client_id );
 
 		if ( false === $grant_response ) {
 			wp_redirect( admin_url( 'admin.php?page=wpa0&error=cant_create_client_grant' ) );

--- a/tests/testInitialSetupConsent.php
+++ b/tests/testInitialSetupConsent.php
@@ -45,7 +45,7 @@ class TestInitialSetupConsent extends WP_Auth0_Test_Case {
 		$this->assertContains( 'error=invalid_state', $redirect_url['query'] );
 
 		$this->assertEquals( $test_domain, self::$opts->get( 'domain' ) );
-		$this->assertEquals( $test_token, self::$opts->get( 'auth0_app_token' ) );
+		$this->assertNull( self::$opts->get( 'auth0_app_token' ) );
 
 		$this->assertEmpty( self::$error_log->get() );
 	}


### PR DESCRIPTION
### Changes

- Change the Setup Wizard to no longer store the API token used in preparation for removing the App Token setting. 
- Add TODO comments for deprecations before release.

### References

Continues the work from #637 and #632 to remove the App Token field (use a Client Credentials grant for Management API work and store in a expiring transient).

### Testing

This can be tested manually by installing the plugin from scratch on a new site. Expect no changes to behavior.

* [x] This change adds unit test coverage
* [x] This change has been tested on WP 5.1.1

### Checklist

* [x] All existing and new tests complete without errors
* [x] All code quality tools/guidelines in the [Contribution guide](CONTRIBUTION.md) have been run/followed
* [x] All active GitHub CI checks have passed
