### PR TITLE
Add ability to generate a new migration token

### DIFF
--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -42,12 +42,7 @@ jQuery(document).ready(function($) {
     Generic form confirm stop
      */
     $('form.js-a0-confirm-submit').submit(function (e) {
-        var message = $(this).attr('data-confirm-msg');
-        if ( !message || !message.length ) {
-            message = wpa0.form_confirm_submit_msg;
-        }
-
-        if ( ! window.confirm(message) ) {
+        if ( ! confirmToContinue($(this)) ) {
             e.preventDefault();
         }
     });
@@ -124,14 +119,38 @@ jQuery(document).ready(function($) {
     var $deleteCacheButton = $( '#' + deleteCacheId );
     $deleteCacheButton.click( function(e) {
         e.preventDefault();
-        $deleteCacheButton.prop( 'disabled', true ).val( wpa0.clear_cache_working );
+        $deleteCacheButton.prop( 'disabled', true ).text( wpa0.ajax_working );
         var postData = {
             'action': deleteCacheId,
             '_ajax_nonce': wpa0.clear_cache_nonce
         };
 
         $.post(wpa0.ajax_url, postData, function() {
-            $deleteCacheButton.prop( 'disabled', false ).val( wpa0.clear_cache_done );
+            $deleteCacheButton.prop( 'disabled', false ).text( wpa0.ajax_done );
+        }, 'json');
+    } );
+
+    /*
+    Clear cache button on Basic settings page
+     */
+    var rotateMigrationTokenId = 'auth0_rotate_migration_token';
+    var $rotateMigrationTokenButton = $( '#' + rotateMigrationTokenId );
+    $rotateMigrationTokenButton.click( function(e) {
+        e.preventDefault();
+
+        if (!confirmToContinue($rotateMigrationTokenButton) ) {
+            return;
+        }
+
+        $rotateMigrationTokenButton.prop( 'disabled', true ).text( wpa0.ajax_working );
+        var postData = {
+            'action': rotateMigrationTokenId,
+            '_ajax_nonce': wpa0.rotate_token_nonce
+        };
+
+        $.post(wpa0.ajax_url, postData, function() {
+            $( '#auth0_migration_token' ).text(wpa0.refresh_prompt);
+            $rotateMigrationTokenButton.remove();
         }, 'json');
     } );
 
@@ -162,6 +181,20 @@ jQuery(document).ready(function($) {
         e.preventDefault();
         $('#profile-form').submit();
     });
+
+  /**
+   *
+   * @param $el
+   * @returns {boolean}
+   */
+  function confirmToContinue( $el ) {
+      var message = $el.attr('data-confirm-msg');
+      if ( !message || !message.length ) {
+        message = wpa0.form_confirm_submit_msg;
+      }
+
+      return window.confirm(message);
+    }
 
     /**
      * Can we use localStorage?

--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -42,7 +42,7 @@ jQuery(document).ready(function($) {
     Generic form confirm stop
      */
     $('form.js-a0-confirm-submit').submit(function (e) {
-        if ( ! confirmToContinue($(this)) ) {
+        if ( cancelAction($(this)) ) {
             e.preventDefault();
         }
     });
@@ -131,26 +131,25 @@ jQuery(document).ready(function($) {
     } );
 
     /*
-    Clear cache button on Basic settings page
+    Generate new migration token button on Advanced settings page
      */
-    var rotateMigrationTokenId = 'auth0_rotate_migration_token';
-    var $rotateMigrationTokenButton = $( '#' + rotateMigrationTokenId );
-    $rotateMigrationTokenButton.click( function(e) {
+    var rotateTokenId = 'auth0_rotate_migration_token';
+    var $rotateTokenButton = $( '#' + rotateTokenId );
+    $rotateTokenButton.click( function(e) {
         e.preventDefault();
 
-        if (!confirmToContinue($rotateMigrationTokenButton) ) {
+        if (cancelAction($rotateTokenButton) ) {
             return;
         }
 
-        $rotateMigrationTokenButton.prop( 'disabled', true ).text( wpa0.ajax_working );
+        $rotateTokenButton.prop( 'disabled', true ).text( wpa0.ajax_working );
         var postData = {
-            'action': rotateMigrationTokenId,
+            'action': rotateTokenId,
             '_ajax_nonce': wpa0.rotate_token_nonce
         };
-
         $.post(wpa0.ajax_url, postData, function() {
             $( '#auth0_migration_token' ).text(wpa0.refresh_prompt);
-            $rotateMigrationTokenButton.remove();
+            $rotateTokenButton.remove();
         }, 'json');
     } );
 
@@ -183,17 +182,19 @@ jQuery(document).ready(function($) {
     });
 
   /**
+   * Show a JS confirm box to give a chance to cancel an on-page action.
    *
-   * @param $el
+   * @param {object} $el - jQuery selector for confirmation message.
+   *
    * @returns {boolean}
    */
-  function confirmToContinue( $el ) {
+  function cancelAction( $el ) {
       var message = $el.attr('data-confirm-msg');
       if ( !message || !message.length ) {
         message = wpa0.form_confirm_submit_msg;
       }
 
-      return window.confirm(message);
+      return !window.confirm(message);
     }
 
     /**

--- a/lib/admin/WP_Auth0_Admin.php
+++ b/lib/admin/WP_Auth0_Admin.php
@@ -35,9 +35,11 @@ class WP_Auth0_Admin {
 			array(
 				'media_title'             => __( 'Choose your icon', 'wp-auth0' ),
 				'media_button'            => __( 'Choose icon', 'wp-auth0' ),
-				'clear_cache_working'     => __( 'Working ...', 'wp-auth0' ),
-				'clear_cache_done'        => __( 'Done!', 'wp-auth0' ),
+				'ajax_working'            => __( 'Working ...', 'wp-auth0' ),
+				'ajax_done'               => __( 'Done!', 'wp-auth0' ),
+				'refresh_prompt'          => __( 'Save or refresh this page to see changes.', 'wp-auth0' ),
 				'clear_cache_nonce'       => wp_create_nonce( 'auth0_delete_cache_transient' ),
+				'rotate_token_nonce'      => wp_create_nonce( WP_Auth0_Admin_Advanced::ROTATE_TOKEN_NONCE_ACTION ),
 				'form_confirm_submit_msg' => __( 'Are you sure?', 'wp-auth0' ),
 				'ajax_url'                => admin_url( 'admin-ajax.php' ),
 			)

--- a/lib/admin/WP_Auth0_Admin_Basic.php
+++ b/lib/admin/WP_Auth0_Admin_Basic.php
@@ -222,7 +222,7 @@ class WP_Auth0_Admin_Basic extends WP_Auth0_Admin_Generic {
 	public function render_cache_expiration( $args = array() ) {
 		$this->render_text_field( $args['label_for'], $args['opt_name'], 'number' );
 		printf(
-			' <input type="button" id="auth0_delete_cache_transient" value="%s" class="button button-secondary">',
+			' <button id="auth0_delete_cache_transient" class="button button-secondary">%s</button>',
 			__( 'Delete Cache', 'wp-auth0' )
 		);
 		$this->render_field_description( __( 'JWKS cache expiration in minutes (use 0 for no caching)', 'wp-auth0' ) );

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -6,7 +6,6 @@
  */
 
 ini_set( 'error_log', '/dev/null' );
-echo 'PHP version: ' . phpversion() . "\n";
 
 $_tests_dir = getenv( 'WP_TESTS_DIR' );
 

--- a/tests/testOptionMigrationWs.php
+++ b/tests/testOptionMigrationWs.php
@@ -140,25 +140,17 @@ class TestOptionMigrationWs extends WP_Auth0_Test_Case {
 	 * Test that the AJAX rotate token endpoint saves a new token when the endpoint succeeds.
 	 */
 	public function testThatAjaxTokenRotationSavesNewToken() {
-		$this->startAjaxHalting();
+		$this->startAjaxReturn();
 
 		$old_token = uniqid();
 		self::$opts->set( 'migration_token', $old_token );
 
 		ob_start();
-		$caught_exception = false;
-		$error_msg        = 'No exception';
-		try {
-			$_REQUEST['_ajax_nonce'] = wp_create_nonce( 'auth0_rotate_migration_token' );
-			self::$admin->auth0_rotate_migration_token();
-		} catch ( Exception $e ) {
-			$error_msg        = $e->getMessage();
-			$caught_exception = ( 'die_ajax' === $error_msg );
-		}
-		$return_json = ob_get_clean();
+		$_REQUEST['_ajax_nonce'] = wp_create_nonce( 'auth0_rotate_migration_token' );
+		self::$admin->auth0_rotate_migration_token();
+		$return_json = explode( PHP_EOL, ob_get_clean() );
 
-		$this->assertTrue( $caught_exception, $error_msg );
-		$this->assertEquals( '{"success":true}', $return_json );
+		$this->assertEquals( '{"success":true}', end( $return_json ) );
 		$this->assertNotEquals( $old_token, self::$opts->get( 'migration_token' ) );
 		$this->assertGreaterThanOrEqual( 64, strlen( self::$opts->get( 'migration_token' ) ) );
 	}

--- a/tests/testOptionMigrationWs.php
+++ b/tests/testOptionMigrationWs.php
@@ -103,7 +103,7 @@ class TestOptionMigrationWs extends WP_Auth0_Test_Case {
 		$this->assertEquals( 'code-block', $code_block->item( 0 )->getAttribute( 'class' ) );
 		$this->assertEquals( 'auth0_migration_token', $code_block->item( 0 )->getAttribute( 'id' ) );
 		$this->assertEquals( 'disabled', $code_block->item( 0 )->getAttribute( 'disabled' ) );
-		$this->assertEquals( self::$opts->get( 'migration_token' ), $code_block->item( 0 )->nodeValue );
+		$this->assertEquals( 'No migration token', $code_block->item( 0 )->nodeValue );
 
 		$token_button = $this->getDomListFromTagName( $field_html, 'button' );
 		$this->assertEquals( 'auth0_rotate_migration_token', $token_button->item( 0 )->getAttribute( 'id' ) );

--- a/tests/testOptionMigrationWs.php
+++ b/tests/testOptionMigrationWs.php
@@ -12,6 +12,8 @@
  */
 class TestOptionMigrationWs extends WP_Auth0_Test_Case {
 
+	use AjaxHelpers;
+
 	use DomDocumentHelpers;
 
 	use UsersHelper;
@@ -30,6 +32,135 @@ class TestOptionMigrationWs extends WP_Auth0_Test_Case {
 		parent::setUp();
 		$router      = new WP_Auth0_Routes( self::$opts );
 		self::$admin = new WP_Auth0_Admin_Advanced( self::$opts, $router );
+	}
+
+	/**
+	 * Test that the migration WS setting field is rendered properly.
+	 */
+	public function testThatSettingsFieldRendersProperly() {
+		$field_args = [
+			'label_for' => 'wpa0_migration_ws',
+			'opt_name'  => 'migration_ws',
+		];
+
+		// Get the field HTML.
+		ob_start();
+		self::$admin->render_migration_ws( $field_args );
+		$field_html = ob_get_clean();
+
+		$input = $this->getDomListFromTagName( $field_html, 'input' );
+		$this->assertEquals( 1, $input->length );
+		$this->assertEquals( $field_args['label_for'], $input->item( 0 )->getAttribute( 'id' ) );
+		$this->assertEquals( 'checkbox', $input->item( 0 )->getAttribute( 'type' ) );
+		$this->assertEquals(
+			self::OPTIONS_NAME . '[' . $field_args['opt_name'] . ']',
+			$input->item( 0 )->getAttribute( 'name' )
+		);
+	}
+
+	/**
+	 * Test that correct settings field documentation appears when the setting is off.
+	 */
+	public function testThatCorrectFieldDocsShowWhenMigrationIsOff() {
+		$field_args = [
+			'label_for' => 'wpa0_migration_ws',
+			'opt_name'  => 'migration_ws',
+		];
+
+		$this->assertFalse( self::$opts->get( $field_args['opt_name'] ) );
+
+		// Get the field HTML.
+		ob_start();
+		self::$admin->render_migration_ws( $field_args );
+		$field_html = ob_get_clean();
+
+		$this->assertContains( 'User migration endpoints deactivated', $field_html );
+		$this->assertContains( 'Custom database connections can be deactivated', $field_html );
+		$this->assertContains( 'https://manage.auth0.com/#/connections/database', $field_html );
+	}
+
+	/**
+	 * Test that correct settings field documentation and additional controls appear when the setting is on.
+	 */
+	public function testThatCorrectFieldDocsShowWhenMigrationIsOn() {
+		$field_args = [
+			'label_for' => 'wpa0_migration_ws',
+			'opt_name'  => 'migration_ws',
+		];
+
+		self::$opts->set( $field_args['opt_name'], 1 );
+
+		// Get the field HTML.
+		ob_start();
+		self::$admin->render_migration_ws( $field_args );
+		$field_html = ob_get_clean();
+
+		$this->assertContains( 'User migration endpoints activated', $field_html );
+		$this->assertContains( 'The custom database scripts need to be configured manually', $field_html );
+		$this->assertContains( 'https://auth0.com/docs/cms/wordpress/user-migration', $field_html );
+
+		$code_block = $this->getDomListFromTagName( $field_html, 'code' );
+		$this->assertEquals( 'code-block', $code_block->item( 0 )->getAttribute( 'class' ) );
+		$this->assertEquals( 'auth0_migration_token', $code_block->item( 0 )->getAttribute( 'id' ) );
+		$this->assertEquals( 'disabled', $code_block->item( 0 )->getAttribute( 'disabled' ) );
+		$this->assertEquals( self::$opts->get( 'migration_token' ), $code_block->item( 0 )->nodeValue );
+
+		$token_button = $this->getDomListFromTagName( $field_html, 'button' );
+		$this->assertEquals( 'auth0_rotate_migration_token', $token_button->item( 0 )->getAttribute( 'id' ) );
+		$this->assertEquals( 'Generate New Migration Token', trim( $token_button->item( 0 )->nodeValue ) );
+		$this->assertContains(
+			'This will change your migration token immediately',
+			$token_button->item( 0 )->getAttribute( 'data-confirm-msg' )
+		);
+		$this->assertContains(
+			'The new token must be changed in the custom scripts for your database Connection',
+			$token_button->item( 0 )->getAttribute( 'data-confirm-msg' )
+		);
+	}
+
+	/**
+	 * Test that the AJAX rotate token endpoint fails when there is a bad nonce value.
+	 */
+	public function testThatAjaxTokenRotationFailsWithBadNonce() {
+		$this->startAjaxHalting();
+
+		$caught_exception = false;
+		$error_msg        = 'No exception';
+		try {
+			$_REQUEST['_ajax_nonce'] = uniqid();
+			self::$admin->auth0_rotate_migration_token();
+		} catch ( Exception $e ) {
+			$error_msg        = $e->getMessage();
+			$caught_exception = ( 'bad_nonce' === $error_msg );
+		}
+		$this->assertTrue( $caught_exception, $error_msg );
+	}
+
+	/**
+	 * Test that the AJAX rotate token endpoint saves a new token when the endpoint succeeds.
+	 */
+	public function testThatAjaxTokenRotationSavesNewToken() {
+		$this->startAjaxHalting();
+
+		$old_token = uniqid();
+		self::$opts->set( 'migration_token', $old_token );
+
+		ob_start();
+		$caught_exception = false;
+		$error_msg        = 'No exception';
+		try {
+			$_REQUEST['_ajax_nonce'] = wp_create_nonce( 'auth0_rotate_migration_token' );
+			self::$admin->auth0_rotate_migration_token();
+		} catch ( Exception $e ) {
+			$error_msg        = $e->getMessage();
+			$caught_exception = ( 'die_ajax' === $error_msg );
+		}
+		$return_json = ob_get_clean();
+
+		$this->assertTrue( $caught_exception, $error_msg );
+		$this->assertEquals( '{"success":true}', $return_json );
+		$this->assertNotEquals( $old_token, self::$opts->get( 'migration_token' ) );
+		$this->assertGreaterThanOrEqual( 64, strlen( self::$opts->get( 'migration_token' ) ) );
 	}
 
 	/**


### PR DESCRIPTION
### Changes

Adds a button to generate a new migration token for user migration setups.

### References

- Fixes #620 
- [Pending Docs PR commit](https://github.com/auth0/docs/pull/7384/commits/b432d9a22e9be4d89d1dc6b9d2aa548c7a522252)

### Testing

[Failed tests for new field and functionality](https://circleci.com/gh/auth0/wp-auth0/453)

**Manual Steps:**

1. Paste the following in `wp-config.php`:

```php
define( 'AUTH0_ENV_MIGRATION_WS',  true );
define( 'AUTH0_ENV_MIGRATION_TOKEN', 'THIS_IS_MY_MIGRATION_TOKEN' );
```

2. Refresh the plugin settings page and see the constant-based settings:

![Screenshot 2019-03-25 16 00 22](https://user-images.githubusercontent.com/855223/54959683-1fed5380-4f17-11e9-93bd-784b135906ff.png)

3. Save the settings page
4. Comment out the `AUTH0_ENV_MIGRATION_TOKEN` definition added above
5. Refresh the settings page to see an empty migration token:

![Screenshot 2019-03-25 16 05 31](https://user-images.githubusercontent.com/855223/54959897-dbae8300-4f17-11e9-9301-3d561f2209d8.png)

6. Click the **Generate New Migration Token** button
7. See the alert message:

![Screenshot 2019-03-25 15 48 33](https://user-images.githubusercontent.com/855223/54959729-40b5a900-4f17-11e9-989e-e4b241f2a823.png)

8. Click **Ok**
8. See "Save or refresh this page to see changes." in the migration token box:

![Screenshot 2019-03-25 16 06 04](https://user-images.githubusercontent.com/855223/54959918-ecf78f80-4f17-11e9-9046-13346a443051.png)

9. Refresh the page and see a token value 

![Screenshot 2019-03-25 16 06 27](https://user-images.githubusercontent.com/855223/54959930-f54fca80-4f17-11e9-8056-5e25a5ed3e5b.png)

* [x] I included manual testing steps above, if applicable
* [x] This change adds unit test coverage
* [x] This change has been tested on WP 5.1.1

### Checklist

* [x] All existing and new tests complete without errors
* [x] All code quality tools/guidelines in the [Contribution guide](CONTRIBUTION.md) have been run/followed
* [x] All active GitHub CI checks have passed
