### PR TITLE
Remove Delete MFA control on user profile; add link to user in dashboard

### DIFF
--- a/WP_Auth0.php
+++ b/WP_Auth0.php
@@ -172,10 +172,6 @@ class WP_Auth0 {
 		$profile_delete_data = new WP_Auth0_Profile_Delete_Data( $users_repo );
 		$profile_delete_data->init();
 
-		$api_delete_mfa     = new WP_Auth0_Api_Delete_User_Mfa( $this->a0_options, $api_client_creds );
-		$profile_delete_mfa = new WP_Auth0_Profile_Delete_Mfa( $this->a0_options, $api_delete_mfa );
-		$profile_delete_mfa->init();
-
 		WP_Auth0_Email_Verification::init();
 	}
 

--- a/assets/js/edit-user-profile.js
+++ b/assets/js/edit-user-profile.js
@@ -6,7 +6,6 @@ jQuery(function($) {
     var passwordFieldRow = $('#password');
     var emailField = $('input[name=email]');
     var deleteUserDataButton = $('#auth0_delete_data');
-    var deleteMfaDataButton = $('#auth0_delete_mfa');
 
     /**
      * Hide the password field if not an Auth0 strategy.
@@ -34,17 +33,6 @@ jQuery(function($) {
         }
         e.preventDefault();
         userProfileAjaxAction($(this), 'auth0_delete_data', wpa0UserProfile.deleteIdNonce );
-    });
-
-    /**
-     * Delete MFA Provider button click.
-     */
-    deleteMfaDataButton.click(function (e) {
-        if ( ! window.confirm(wpa0UserProfile.i18n.confirmDeleteMfa) ) {
-            return;
-        }
-        e.preventDefault();
-        userProfileAjaxAction($(this), 'auth0_delete_mfa', wpa0UserProfile.deleteMfaNonce);
     });
 
     /**

--- a/lib/WP_Auth0_EditProfile.php
+++ b/lib/WP_Auth0_EditProfile.php
@@ -92,7 +92,6 @@ class WP_Auth0_EditProfile {
 				'ajaxUrl'        => admin_url( 'admin-ajax.php' ),
 				'i18n'           => array(
 					'confirmDeleteId'   => __( 'Are you sure you want to delete the Auth0 user data for this user?', 'wp-auth0' ),
-					'confirmDeleteMfa'  => __( 'Are you sure you want to delete the Auth0 MFA data for this user?', 'wp-auth0' ),
 					'actionComplete'    => __( 'Deleted', 'wp-auth0' ),
 					'actionFailed'      => __( 'Action failed, please see the Auth0 error log for details.', 'wp-auth0' ),
 					'cannotChangeEmail' => __( 'Email cannot be changed for non-database connections.', 'wp-auth0' ),

--- a/lib/api/WP_Auth0_Api_Delete_User_Mfa.php
+++ b/lib/api/WP_Auth0_Api_Delete_User_Mfa.php
@@ -9,6 +9,7 @@
 
 /**
  * Class WP_Auth0_Api_Delete_User_Mfa to perform a client credentials grant.
+ * TODO: Deprecate
  */
 class WP_Auth0_Api_Delete_User_Mfa extends WP_Auth0_Api_Abstract {
 
@@ -33,6 +34,7 @@ class WP_Auth0_Api_Delete_User_Mfa extends WP_Auth0_Api_Abstract {
 
 	/**
 	 * WP_Auth0_Api_Delete_User_Mfa constructor.
+	 * TODO: Deprecate
 	 *
 	 * @param WP_Auth0_Options                $options - WP_Auth0_Options instance.
 	 * @param WP_Auth0_Api_Client_Credentials $api_client_creds - WP_Auth0_Api_Client_Credentials instance.

--- a/lib/profile/WP_Auth0_Profile_Delete_Data.php
+++ b/lib/profile/WP_Auth0_Profile_Delete_Data.php
@@ -51,7 +51,8 @@ class WP_Auth0_Profile_Delete_Data {
 			return;
 		}
 
-		if ( ! get_auth0userinfo( $GLOBALS['user_id'] ) ) {
+		$auth0_user = get_auth0userinfo( $GLOBALS['user_id'] );
+		if ( ! $auth0_user ) {
 			return;
 		}
 
@@ -64,6 +65,10 @@ class WP_Auth0_Profile_Delete_Data {
 				<td>
 					<input type="button" id="auth0_delete_data" class="button button-secondary"
 						value="<?php _e( 'Delete Auth0 Data', 'wp-auth0' ); ?>" />
+					<br><br>
+					<a href="https://manage.auth0.com/#/users/<?php echo rawurlencode( $auth0_user->sub ); ?>" target="_blank">
+						<?php _e( 'View in Auth0', 'wp-auth0' ); ?>
+					</a>
 				</td>
 			</tr>
 		</table>

--- a/lib/profile/WP_Auth0_Profile_Delete_Mfa.php
+++ b/lib/profile/WP_Auth0_Profile_Delete_Mfa.php
@@ -10,6 +10,7 @@
 /**
  * Class WP_Auth0_Profile_Delete_Mfa.
  * Provides UI and AJAX handlers to delete a user's MFA.
+ * TODO: Deprecate
  */
 class WP_Auth0_Profile_Delete_Mfa {
 
@@ -29,6 +30,7 @@ class WP_Auth0_Profile_Delete_Mfa {
 
 	/**
 	 * WP_Auth0_Profile_Delete_Mfa constructor.
+	 * TODO: Deprecate
 	 *
 	 * @param WP_Auth0_Options             $a0_options - WP_Auth0_Options instance.
 	 * @param WP_Auth0_Api_Delete_User_Mfa $api_delete_mfa - WP_Auth0_Api_Delete_User_Mfa instance.

--- a/tests/testProfileDeleteMfa.php
+++ b/tests/testProfileDeleteMfa.php
@@ -60,30 +60,6 @@ class TestProfileDeleteMfa extends WP_Auth0_Test_Case {
 	}
 
 	/**
-	 * Test that correct hooks are loaded
-	 */
-	public function testInitHooks() {
-
-		$expect_hooked = [
-			'show_delete_mfa' => [
-				'priority'      => 10,
-				'accepted_args' => 1,
-			],
-		];
-		// Same method hooked to both actions.
-		$this->assertHooked( 'edit_user_profile', 'WP_Auth0_Profile_Delete_Mfa', $expect_hooked );
-		$this->assertHooked( 'show_user_profile', 'WP_Auth0_Profile_Delete_Mfa', $expect_hooked );
-
-		$expect_hooked = [
-			'delete_mfa' => [
-				'priority'      => 10,
-				'accepted_args' => 1,
-			],
-		];
-		$this->assertHooked( 'wp_ajax_auth0_delete_mfa', 'WP_Auth0_Profile_Delete_Mfa', $expect_hooked );
-	}
-
-	/**
 	 * Test that an AJAX call with no nonce fails.
 	 */
 	public function testThatAjaxFailsWithNoNonce() {


### PR DESCRIPTION
### Changes

The **Delete MFA** control on the user profile was not playing nicely with how MFA is deleted. Since we have not had any reports about it, this PR removes the control and adds a link to the user in the Auth0 dashboard where MFA changes can be made directly.

### Checklist

* [x] All existing and new tests complete without errors
* [x] All code quality tools/guidelines in the [Contribution guide](CONTRIBUTION.md) have been run/followed
* [ ] All active GitHub CI checks have passed
