### PR TITLE
Deprecate WP_Auth0_Api_Operations methods

### DIFF
--- a/lib/WP_Auth0_Api_Operations.php
+++ b/lib/WP_Auth0_Api_Operations.php
@@ -8,9 +8,13 @@ class WP_Auth0_Api_Operations {
 	}
 
 	/**
-	 * TODO: Deprecate
+	 * @deprecated - 3.10.0, not used and no replacement provided.
+	 *
+	 * @codeCoverageIgnore - To be deprecated
 	 */
 	public function update_wordpress_connection( $app_token, $connection_id, $password_policy, $migration_token ) {
+		// phpcs:ignore
+		@trigger_error( sprintf( __( 'Method %s is deprecated.', 'wp-auth0' ), __METHOD__ ), E_USER_DEPRECATED );
 
 		$domain = $this->a0_options->get( 'domain' );
 
@@ -93,11 +97,13 @@ class WP_Auth0_Api_Operations {
 	}
 
 	/**
-	 * TODO: Deprecate
+	 * @deprecated - 3.10.0, Rules are no longer managed in the plugin, use the Auth0 dashboard.
 	 *
 	 * @codeCoverageIgnore - To be deprecated
 	 */
 	public function toggle_rule( $app_token, $rule_id, $rule_name, $rule_script ) {
+		// phpcs:ignore
+		@trigger_error( sprintf( __( 'Method %s is deprecated.', 'wp-auth0' ), __METHOD__ ), E_USER_DEPRECATED );
 
 		$domain = $this->a0_options->get( 'domain' );
 

--- a/lib/WP_Auth0_Configure_JWTAUTH.php
+++ b/lib/WP_Auth0_Configure_JWTAUTH.php
@@ -4,6 +4,8 @@
  * Class WP_Auth0_Configure_JWTAUTH
  *
  * @deprecated - 3.10.0, plugin is deprecated and removed from the WP plugin repo.
+ *
+ * @codeCoverageIgnore - Deprecated.
  */
 class WP_Auth0_Configure_JWTAUTH {
 

--- a/lib/WP_Auth0_DBManager.php
+++ b/lib/WP_Auth0_DBManager.php
@@ -9,6 +9,9 @@ class WP_Auth0_DBManager {
 		$this->a0_options = $a0_options;
 	}
 
+	/**
+	 * TODO: Deprecate init()
+	 */
 	public function init() {
 		$this->current_db_version = (int) get_option( 'auth0_db_version', 0 );
 		if ( $this->current_db_version === 0 ) {
@@ -207,6 +210,8 @@ class WP_Auth0_DBManager {
 	 * Display a banner if we are not able to get a Management API token.
 	 *
 	 * @deprecated - 3.10.0, not used.
+	 *
+	 * @codeCoverageIgnore - Deprecated.
 	 */
 	public function notice_failed_client_grant() {
 
@@ -266,6 +271,8 @@ class WP_Auth0_DBManager {
 	 * Display a banner once after 3.5.0 upgrade.
 	 *
 	 * @deprecated - 3.10.0, not used.
+	 *
+	 * @codeCoverageIgnore - Deprecated.
 	 */
 	public function notice_successful_client_grant() {
 
@@ -293,6 +300,8 @@ class WP_Auth0_DBManager {
 	 * Display a banner once after 3.5.1 upgrade.
 	 *
 	 * @deprecated - 3.10.0, not used.
+	 *
+	 * @codeCoverageIgnore - Deprecated.
 	 */
 	public function notice_successful_grant_types() {
 

--- a/lib/WP_Auth0_EditProfile.php
+++ b/lib/WP_Auth0_EditProfile.php
@@ -53,6 +53,7 @@ class WP_Auth0_EditProfile {
 
 	/**
 	 * Add actions and filters for the profile page.
+	 * TODO: Deprecate init()
 	 */
 	public function init() {
 		add_action( 'admin_enqueue_scripts', array( $this, 'admin_enqueue_scripts' ) );

--- a/lib/WP_Auth0_Email_Verification.php
+++ b/lib/WP_Auth0_Email_Verification.php
@@ -32,6 +32,7 @@ class WP_Auth0_Email_Verification {
 
 	/**
 	 * Set up hooks tied to functions that can be dequeued.
+	 * TODO: Deprecate init()
 	 *
 	 * @codeCoverageIgnore - Called at startup, tested in TestEmailVerification::testHooks()
 	 */

--- a/lib/WP_Auth0_ErrorLog.php
+++ b/lib/WP_Auth0_ErrorLog.php
@@ -24,6 +24,7 @@ class WP_Auth0_ErrorLog {
 
 	/**
 	 * Add actions and filters for the error log settings section.
+	 * TODO: Deprecate init()
 	 *
 	 * @link https://developer.wordpress.org/reference/hooks/admin_action__requestaction/
 	 */

--- a/lib/WP_Auth0_Export_Users.php
+++ b/lib/WP_Auth0_Export_Users.php
@@ -8,6 +8,9 @@ class WP_Auth0_Export_Users {
 		$this->db_manager = $db_manager;
 	}
 
+	/**
+	 * TODO: Deprecate init()
+	 */
 	public function init() {
 		add_action( 'admin_footer', array( $this, 'a0_add_users_export' ) );
 		add_action( 'load-users.php', array( $this, 'a0_export_selected_users' ) );

--- a/lib/WP_Auth0_Import_Settings.php
+++ b/lib/WP_Auth0_Import_Settings.php
@@ -8,6 +8,9 @@ class WP_Auth0_Import_Settings {
 		$this->a0_options = $a0_options;
 	}
 
+	/**
+	 * TODO: Deprecate init()
+	 */
 	public function init() {
 		add_action( 'admin_action_wpauth0_export_settings', array( $this, 'export_settings' ) );
 		add_action( 'admin_action_wpauth0_import_settings', array( $this, 'import_settings' ) );


### PR DESCRIPTION
### Changes

This PR deprecates the following methods:

- `WP_Auth0_Api_Operations:: update_wordpress_connection()` - No longer used.
- `WP_Auth0_Api_Operations:: toggle_rule()` - No longer used.

Added a few more `TODO` comments and `@codeCoverageIgnore` annotations