### PR TITLE
Deprecate WP_Auth0_RulesLib class

### DIFF
--- a/lib/WP_Auth0_RulesLib.php
+++ b/lib/WP_Auth0_RulesLib.php
@@ -1,13 +1,13 @@
 <?php
 /**
- * TODO: Deprecate
+ * @deprecated - 3.10.0, not used and no replacement provided.
  *
  * @codeCoverageIgnore - Deprecated.
  */
 class WP_Auth0_RulesLib {
 
 	/**
-	 * TODO: Deprecate
+	 * @deprecated - 3.10.0, not used and no replacement provided.
 	 *
 	 * @codeCoverageIgnore - Deprecated.
 	 */
@@ -80,7 +80,7 @@ function (user, context, callback) {
 	);
 
 	/**
-	 * TODO: Deprecate
+	 * @deprecated - 3.10.0, not used and no replacement provided.
 	 *
 	 * @codeCoverageIgnore - Deprecated.
 	 */
@@ -104,7 +104,7 @@ function (user, context, callback) {
 	);
 
 	/**
-	 * TODO: Deprecate
+	 * @deprecated - 3.10.0, not used and no replacement provided.
 	 *
 	 * @codeCoverageIgnore - Deprecated.
 	 */
@@ -132,7 +132,7 @@ function (user, context, callback) {
 	);
 
 	/**
-	 * TODO: Deprecate
+	 * @deprecated - 3.10.0, not used and no replacement provided.
 	 *
 	 * @codeCoverageIgnore - Deprecated.
 	 */
@@ -184,7 +184,7 @@ function (user, context, callback) {
 	);
 
 	/**
-	 * TODO: Deprecate
+	 * @deprecated - 3.10.0, not used and no replacement provided.
 	 *
 	 * @codeCoverageIgnore - Deprecated.
 	 */
@@ -243,12 +243,6 @@ function (user, context, callback) {
     }
 }",
 	);
-
-	/*
-	 *
-	 * DEPRECATED
-	 *
-	 */
 
 	/**
 	 * @deprecated - 3.8.0, not used and no replacement provided.

--- a/lib/WP_Auth0_Settings_Section.php
+++ b/lib/WP_Auth0_Settings_Section.php
@@ -20,6 +20,9 @@ class WP_Auth0_Settings_Section {
 		$this->import_settings    = $import_settings;
 	}
 
+	/**
+	 * TODO: Deprecate init()
+	 */
 	public function init() {
 		add_action( 'admin_menu', array( $this, 'init_menu' ), 95.55, 0 );
 	}


### PR DESCRIPTION
### Changes

This PR deprecates the `WP_Auth0_RulesLib` class as it is no longer used.