### PR TITLE
Replace get_client_token with WP_Auth0_Api_Client_Credentials

### DIFF
--- a/lib/WP_Auth0_Api_Client.php
+++ b/lib/WP_Auth0_Api_Client.php
@@ -134,11 +134,13 @@ class WP_Auth0_Api_Client {
 
 	/**
 	 * Get a client_credentials token using default stored connection info
-	 * TODO: Change implementations to use WP_Auth0_Api_Abstract and deprecate.
+	 * TODO: Deprecate
 	 *
 	 * @since 3.4.1
 	 *
 	 * @return bool|string
+	 *
+	 * @codeCoverageIgnore - Deprecated
 	 */
 	public static function get_client_token() {
 

--- a/lib/WP_Auth0_LoginManager.php
+++ b/lib/WP_Auth0_LoginManager.php
@@ -302,7 +302,8 @@ class WP_Auth0_LoginManager {
 		);
 
 		// Attempt to authenticate with the Management API.
-		$client_credentials_token = WP_Auth0_Api_Client::get_client_token();
+		$client_credentials_api   = new WP_Auth0_Api_Client_Credentials( $this->a0_options );
+		$client_credentials_token = $client_credentials_api->call();
 
 		if ( $client_credentials_token ) {
 			$userinfo_resp      = WP_Auth0_Api_Client::get_user( $domain, $client_credentials_token, $decoded_token->sub );

--- a/lib/api/WP_Auth0_Api_Abstract.php
+++ b/lib/api/WP_Auth0_Api_Abstract.php
@@ -182,10 +182,15 @@ abstract class WP_Auth0_Api_Abstract {
 	 */
 	protected function set_bearer( $scope ) {
 
-		$api_token = WP_Auth0_Api_Client_Credentials::get_stored_token();
+		if ( ! $this->api_client_creds instanceof WP_Auth0_Api_Client_Credentials ) {
+			return false;
+		}
+
+		$cc_api    = $this->api_client_creds;
+		$api_token = $cc_api::get_stored_token();
 
 		// No stored API token so need to get a new one.
-		if ( ! $api_token && $this->api_client_creds instanceof WP_Auth0_Api_Client_Credentials ) {
+		if ( ! $api_token ) {
 			$api_token = $this->api_client_creds->call();
 		}
 
@@ -194,7 +199,7 @@ abstract class WP_Auth0_Api_Abstract {
 			return false;
 		}
 
-		if ( WP_Auth0_Api_Client_Credentials::check_stored_scope( $scope ) ) {
+		if ( $cc_api::check_stored_scope( $scope ) ) {
 			// Scope exists, add to the header and cache.
 			$this->add_header( 'Authorization', 'Bearer ' . $api_token );
 			return true;
@@ -211,7 +216,7 @@ abstract class WP_Auth0_Api_Abstract {
 		);
 
 		// Delete the stored token so we can try again.
-		WP_Auth0_Api_Client_Credentials::delete_store();
+		$cc_api::delete_store();
 		return false;
 	}
 


### PR DESCRIPTION
### Changes

Internals change to use `WP_Auth0_Api_Client_Credentials` instead of `WP_Auth0_Api_Client` and use injected class instance in `set_bearer` rather than the global class.

### Testing

Internal only, no testing changes needed. 

### Checklist

* [x] All existing and new tests complete without errors
* [x] All code quality tools/guidelines in the [Contribution guide](CONTRIBUTION.md) have been run/followed
* [x] All active GitHub CI checks have passed
