### PR TITLE
Deprecate methods that control field rendering and validation

### DIFF
--- a/lib/admin/WP_Auth0_Admin_Advanced.php
+++ b/lib/admin/WP_Auth0_Admin_Advanced.php
@@ -332,14 +332,14 @@ class WP_Auth0_Admin_Advanced extends WP_Auth0_Admin_Generic {
 	 * Render form field and description for the `link_auth0_users` option.
 	 * IMPORTANT: Internal callback use only, do not call this function directly!
 	 *
-	 * TODO: Deprecate
+	 * @deprecated - 3.10.0, account linking should be administered in the Auth0 dashboard.
 	 *
 	 * @param array $args - callback args passed in from add_settings_field().
 	 *
 	 * @see WP_Auth0_Admin_Generic::init_option_section()
 	 * @see add_settings_field()
 	 *
-	 * @codeCoverageIgnore - To be deprecated
+	 * @codeCoverageIgnore - Deprecated.
 	 */
 	public function render_link_auth0_users( $args = array() ) {
 		$this->render_field_description(
@@ -561,6 +561,8 @@ class WP_Auth0_Admin_Advanced extends WP_Auth0_Admin_Generic {
 	 *
 	 * @see WP_Auth0_Admin_Generic::init_option_section()
 	 * @see add_settings_field()
+	 *
+	 * @codeCoverageIgnore - Deprecated.
 	 */
 	public function render_jwt_auth_integration( $args = array() ) {
 		$this->render_switch( $args['label_for'], $args['opt_name'] );
@@ -680,9 +682,9 @@ class WP_Auth0_Admin_Advanced extends WP_Auth0_Admin_Generic {
 	}
 
 	/**
-	 * TODO: Deprecate
+	 * @deprecated - 3.10.0, no longer used.
 	 *
-	 * @codeCoverageIgnore - To be deprecated
+	 * @codeCoverageIgnore - Deprecated.
 	 */
 	public function link_accounts_validation( $old_options, $input ) {
 		$link_script = WP_Auth0_RulesLib::$link_accounts['script'];

--- a/lib/admin/WP_Auth0_Admin_Advanced.php
+++ b/lib/admin/WP_Auth0_Admin_Advanced.php
@@ -687,6 +687,8 @@ class WP_Auth0_Admin_Advanced extends WP_Auth0_Admin_Generic {
 	 * @codeCoverageIgnore - Deprecated.
 	 */
 	public function link_accounts_validation( $old_options, $input ) {
+		// phpcs:ignore
+		@trigger_error( sprintf( __( 'Method %s is deprecated.', 'wp-auth0' ), __METHOD__ ), E_USER_DEPRECATED );
 		$link_script = WP_Auth0_RulesLib::$link_accounts['script'];
 		$link_script = str_replace( 'REPLACE_WITH_YOUR_CLIENT_ID', $input['client_id'], $link_script );
 		$link_script = str_replace( 'REPLACE_WITH_YOUR_DOMAIN', $input['domain'], $link_script );
@@ -769,6 +771,8 @@ class WP_Auth0_Admin_Advanced extends WP_Auth0_Admin_Generic {
 	 * @codeCoverageIgnore - Deprecated
 	 */
 	public function render_ip_range_check( $args = array() ) {
+		// phpcs:ignore
+		@trigger_error( sprintf( __( 'Method %s is deprecated.', 'wp-auth0' ), __METHOD__ ), E_USER_DEPRECATED );
 		$this->render_switch( $args['label_for'], $args['opt_name'], 'wpa0_ip_ranges' );
 	}
 
@@ -786,6 +790,8 @@ class WP_Auth0_Admin_Advanced extends WP_Auth0_Admin_Generic {
 	 * @codeCoverageIgnore - Deprecated
 	 */
 	public function render_ip_ranges( $args = array() ) {
+		// phpcs:ignore
+		@trigger_error( sprintf( __( 'Method %s is deprecated.', 'wp-auth0' ), __METHOD__ ), E_USER_DEPRECATED );
 		$this->render_textarea_field( $args['label_for'], $args['opt_name'] );
 		$this->render_field_description(
 			__( 'Only one range per line! Range format should be as follows (spaces ignored): ', 'wp-auth0' ) .

--- a/lib/admin/WP_Auth0_Admin_Appearance.php
+++ b/lib/admin/WP_Auth0_Admin_Appearance.php
@@ -160,7 +160,8 @@ class WP_Auth0_Admin_Appearance extends WP_Auth0_Admin_Generic {
 	/**
 	 * Render form field and description for the `custom_css` option.
 	 * IMPORTANT: Internal callback use only, do not call this function directly!
-	 * TODO: Deprecate
+	 *
+	 * @deprecated - 3.10.0, CSS must be added as an external file starting in the next major release.
 	 *
 	 * @param array $args - callback args passed in from add_settings_field().
 	 *
@@ -186,7 +187,8 @@ class WP_Auth0_Admin_Appearance extends WP_Auth0_Admin_Generic {
 	/**
 	 * Render form field and description for the `custom_js` option.
 	 * IMPORTANT: Internal callback use only, do not call this function directly!
-	 * TODO: Deprecate
+	 *
+	 * @deprecated - 3.10.0, JS must be added as an external file starting in the next major release.
 	 *
 	 * @param array $args - callback args passed in from add_settings_field().
 	 *

--- a/lib/admin/WP_Auth0_Admin_Basic.php
+++ b/lib/admin/WP_Auth0_Admin_Basic.php
@@ -235,12 +235,15 @@ class WP_Auth0_Admin_Basic extends WP_Auth0_Admin_Generic {
 	/**
 	 * Render form field and description for the `auth0_app_token` option.
 	 * IMPORTANT: Internal callback use only, do not call this function directly!
-	 * TODO: Deprecate
+	 *
+	 * @deprecated - 3.10.0, no longer used.
 	 *
 	 * @param array $args - callback args passed in from add_settings_field().
 	 *
 	 * @see WP_Auth0_Admin_Generic::init_option_section()
 	 * @see add_settings_field()
+	 *
+	 * @codeCoverageIgnore - Deprecated.
 	 */
 	public function render_auth0_app_token( $args = array() ) {
 		$this->render_text_field( $args['label_for'], $args['opt_name'], 'password' );

--- a/lib/admin/WP_Auth0_Admin_Basic.php
+++ b/lib/admin/WP_Auth0_Admin_Basic.php
@@ -246,6 +246,8 @@ class WP_Auth0_Admin_Basic extends WP_Auth0_Admin_Generic {
 	 * @codeCoverageIgnore - Deprecated.
 	 */
 	public function render_auth0_app_token( $args = array() ) {
+		// phpcs:ignore
+		@trigger_error( sprintf( __( 'Method %s is deprecated.', 'wp-auth0' ), __METHOD__ ), E_USER_DEPRECATED );
 		$this->render_text_field( $args['label_for'], $args['opt_name'], 'password' );
 		$this->render_field_description(
 			__( 'This token should include the following scopes: ', 'wp-auth0' ) .

--- a/lib/admin/WP_Auth0_Admin_Features.php
+++ b/lib/admin/WP_Auth0_Admin_Features.php
@@ -123,6 +123,8 @@ class WP_Auth0_Admin_Features extends WP_Auth0_Admin_Generic {
 	 * @codeCoverageIgnore - Deprecated.
 	 */
 	public function render_password_policy( $args = array() ) {
+		// phpcs:ignore
+		@trigger_error( sprintf( __( 'Method %s is deprecated.', 'wp-auth0' ), __METHOD__ ), E_USER_DEPRECATED );
 		$this->render_radio_buttons(
 			array(
 				array(
@@ -309,6 +311,8 @@ class WP_Auth0_Admin_Features extends WP_Auth0_Admin_Generic {
 	 * @codeCoverageIgnore - Deprecated.
 	 */
 	public function render_fullcontact_apikey( $args = array() ) {
+		// phpcs:ignore
+		@trigger_error( sprintf( __( 'Method %s is deprecated.', 'wp-auth0' ), __METHOD__ ), E_USER_DEPRECATED );
 		$this->render_text_field( $args['label_for'], $args['opt_name'] );
 	}
 
@@ -396,6 +400,8 @@ class WP_Auth0_Admin_Features extends WP_Auth0_Admin_Generic {
 	 */
 
 	public function sso_validation( $old_options, $input ) {
+		// phpcs:ignore
+		@trigger_error( sprintf( __( 'Method %s is deprecated.', 'wp-auth0' ), __METHOD__ ), E_USER_DEPRECATED );
 		$input['sso'] = ( isset( $input['sso'] ) ? $input['sso'] : 0 );
 		$is_sso       = ! empty( $input['sso'] );
 
@@ -444,6 +450,8 @@ class WP_Auth0_Admin_Features extends WP_Auth0_Admin_Generic {
 	 * @codeCoverageIgnore - Deprecated.
 	 */
 	public function security_validation( $old_options, $input ) {
+		// phpcs:ignore
+		@trigger_error( sprintf( __( 'Method %s is deprecated.', 'wp-auth0' ), __METHOD__ ), E_USER_DEPRECATED );
 		$input['password_policy'] = ! empty( $input['password_policy'] ) ? $input['password_policy'] : null;
 
 		if ( $old_options['password_policy'] !== $input['password_policy'] ) {
@@ -487,6 +495,8 @@ class WP_Auth0_Admin_Features extends WP_Auth0_Admin_Generic {
 	 * @@codeCoverageIgnore - Deprecated.
 	 */
 	public function fullcontact_validation( $old_options, $input ) {
+		// phpcs:ignore
+		@trigger_error( sprintf( __( 'Method %s is deprecated.', 'wp-auth0' ), __METHOD__ ), E_USER_DEPRECATED );
 		$fullcontact_script = WP_Auth0_RulesLib::$fullcontact['script'];
 		$fullcontact_script = str_replace( 'REPLACE_WITH_YOUR_CLIENT_ID', $input['client_id'], $fullcontact_script );
 		$fullcontact_script = str_replace( 'REPLACE_WITH_YOUR_FULLCONTACT_API_KEY', $input['fullcontact_apikey'], $fullcontact_script );
@@ -499,6 +509,8 @@ class WP_Auth0_Admin_Features extends WP_Auth0_Admin_Generic {
 	 * @codeCoverageIgnore - Deprecated.
 	 */
 	public function mfa_validation( $old_options, $input ) {
+		// phpcs:ignore
+		@trigger_error( sprintf( __( 'Method %s is deprecated.', 'wp-auth0' ), __METHOD__ ), E_USER_DEPRECATED );
 
 		if ( ! isset( $input['mfa'] ) ) {
 			$input['mfa'] = null;
@@ -522,6 +534,8 @@ class WP_Auth0_Admin_Features extends WP_Auth0_Admin_Generic {
 	 * @codeCoverageIgnore - Deprecated.
 	 */
 	public function georule_validation( $old_options, $input ) {
+		// phpcs:ignore
+		@trigger_error( sprintf( __( 'Method %s is deprecated.', 'wp-auth0' ), __METHOD__ ), E_USER_DEPRECATED );
 		$geo_script = WP_Auth0_RulesLib::$geo['script'];
 		$geo_script = str_replace( 'REPLACE_WITH_YOUR_CLIENT_ID', $input['client_id'], $geo_script );
 		return $this->rule_validation( $old_options, $input, 'geo_rule', WP_Auth0_RulesLib::$geo['name'] . '-' . get_auth0_curatedBlogName(), $geo_script );
@@ -533,6 +547,8 @@ class WP_Auth0_Admin_Features extends WP_Auth0_Admin_Generic {
 	 * @codeCoverageIgnore - Deprecated.
 	 */
 	public function incomerule_validation( $old_options, $input ) {
+		// phpcs:ignore
+		@trigger_error( sprintf( __( 'Method %s is deprecated.', 'wp-auth0' ), __METHOD__ ), E_USER_DEPRECATED );
 		$income_script = WP_Auth0_RulesLib::$income['script'];
 		$income_script = str_replace( 'REPLACE_WITH_YOUR_CLIENT_ID', $input['client_id'], $income_script );
 		return $this->rule_validation( $old_options, $input, 'income_rule', WP_Auth0_RulesLib::$income['name'] . '-' . get_auth0_curatedBlogName(), $income_script );

--- a/lib/admin/WP_Auth0_Admin_Features.php
+++ b/lib/admin/WP_Auth0_Admin_Features.php
@@ -113,12 +113,14 @@ class WP_Auth0_Admin_Features extends WP_Auth0_Admin_Generic {
 	 * Render form field and description for the `password_policy` option.
 	 * IMPORTANT: Internal callback use only, do not call this function directly!
 	 *
-	 * TODO: Deprecate
+	 * @deprecated - 3.10.0, no longer used.
 	 *
 	 * @param array $args - callback args passed in from add_settings_field().
 	 *
 	 * @see WP_Auth0_Admin_Generic::init_option_section()
 	 * @see add_settings_field()
+	 *
+	 * @codeCoverageIgnore - Deprecated.
 	 */
 	public function render_password_policy( $args = array() ) {
 		$this->render_radio_buttons(
@@ -276,14 +278,14 @@ class WP_Auth0_Admin_Features extends WP_Auth0_Admin_Generic {
 	 * Render form field and description for the `fullcontact` option.
 	 * IMPORTANT: Internal callback use only, do not call this function directly!
 	 *
-	 * TODO: Deprecate
+	 * @deprecated - 3.10.0, Rules must be managed in the Auth0 dashboard.
 	 *
 	 * @param array $args - callback args passed in from add_settings_field().
 	 *
 	 * @see WP_Auth0_Admin_Generic::init_option_section()
 	 * @see add_settings_field()
 	 *
-	 * @codeCoverageIgnore - To be deprecated
+	 * @codeCoverageIgnore - Deprecated.
 	 */
 	public function render_fullcontact( $args = array() ) {
 		$this->render_field_description(
@@ -297,14 +299,14 @@ class WP_Auth0_Admin_Features extends WP_Auth0_Admin_Generic {
 	 * Render form field and description for the `fullcontact_apikey` option.
 	 * IMPORTANT: Internal callback use only, do not call this function directly!
 	 *
-	 * TODO: Deprecate
+	 * @deprecated - 3.10.0, Rules must be managed in the Auth0 dashboard.
 	 *
 	 * @param array $args - callback args passed in from add_settings_field().
 	 *
 	 * @see WP_Auth0_Admin_Generic::init_option_section()
 	 * @see add_settings_field()
 	 *
-	 * @codeCoverageIgnore - To be deprecated
+	 * @codeCoverageIgnore - Deprecated.
 	 */
 	public function render_fullcontact_apikey( $args = array() ) {
 		$this->render_text_field( $args['label_for'], $args['opt_name'] );
@@ -314,14 +316,14 @@ class WP_Auth0_Admin_Features extends WP_Auth0_Admin_Generic {
 	 * Render form field and description for the `geo_rule` option.
 	 * IMPORTANT: Internal callback use only, do not call this function directly!
 	 *
-	 * TODO: Deprecate
+	 * @deprecated - 3.10.0, Rules must be managed in the Auth0 dashboard.
 	 *
 	 * @param array $args - callback args passed in from add_settings_field().
 	 *
 	 * @see WP_Auth0_Admin_Generic::init_option_section()
 	 * @see add_settings_field()
 	 *
-	 * @codeCoverageIgnore - To be deprecated
+	 * @codeCoverageIgnore - Deprecated.
 	 */
 	public function render_geo( $args = array() ) {
 		$this->render_field_description(
@@ -335,14 +337,14 @@ class WP_Auth0_Admin_Features extends WP_Auth0_Admin_Generic {
 	 * Render form field and description for the `income_rule` option.
 	 * IMPORTANT: Internal callback use only, do not call this function directly!
 	 *
-	 * TODO: Deprecate
+	 * @deprecated - 3.10.0, Rules must be managed in the Auth0 dashboard.
 	 *
 	 * @param array $args - callback args passed in from add_settings_field().
 	 *
 	 * @see WP_Auth0_Admin_Generic::init_option_section()
 	 * @see add_settings_field()
 	 *
-	 * @codeCoverageIgnore - To be deprecated
+	 * @codeCoverageIgnore - Deprecated.
 	 */
 	public function render_income( $args = array() ) {
 		$this->render_field_description(
@@ -383,14 +385,14 @@ class WP_Auth0_Admin_Features extends WP_Auth0_Admin_Generic {
 	/**
 	 * Update the Auth0 Application if SSO is turned on and disable SLO if it is turned off.
 	 *
-	 * TODO: Deprecate
+	 * @deprecated - 3.10.0, no longer used.
 	 *
 	 * @param array $old_options - option values before saving.
 	 * @param array $input - new option values being saved.
 	 *
 	 * @return array
 	 *
-	 * @codeCoverageIgnore - To be deprecated
+	 * @codeCoverageIgnore - Deprecated.
 	 */
 
 	public function sso_validation( $old_options, $input ) {
@@ -432,12 +434,14 @@ class WP_Auth0_Admin_Features extends WP_Auth0_Admin_Generic {
 	/**
 	 * Update the password policy for the database connection used with this application
 	 *
-	 * TODO: Deprecate
+	 * @deprecated - 3.10.0, setting removed.
 	 *
 	 * @param array $old_options - previous option values
 	 * @param array $input - new option values
 	 *
 	 * @return array
+	 *
+	 * @codeCoverageIgnore - Deprecated.
 	 */
 	public function security_validation( $old_options, $input ) {
 		$input['password_policy'] = ! empty( $input['password_policy'] ) ? $input['password_policy'] : null;
@@ -478,9 +482,9 @@ class WP_Auth0_Admin_Features extends WP_Auth0_Admin_Generic {
 	}
 
 	/**
-	 * TODO: Deprecate
+	 *  @deprecated - 3.10.0, setting removed.
 	 *
-	 * @codeCoverageIgnore - To be deprecated
+	 * @@codeCoverageIgnore - Deprecated.
 	 */
 	public function fullcontact_validation( $old_options, $input ) {
 		$fullcontact_script = WP_Auth0_RulesLib::$fullcontact['script'];
@@ -490,9 +494,9 @@ class WP_Auth0_Admin_Features extends WP_Auth0_Admin_Generic {
 	}
 
 	/**
-	 * TODO: Deprecate
+	 *  @deprecated - 3.10.0, setting removed.
 	 *
-	 * @codeCoverageIgnore - To be deprecated
+	 * @codeCoverageIgnore - Deprecated.
 	 */
 	public function mfa_validation( $old_options, $input ) {
 
@@ -513,9 +517,9 @@ class WP_Auth0_Admin_Features extends WP_Auth0_Admin_Generic {
 	}
 
 	/**
-	 * TODO: Deprecate
+	 *  @deprecated - 3.10.0, setting removed.
 	 *
-	 * @codeCoverageIgnore - To be deprecated
+	 * @codeCoverageIgnore - Deprecated.
 	 */
 	public function georule_validation( $old_options, $input ) {
 		$geo_script = WP_Auth0_RulesLib::$geo['script'];
@@ -524,9 +528,9 @@ class WP_Auth0_Admin_Features extends WP_Auth0_Admin_Generic {
 	}
 
 	/**
-	 * TODO: Deprecate
+	 *  @deprecated - 3.10.0, setting removed.
 	 *
-	 * @codeCoverageIgnore - To be deprecated
+	 * @codeCoverageIgnore - Deprecated.
 	 */
 	public function incomerule_validation( $old_options, $input ) {
 		$income_script = WP_Auth0_RulesLib::$income['script'];
@@ -537,7 +541,7 @@ class WP_Auth0_Admin_Features extends WP_Auth0_Admin_Generic {
 	/**
 	 * @deprecated - 3.6.0, handled by WP_Auth0_Admin_Generic::render_description()
 	 *
-	 * @codeCoverageIgnore - Deprecated
+	 * @codeCoverageIgnore - Deprecated.
 	 */
 	public function render_features_description() {
 		// phpcs:ignore

--- a/lib/admin/WP_Auth0_Admin_Generic.php
+++ b/lib/admin/WP_Auth0_Admin_Generic.php
@@ -98,9 +98,9 @@ class WP_Auth0_Admin_Generic {
 	}
 
 	/**
-	 * TODO: Deprecate
+	 * @deprecated - 3.10.0, no longer used.
 	 *
-	 * @codeCoverageIgnore - To be deprecated
+	 * @codeCoverageIgnore - Deprecated.
 	 */
 	protected function rule_validation( $old_options, $input, $key, $rule_name, $rule_script ) {
 		$input[ $key ] = ( isset( $input[ $key ] ) ? $input[ $key ] : null );

--- a/lib/admin/WP_Auth0_Admin_Generic.php
+++ b/lib/admin/WP_Auth0_Admin_Generic.php
@@ -103,6 +103,8 @@ class WP_Auth0_Admin_Generic {
 	 * @codeCoverageIgnore - Deprecated.
 	 */
 	protected function rule_validation( $old_options, $input, $key, $rule_name, $rule_script ) {
+		// phpcs:ignore
+		@trigger_error( sprintf( __( 'Method %s is deprecated.', 'wp-auth0' ), __METHOD__ ), E_USER_DEPRECATED );
 		$input[ $key ] = ( isset( $input[ $key ] ) ? $input[ $key ] : null );
 
 		if ( ( $input[ $key ] !== null && $old_options[ $key ] === null ) || ( $input[ $key ] === null && $old_options[ $key ] !== null ) ) {


### PR DESCRIPTION
### Changes

This PR deprecates the following methods:

- `WP_Auth0_Admin_Advanced::render_link_auth0_users()` - Setting no longer used, field will be removed in the next major.
- `WP_Auth0_Admin_Advanced::render_jwt_auth_integration()` - Integration is deprecated (#636).
- `WP_Auth0_Admin_Advanced::link_accounts_validation()` - No longer used.
