### PR TITLE
Deprecate WP_Auth0_UsersRepo methods

### DIFF
--- a/lib/WP_Auth0_Configure_JWTAUTH.php
+++ b/lib/WP_Auth0_Configure_JWTAUTH.php
@@ -3,14 +3,14 @@
 /**
  * Class WP_Auth0_Configure_JWTAUTH
  *
- * @deprecated 3.10.0, plugin is deprecated and removed from the WP plugin repo.
+ * @deprecated - 3.10.0, plugin is deprecated and removed from the WP plugin repo.
  */
 class WP_Auth0_Configure_JWTAUTH {
 
 	protected $a0_options;
 
 	/**
-	 * @deprecated 3.10.0, plugin is deprecated and removed from the WP plugin repo.
+	 * @deprecated - 3.10.0, plugin is deprecated and removed from the WP plugin repo.
 	 */
 	public function __construct( WP_Auth0_Options $a0_options ) {
 		$this->a0_options = $a0_options;
@@ -75,7 +75,7 @@ class WP_Auth0_Configure_JWTAUTH {
 	}
 
 	/**
-	 * @deprecated 3.10.0, plugin is deprecated and removed from the WP plugin repo.
+	 * @deprecated - 3.10.0, plugin is deprecated and removed from the WP plugin repo.
 	 *
 	 * @return bool
 	 */
@@ -88,7 +88,7 @@ class WP_Auth0_Configure_JWTAUTH {
 	}
 
 	/**
-	 * @deprecated 3.10.0, plugin is deprecated and removed from the WP plugin repo.
+	 * @deprecated - 3.10.0, plugin is deprecated and removed from the WP plugin repo.
 	 *
 	 * @return bool
 	 */

--- a/lib/WP_Auth0_UsersRepo.php
+++ b/lib/WP_Auth0_UsersRepo.php
@@ -8,13 +8,25 @@ class WP_Auth0_UsersRepo {
 		$this->a0_options = $a0_options;
 	}
 
+	/**
+	 * @deprecated - 3.10.0, JWT Auth plugin is deprecated and removed from the WP plugin repo.
+	 *
+	 * @codeCoverageIgnore - Deprecated
+	 */
 	public function init() {
 		if ( $this->a0_options->get( 'jwt_auth_integration' ) == 1 ) {
 			add_filter( 'wp_jwt_auth_get_user', array( $this, 'getUser' ), 0, 2 );
 		}
 	}
 
+	/**
+	 * @deprecated - 3.10.0, JWT Auth plugin is deprecated and removed from the WP plugin repo.
+	 *
+	 * @codeCoverageIgnore - Deprecated
+	 */
 	public function getUser( $jwt, $encodedJWT ) {
+		// phpcs:ignore
+		@trigger_error( sprintf( __( 'Method %s is deprecated.', 'wp-auth0' ), __METHOD__ ), E_USER_DEPRECATED );
 
 		$userRow = $this->find_auth0_user( $jwt->sub );
 
@@ -59,7 +71,14 @@ class WP_Auth0_UsersRepo {
 
 	}
 
+	/**
+	 * @deprecated - 3.10.0, JWT Auth plugin is deprecated and removed from the WP plugin repo.
+	 *
+	 * @codeCoverageIgnore - Deprecated
+	 */
 	public function tokenHasRequiredScopes( $jwt ) {
+		// phpcs:ignore
+		@trigger_error( sprintf( __( 'Method %s is deprecated.', 'wp-auth0' ), __METHOD__ ), E_USER_DEPRECATED );
 
 		return (
 			( isset( $jwt->email ) || isset( $jwt->nickname ) )


### PR DESCRIPTION
### Changes

This PR deprecates the following methods:

- `WP_Auth0_UsersRepo::init()` - still used but will be removed in the next major.
- `WP_Auth0_UsersRepo::getUser()` - no longer used
- `WP_Auth0_UsersRepo::tokenHasRequiredScopes()` - no longer used
