### PR TITLE
Deprecate WP_Auth0_Lock10_Options class

### DIFF
--- a/lib/WP_Auth0_Lock10_Options.php
+++ b/lib/WP_Auth0_Lock10_Options.php
@@ -27,11 +27,27 @@ class WP_Auth0_Lock10_Options {
 		return $this->wp_options->get_wp_auth0_url( $this->get_callback_protocol(), true );
 	}
 
+	/**
+	 * @deprecated - 3.10.0, not used.
+	 *
+	 * @return bool
+	 *
+	 * @codeCoverageIgnore - Deprecated.
+	 */
 	public function get_sso() {
+		// phpcs:ignore
+		@trigger_error( sprintf( __( 'Method %s is deprecated.', 'wp-auth0' ), __METHOD__ ), E_USER_DEPRECATED );
 		return $this->_get_boolean( $this->wp_options->get( 'sso' ) );
 	}
 
+	/**
+	 * @deprecated - 3.10.0, not used.
+	 *
+	 * @codeCoverageIgnore - Deprecated.
+	 */
 	public function get_client_id() {
+		// phpcs:ignore
+		@trigger_error( sprintf( __( 'Method %s is deprecated.', 'wp-auth0' ), __METHOD__ ), E_USER_DEPRECATED );
 		return $this->wp_options->get( 'client_id' );
 	}
 

--- a/lib/WP_Auth0_Routes.php
+++ b/lib/WP_Auth0_Routes.php
@@ -34,6 +34,9 @@ class WP_Auth0_Routes {
 		$this->ip_check   = $ip_check instanceof WP_Auth0_Ip_Check ? $ip_check : new WP_Auth0_Ip_Check( $a0_options );
 	}
 
+	/**
+	 * TODO: Deprecate init()
+	 */
 	public function init() {
 		add_action( 'parse_request', array( $this, 'custom_requests' ) );
 	}


### PR DESCRIPTION
### Changes

This PR deprecates the following methods:

- `WP_Auth0_Lock10_Options::get_sso()` - No longer used.
- `WP_Auth0_Lock10_Options::get_client_id()` - No longer used.