### PR TITLE
Deprecations for API token handling

### DIFF
--- a/lib/api/WP_Auth0_Api_Abstract.php
+++ b/lib/api/WP_Auth0_Api_Abstract.php
@@ -55,7 +55,8 @@ abstract class WP_Auth0_Api_Abstract {
 
 	/**
 	 * API token from plugin settings or Client Credentials call.
-	 * TODO: Deprecate
+	 *
+	 * @deprecated - 3.10.0, not used.
 	 *
 	 * @var string
 	 */
@@ -63,7 +64,8 @@ abstract class WP_Auth0_Api_Abstract {
 
 	/**
 	 * Decoded API token from plugin settings.
-	 * TODO: Deprecate
+	 *
+	 * @deprecated - 3.10.0, not used.
 	 *
 	 * @var object
 	 */
@@ -381,7 +383,8 @@ abstract class WP_Auth0_Api_Abstract {
 
 	/**
 	 * Decode an RS256 Auth0 Management API token.
-	 * TODO: Deprecate
+	 *
+	 * @deprecated - 3.10.0, not used.
 	 *
 	 * @param string $token - API JWT to decode.
 	 *
@@ -394,7 +397,7 @@ abstract class WP_Auth0_Api_Abstract {
 	 * @throws BeforeValidException         Provided JWT used before it's been created as defined by 'iat'.
 	 * @throws ExpiredException             Provided JWT has since expired, as defined by the 'exp' claim.
 	 *
-	 * @codeCoverageIgnore - To be deprecated.
+	 * @codeCoverageIgnore - Deprecated.
 	 */
 	protected function decode_jwt( $token ) {
 		return JWT::decode(

--- a/lib/api/WP_Auth0_Api_Client_Credentials.php
+++ b/lib/api/WP_Auth0_Api_Client_Credentials.php
@@ -29,7 +29,8 @@ class WP_Auth0_Api_Client_Credentials extends WP_Auth0_Api_Abstract {
 
 	/**
 	 * Decoded token received.
-	 * TODO: Deprecate
+	 *
+	 * @deprecated - 3.10.0, not used.
 	 *
 	 * @var null|object
 	 */
@@ -60,11 +61,12 @@ class WP_Auth0_Api_Client_Credentials extends WP_Auth0_Api_Abstract {
 
 	/**
 	 * Return the decoded API token received.
-	 * TODO: Deprecate
+	 *
+	 * @deprecated - 3.10.0, not used.
 	 *
 	 * @return null|object
 	 *
-	 * @codeCoverageIgnore - To be deprecated.
+	 * @codeCoverageIgnore - Deprecated.
 	 */
 	public function get_token_decoded() {
 		return $this->token_decoded;


### PR DESCRIPTION
### Changes

This PR deprecates the following methods + properties:

- `\WP_Auth0_Api_Abstract::$api_token` - No longer used.
- `\WP_Auth0_Api_Abstract::$api_token_decoded` - No longer used.
- `\WP_Auth0_Api_Abstract::decode_jwt()` - No longer used.
- `\WP_Auth0_Api_Client_Credentials::$token_decoded` - No longer used.
- `\WP_Auth0_Api_Client_Credentials::get_token_decoded()` - No longer used.