### PR TITLE
Change API scopes needed in the Setup Wizard

### DIFF
--- a/lib/WP_Auth0_Api_Client.php
+++ b/lib/WP_Auth0_Api_Client.php
@@ -732,29 +732,28 @@ class WP_Auth0_Api_Client {
 		return json_decode( $response['body'] );
 	}
 
+	/**
+	 * Return the Management API scopes needed for install.
+	 *
+	 * @return array
+	 */
 	public static function ConsentRequiredScopes() {
 		return array(
 			'create:clients',
-			'update:clients',
-
 			'create:client_grants',
-			'update:client_grants',
-
 			'update:connections',
 			'create:connections',
 			'read:connections',
-
-			'create:rules',
-			'delete:rules',
-
 			'read:users',
 			'update:users',
-			'create:users',
-
-			'update:guardian_factors',
 		);
 	}
 
+	/**
+	 * TODO: Deprecate
+	 *
+	 * @codeCoverageIgnore - To be deprecated
+	 */
 	public static function GetConsentScopestoShow() {
 		$scopes    = self::ConsentRequiredScopes();
 		$grouped   = array();

--- a/templates/initial-setup/connection_profile.php
+++ b/templates/initial-setup/connection_profile.php
@@ -161,29 +161,16 @@
 					<?php _e( 'Manually create an API token with the', 'wp-auth0' ); ?>
 				  <a href="https://auth0.com/docs/api/management/v2/tokens#get-a-token-manually" target="_blank">
 						<?php _e( 'token generator', 'wp-auth0' ); ?></a>
-					<?php _e( ' and paste it here:', 'wp-auth0' ); ?>
+					<?php _e( ' and paste it below:', 'wp-auth0' ); ?>
 				</p>
+				  <p>
+					  <small>
+						  <?php _e( 'Scopes required', 'wp-auth0' ); ?>:
+						  <code><?php echo implode( '</code> <code>', WP_Auth0_Api_Client::ConsentRequiredScopes() ); ?></code>
+					  </small>
+				  </p>
 				<input type="password" name="apitoken" class="js-a0-setup-input" autocomplete="off" required>
-				<p>
-				  <small>
-					Scopes required:
-					<?php
-					$a      = 0;
-					$scopes = WP_Auth0_Api_Client::GetConsentScopestoShow();
-					foreach ( $scopes as $resource => $actions ) {
-						$a++;
-						?>
-					  <code><?php echo $actions; ?> <?php echo $resource; ?></code>
-						<?php
-						if ( $a < count( $scopes ) - 1 ) {
-							echo ', ';
-						} elseif ( $a === count( $scopes ) - 1 ) {
-							echo ' and ';
-						}
-						?>
-					<?php } ?>.
-				  </small>
-				</p>
+
 			  </div>
 			  <div class="modal-footer">
 				<input type="submit" class="a0-button primary" value="<?php _e( 'Continue', 'wp-auth0' ); ?>"/>

--- a/tests/testApiClient.php
+++ b/tests/testApiClient.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * Contains Class TestApiClient.
+ *
+ * @package WP-Auth0
+ *
+ * @since 3.10.0
+ */
+
+/**
+ * Class TestApiClient.
+ * Test the WP_Auth0_Api_Client class.
+ */
+class TestApiClient extends WP_Auth0_Test_Case {
+
+	use HttpHelpers;
+
+	/**
+	 * Test that the default grant types used on install are correct.
+	 */
+	public function testThatGrantTypesAreCorrect() {
+		$grant_types = WP_Auth0_Api_Client::get_client_grant_types();
+		$this->assertCount( 4, $grant_types );
+		$this->assertContains( 'authorization_code', $grant_types );
+		$this->assertContains( 'implicit', $grant_types );
+		$this->assertContains( 'refresh_token', $grant_types );
+		$this->assertContains( 'client_credentials', $grant_types );
+	}
+
+
+	/**
+	 * Test that the API scopes requested are correct.
+	 */
+	public function testThatConsentScopesAreCorrect() {
+		$scopes = WP_Auth0_Api_Client::ConsentRequiredScopes();
+		$this->assertCount( 7, $scopes );
+		$this->assertContains( 'create:clients', $scopes );
+		$this->assertContains( 'create:client_grants', $scopes );
+		$this->assertContains( 'create:connections', $scopes );
+		$this->assertContains( 'read:connections', $scopes );
+		$this->assertContains( 'update:connections', $scopes );
+		$this->assertContains( 'read:users', $scopes );
+		$this->assertContains( 'update:users', $scopes );
+	}
+}


### PR DESCRIPTION
### Changes

Change the Management API scopes displayed during setup.

### References

[Docs PR commit](https://github.com/auth0/docs/pull/7384/commits/28012e48126ecd91caf92549b7ef3da9fb2d0651)

### Testing

* [x] This change adds unit test coverage
