### PR TITLE
Set OIDC conformant for new installs

### DIFF
--- a/lib/WP_Auth0_Api_Client.php
+++ b/lib/WP_Auth0_Api_Client.php
@@ -335,6 +335,10 @@ class WP_Auth0_Api_Client {
 
 			// "Use Auth0 to do Single Sign On"
 			'sso'                 => true,
+
+			// Advanced > OAuth > OIDC Conformant
+			// https://auth0.com/docs/api-auth/intro#legacy-vs-new
+			'oidc_conformant'     => true,
 		);
 
 		$response = wp_remote_post(


### PR DESCRIPTION
### Changes

New installs will now be flagged as OIDC conformant.

### References

[OIDC Conformant applications](https://auth0.com/docs/api-auth/intro#legacy-vs-new)