### PR TITLE
Deprecate WP_Auth0_Profile_Delete_Mfa and WP_Auth0_Api_Delete_User_Mfa

### DIFF
--- a/lib/api/WP_Auth0_Api_Delete_User_Mfa.php
+++ b/lib/api/WP_Auth0_Api_Delete_User_Mfa.php
@@ -9,7 +9,8 @@
 
 /**
  * Class WP_Auth0_Api_Delete_User_Mfa to perform a client credentials grant.
- * TODO: Deprecate
+ *
+ * @deprecated - 3.10.0, no longer used.
  */
 class WP_Auth0_Api_Delete_User_Mfa extends WP_Auth0_Api_Abstract {
 
@@ -34,7 +35,8 @@ class WP_Auth0_Api_Delete_User_Mfa extends WP_Auth0_Api_Abstract {
 
 	/**
 	 * WP_Auth0_Api_Delete_User_Mfa constructor.
-	 * TODO: Deprecate
+	 *
+	 * @deprecated - 3.10.0, no longer used.
 	 *
 	 * @param WP_Auth0_Options                $options - WP_Auth0_Options instance.
 	 * @param WP_Auth0_Api_Client_Credentials $api_client_creds - WP_Auth0_Api_Client_Credentials instance.

--- a/lib/profile/WP_Auth0_Profile_Delete_Mfa.php
+++ b/lib/profile/WP_Auth0_Profile_Delete_Mfa.php
@@ -10,7 +10,8 @@
 /**
  * Class WP_Auth0_Profile_Delete_Mfa.
  * Provides UI and AJAX handlers to delete a user's MFA.
- * TODO: Deprecate
+ *
+ * @deprecated - 3.10.0, no longer used.
  */
 class WP_Auth0_Profile_Delete_Mfa {
 
@@ -30,7 +31,8 @@ class WP_Auth0_Profile_Delete_Mfa {
 
 	/**
 	 * WP_Auth0_Profile_Delete_Mfa constructor.
-	 * TODO: Deprecate
+	 *
+	 * @deprecated - 3.10.0, no longer used.
 	 *
 	 * @param WP_Auth0_Options             $a0_options - WP_Auth0_Options instance.
 	 * @param WP_Auth0_Api_Delete_User_Mfa $api_delete_mfa - WP_Auth0_Api_Delete_User_Mfa instance.


### PR DESCRIPTION
### Changes

This PR deprecates the following classes:

- `WP_Auth0_Profile_Delete_Mfa` - No longer used, MFA must be administered in the Auth0 Dashboard.
- `WP_Auth0_Api_Delete_User_Mfa` - No longer used, supporting class for above.