### PR TITLE
Fix all translate-able text issues

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,6 +32,7 @@
     "scripts": {
         "compat": "\"vendor/bin/phpcs\" --standard=phpcs-compat-ruleset.xml .",
         "phpcs": "\"vendor/bin/phpcs\"",
+        "phpcs-i18n": "\"vendor/bin/phpcs\" --sniffs=WordPress.WP.I18n ./lib/",
         "phpcs-tests": "\"vendor/bin/phpcs\" --standard=phpcs-test-ruleset.xml -s ./tests/",
         "phpcbf": "\"vendor/bin/phpcbf\"",
         "phpcbf-tests": "\"vendor/bin/phpcbf\" --standard=phpcs-test-ruleset.xml -s ./tests/",

--- a/lib/WP_Auth0_Amplificator.php
+++ b/lib/WP_Auth0_Amplificator.php
@@ -1,5 +1,5 @@
 <?php
-
+// phpcs:ignoreFile
 /**
  * Class WP_Auth0_Amplificator
  *

--- a/lib/WP_Auth0_Api_Client.php
+++ b/lib/WP_Auth0_Api_Client.php
@@ -509,6 +509,7 @@ class WP_Auth0_Api_Client {
 			WP_Auth0_ErrorManager::insert_auth0_error(
 				__METHOD__,
 				sprintf(
+					// translators: placeholders are machine names stored for this WP instance and must be included.
 					__( 'A client grant for %1$s to %2$s already exists. Make sure this grant at least includes %3$s.', 'wp-auth0' ),
 					self::get_connect_info( 'client_id' ),
 					self::get_connect_info( 'audience' ),

--- a/lib/WP_Auth0_Configure_JWTAUTH.php
+++ b/lib/WP_Auth0_Configure_JWTAUTH.php
@@ -1,5 +1,5 @@
 <?php
-
+// phpcs:ignoreFile
 /**
  * Class WP_Auth0_Configure_JWTAUTH
  *

--- a/lib/WP_Auth0_CustomDBLib.php
+++ b/lib/WP_Auth0_CustomDBLib.php
@@ -1,4 +1,5 @@
 <?php
+// phpcs:ignoreFile
 /**
  * Contains class WP_Auth0_CustomDBLib
  *
@@ -9,6 +10,8 @@
 
 /**
  * Class WP_Auth0_CustomDBLib
+ *
+ * @deprecated - 3.9.0, moved to separate files in lib/scripts-js.
  *
  * @codeCoverageIgnore - Deprecated.
  */

--- a/lib/WP_Auth0_DBManager.php
+++ b/lib/WP_Auth0_DBManager.php
@@ -225,6 +225,7 @@ class WP_Auth0_DBManager {
 					<p>
 					<?php
 						printf(
+							// translators: Placeholder is the plugin version.
 							__( 'WP-Auth0 has upgraded to %s but could not complete the upgrade in your Auth0 dashboard.', 'wp-auth0' ),
 							WPA0_VERSION
 						);

--- a/lib/WP_Auth0_Embed_Widget.php
+++ b/lib/WP_Auth0_Embed_Widget.php
@@ -5,8 +5,8 @@ class WP_Auth0_Embed_Widget extends WP_Widget {
 	function __construct() {
 		parent::__construct(
 			$this->getWidgetId(),
-			__( $this->getWidgetName(), 'wp_auth0_widget_domain' ),
-			array( 'description' => __( $this->getWidgetDescription(), 'wpb_widget_domain' ) )
+			$this->getWidgetName(),
+			array( 'description' => $this->getWidgetDescription() )
 		);
 	}
 

--- a/lib/WP_Auth0_Lock_Options.php
+++ b/lib/WP_Auth0_Lock_Options.php
@@ -1,5 +1,5 @@
 <?php
-
+// phpcs:ignoreFile
 /**
  * Class WP_Auth0_Lock_Options.
  *

--- a/lib/WP_Auth0_Metrics.php
+++ b/lib/WP_Auth0_Metrics.php
@@ -1,4 +1,5 @@
 <?php
+// phpcs:ignoreFile
 /**
  * @deprecated - 3.8.0, not used and no replacement provided.
  *

--- a/lib/WP_Auth0_Referer_Check.php
+++ b/lib/WP_Auth0_Referer_Check.php
@@ -1,4 +1,5 @@
 <?php
+// phpcs:ignoreFile
 /**
  * @deprecated - 3.8.0, not used and no replacement provided.
  *

--- a/lib/WP_Auth0_SocialAmplification_Widget.php
+++ b/lib/WP_Auth0_SocialAmplification_Widget.php
@@ -1,5 +1,5 @@
 <?php
-
+// phpcs:ignoreFile
 /**
  * Class WP_Auth0_SocialAmplification_Widget
  *

--- a/lib/admin/WP_Auth0_Admin_Advanced.php
+++ b/lib/admin/WP_Auth0_Admin_Advanced.php
@@ -265,6 +265,7 @@ class WP_Auth0_Admin_Advanced extends WP_Auth0_Admin_Generic {
 			__( 'If this is empty, all enabled connections for this Application will be shown. ', 'wp-auth0' ) .
 			__( 'Separate multiple connection names with a comma. ', 'wp-auth0' ) .
 			sprintf(
+				// translators: HTML link to the Auth0 dashboard.
 				__( 'Connections listed here must already be active in your %s', 'wp-auth0' ),
 				$this->get_dashboard_link( 'connections/social' )
 			) .

--- a/lib/admin/WP_Auth0_Admin_Basic.php
+++ b/lib/admin/WP_Auth0_Admin_Basic.php
@@ -199,7 +199,7 @@ class WP_Auth0_Admin_Basic extends WP_Auth0_Admin_Generic {
 			$curr_value
 		);
 		$this->render_field_description(
-			__( 'This value can be found the Application settings in the ' ) .
+			__( 'This value can be found the Application settings in the ', 'wp-auth0' ) .
 			$this->get_dashboard_link( 'applications' ) .
 			__( ' under Show Advanced Settings > OAuth > "JsonWebToken Signature Algorithm"', 'wp-auth0' )
 		);
@@ -333,7 +333,7 @@ class WP_Auth0_Admin_Basic extends WP_Auth0_Admin_Generic {
 		$this->render_field_description(
 			__( 'Signups are currently ', 'wp-auth0' ) . '<b>' .
 			( $allow_signup ? __( 'enabled', 'wp-auth0' ) : __( 'disabled', 'wp-auth0' ) ) .
-			'</b>' . __( ' by this setting ' ) . $settings_text
+			'</b>' . __( ' by this setting ', 'wp-auth0' ) . $settings_text
 		);
 	}
 

--- a/lib/admin/WP_Auth0_Admin_Dashboard.php
+++ b/lib/admin/WP_Auth0_Admin_Dashboard.php
@@ -1,5 +1,5 @@
 <?php
-
+// phpcs:ignoreFile
 /**
  * Class WP_Auth0_Admin_Dashboard
  *

--- a/lib/admin/WP_Auth0_Admin_Features.php
+++ b/lib/admin/WP_Auth0_Admin_Features.php
@@ -237,6 +237,7 @@ class WP_Auth0_Admin_Features extends WP_Auth0_Admin_Generic {
 		$this->render_field_description(
 			__( 'Enter a name here to automatically use a single, specific connection to login . ', 'wp-auth0' ) .
 			sprintf(
+				// translators: Placeholder is an HTML link to the Auth0 dashboard.
 				__( 'Find the method name to use under Connections > [Connection Type] in your %s. ', 'wp-auth0' ),
 				$this->get_dashboard_link()
 			) .

--- a/lib/dashboard-widgets/WP_Auth0_Dashboard_Plugins_Age.php
+++ b/lib/dashboard-widgets/WP_Auth0_Dashboard_Plugins_Age.php
@@ -1,4 +1,5 @@
 <?php
+// phpcs:ignoreFile
 /**
  * Class WP_Auth0_Dashboard_Plugins_Age
  *

--- a/lib/dashboard-widgets/WP_Auth0_Dashboard_Plugins_Gender.php
+++ b/lib/dashboard-widgets/WP_Auth0_Dashboard_Plugins_Gender.php
@@ -1,4 +1,5 @@
 <?php
+// phpcs:ignoreFile
 /**
  * Class WP_Auth0_Dashboard_Plugins_Gender
  *

--- a/lib/dashboard-widgets/WP_Auth0_Dashboard_Plugins_Generic.php
+++ b/lib/dashboard-widgets/WP_Auth0_Dashboard_Plugins_Generic.php
@@ -1,4 +1,5 @@
 <?php
+// phpcs:ignoreFile
 /**
  * Class WP_Auth0_Dashboard_Plugins_Generic
  *

--- a/lib/dashboard-widgets/WP_Auth0_Dashboard_Plugins_IdP.php
+++ b/lib/dashboard-widgets/WP_Auth0_Dashboard_Plugins_IdP.php
@@ -1,4 +1,5 @@
 <?php
+// phpcs:ignoreFile
 /**
  * Class WP_Auth0_Dashboard_Plugins_IdP
  *

--- a/lib/dashboard-widgets/WP_Auth0_Dashboard_Plugins_Income.php
+++ b/lib/dashboard-widgets/WP_Auth0_Dashboard_Plugins_Income.php
@@ -1,4 +1,5 @@
 <?php
+// phpcs:ignoreFile
 /**
  * Class WP_Auth0_Dashboard_Plugins_Income
  *

--- a/lib/dashboard-widgets/WP_Auth0_Dashboard_Plugins_Location.php
+++ b/lib/dashboard-widgets/WP_Auth0_Dashboard_Plugins_Location.php
@@ -1,4 +1,5 @@
 <?php
+// phpcs:ignoreFile
 /**
  * Class WP_Auth0_Dashboard_Plugins_Location
  *

--- a/lib/dashboard-widgets/WP_Auth0_Dashboard_Plugins_Signups.php
+++ b/lib/dashboard-widgets/WP_Auth0_Dashboard_Plugins_Signups.php
@@ -1,4 +1,5 @@
 <?php
+// phpcs:ignoreFile
 /**
  * Class WP_Auth0_Dashboard_Plugins_Signups
  *

--- a/lib/dashboard-widgets/WP_Auth0_Dashboard_Widgets.php
+++ b/lib/dashboard-widgets/WP_Auth0_Dashboard_Widgets.php
@@ -1,4 +1,5 @@
 <?php
+// phpcs:ignoreFile
 /**
  * Class WP_Auth0_Dashboard_Widgets
  *

--- a/lib/initial-setup/WP_Auth0_InitialSetup.php
+++ b/lib/initial-setup/WP_Auth0_InitialSetup.php
@@ -143,15 +143,15 @@ class WP_Auth0_InitialSetup {
 					<?php echo __( 'There was an error creating the necessary client grants. ', 'wp-auth0' ); ?>
 					<?php
 					echo __(
-						'Go to your Auth0 dashboard > APIs > Auth0 Management API > Non-Interactive Clients'
-								   . ' tab and authorize the client for this site. ',
+						'Go to your Auth0 dashboard > APIs > Auth0 Management API > Machine to Machine Applications tab and authorize this Application. ',
 						'wp-auth0'
 					);
 					?>
 					<?php echo __( 'Make sure to add the following scopes: ', 'wp-auth0' ); ?>
 					<code><?php echo implode( '</code>, <code>', WP_Auth0_Api_Client::get_required_scopes() ); ?></code>
 					<?php echo __( 'You can also check the ', 'wp-auth0' ); ?>
-					<a target="_blank" href="<?php echo admin_url( 'admin.php?page=wpa0-errors' ); ?>"><?php echo __( 'Error log', 'wp-auth0' ); ?></a> <?php echo __( ' for more information.' ); ?>
+					<a target="_blank" href="<?php echo admin_url( 'admin.php?page=wpa0-errors' ); ?>"><?php echo __( 'Error log', 'wp-auth0' ); ?></a>
+					<?php echo __( ' for more information.', 'wp-auth0' ); ?>
 				</strong>
 			</p>
 		</div>
@@ -159,14 +159,15 @@ class WP_Auth0_InitialSetup {
 	}
 
 	public function cant_exchange_token_message() {
-		$domain = $this->a0_options->get( 'domain' );
 		?>
 		  <div id="message" class="error">
 			  <p>
 				  <strong>
 					<?php echo __( 'There was an error retrieving your Auth0 credentials. Check the ', 'wp-auth0' ); ?>
-					  <a target="_blank" href="<?php echo admin_url( 'admin.php?page=wpa0-errors' ); ?>"><?php echo __( 'Error log', 'wp-auth0' ); ?></a>
-					<?php echo __( ' for more information. Please check that your server has internet access and can reach "https://' . $domain . '/" ', 'wp-auth0' ); ?>
+					<a target="_blank" href="<?php echo admin_url( 'admin.php?page=wpa0-errors' ); ?>"><?php echo __( 'Error log', 'wp-auth0' ); ?></a>
+					<?php echo __( ' for more information.', 'wp-auth0' ); ?>
+					<?php echo __( 'Please check that your server has internet access and can reach ', 'wp-auth0' ); ?>
+					<code>https://<?php echo $this->a0_options->get( 'domain' ); ?></code>
 				  </strong>
 			  </p>
 		  </div>

--- a/lib/initial-setup/WP_Auth0_InitialSetup_Migration.php
+++ b/lib/initial-setup/WP_Auth0_InitialSetup_Migration.php
@@ -1,4 +1,5 @@
 <?php
+// phpcs:ignoreFile
 /**
  * @deprecated - 3.8.0, not used and no replacement provided.
  *

--- a/lib/initial-setup/WP_Auth0_InitialSetup_Rules.php
+++ b/lib/initial-setup/WP_Auth0_InitialSetup_Rules.php
@@ -1,4 +1,5 @@
 <?php
+// phpcs:ignoreFile
 /**
  * @deprecated - 3.8.0, not used and no replacement provided.
  *

--- a/lib/initial-setup/WP_Auth0_InitialSetup_Signup.php
+++ b/lib/initial-setup/WP_Auth0_InitialSetup_Signup.php
@@ -1,4 +1,5 @@
 <?php
+// phpcs:ignoreFile
 /**
  * @deprecated - 3.8.0, not used and no replacement provided.
  *

--- a/lib/twitter-api-php/TwitterAPIExchange.php
+++ b/lib/twitter-api-php/TwitterAPIExchange.php
@@ -1,5 +1,5 @@
 <?php
-
+// phpcs:ignoreFile
 /**
  * Twitter-API-PHP : Simple PHP wrapper for the v1.1 API
  *


### PR DESCRIPTION
### Changes

- Add translation issue scan to Composer scripts: `composer phpcs-i18n`
- Fix all issues from the scan above
- Add `phpcs:ignoreFile` directives to deprecated classes to skip scans for that file

### References

[WordPress i18n guidelines](https://codex.wordpress.org/I18n_for_WordPress_Developers)
