### PR TITLE
Deprecations for init functions calling add_action or add_filter

### DIFF
--- a/WP_Auth0.php
+++ b/WP_Auth0.php
@@ -78,16 +78,17 @@ class WP_Auth0 {
 	public function __construct( $options = null ) {
 		spl_autoload_register( array( $this, 'autoloader' ) );
 		$this->a0_options = $options instanceof WP_Auth0_Options ? $options : WP_Auth0_Options::Instance();
+		$this->basename   = plugin_basename( __FILE__ );
 	}
 
 	/**
-	 * Initialize the plugin and its modules setting all the hooks
+	 * Initialize the plugin and its modules setting all the hooks.
+	 *
+	 * @deprecated - 3.10.0, will move add_action calls out of this class in the next major.
+	 *
+	 * @codeCoverageIgnore - Deprecated.
 	 */
 	public function init() {
-		$this->basename = plugin_basename( __FILE__ );
-
-		$ip_checker = new WP_Auth0_Ip_Check();
-		$ip_checker->init();
 
 		$this->db_manager = new WP_Auth0_DBManager( $this->a0_options );
 		$this->db_manager->init();
@@ -118,10 +119,6 @@ class WP_Auth0 {
 		add_filter( 'query_vars', array( $this, 'a0_register_query_vars' ) );
 
 		add_filter( 'plugin_action_links_' . $this->basename, array( $this, 'wp_add_plugin_settings_link' ) );
-
-		if ( isset( $_GET['message'] ) ) {
-			add_action( 'wp_footer', array( $this, 'a0_render_message' ) );
-		}
 
 		$initial_setup = new WP_Auth0_InitialSetup( $this->a0_options );
 		$initial_setup->init();

--- a/lib/WP_Auth0_DBManager.php
+++ b/lib/WP_Auth0_DBManager.php
@@ -10,7 +10,9 @@ class WP_Auth0_DBManager {
 	}
 
 	/**
-	 * TODO: Deprecate init()
+	 * @deprecated - 3.10.0, will move add_action calls out of this class in the next major.
+	 *
+	 * @codeCoverageIgnore - Deprecated.
 	 */
 	public function init() {
 		$this->current_db_version = (int) get_option( 'auth0_db_version', 0 );

--- a/lib/WP_Auth0_EditProfile.php
+++ b/lib/WP_Auth0_EditProfile.php
@@ -53,7 +53,10 @@ class WP_Auth0_EditProfile {
 
 	/**
 	 * Add actions and filters for the profile page.
-	 * TODO: Deprecate init()
+	 *
+	 * @deprecated - 3.10.0, will move add_action calls out of this class in the next major.
+	 *
+	 * @codeCoverageIgnore - Deprecated.
 	 */
 	public function init() {
 		add_action( 'admin_enqueue_scripts', array( $this, 'admin_enqueue_scripts' ) );

--- a/lib/WP_Auth0_Email_Verification.php
+++ b/lib/WP_Auth0_Email_Verification.php
@@ -32,9 +32,10 @@ class WP_Auth0_Email_Verification {
 
 	/**
 	 * Set up hooks tied to functions that can be dequeued.
-	 * TODO: Deprecate init()
 	 *
-	 * @codeCoverageIgnore - Called at startup, tested in TestEmailVerification::testHooks()
+	 * @deprecated - 3.10.0, will move add_action calls out of this class in the next major.
+	 *
+	 * @codeCoverageIgnore - Deprecated.
 	 */
 	public static function init() {
 		add_action( 'wp_ajax_nopriv_resend_verification_email', 'wp_auth0_ajax_resend_verification_email' );

--- a/lib/WP_Auth0_ErrorLog.php
+++ b/lib/WP_Auth0_ErrorLog.php
@@ -24,9 +24,10 @@ class WP_Auth0_ErrorLog {
 
 	/**
 	 * Add actions and filters for the error log settings section.
-	 * TODO: Deprecate init()
 	 *
-	 * @link https://developer.wordpress.org/reference/hooks/admin_action__requestaction/
+	 * @deprecated - 3.10.0, will move add_action calls out of this class in the next major.
+	 *
+	 * @codeCoverageIgnore - Deprecated.
 	 */
 	public function init() {
 		add_action( 'admin_action_wpauth0_clear_error_log', 'wp_auth0_errorlog_clear_error_log' );

--- a/lib/WP_Auth0_Export_Users.php
+++ b/lib/WP_Auth0_Export_Users.php
@@ -9,7 +9,9 @@ class WP_Auth0_Export_Users {
 	}
 
 	/**
-	 * TODO: Deprecate init()
+	 * @deprecated - 3.10.0, will move add_action calls out of this class in the next major.
+	 *
+	 * @codeCoverageIgnore - Deprecated.
 	 */
 	public function init() {
 		add_action( 'admin_footer', array( $this, 'a0_add_users_export' ) );

--- a/lib/WP_Auth0_Import_Settings.php
+++ b/lib/WP_Auth0_Import_Settings.php
@@ -9,7 +9,9 @@ class WP_Auth0_Import_Settings {
 	}
 
 	/**
-	 * TODO: Deprecate init()
+	 * @deprecated - 3.10.0, will move add_action calls out of this class in the next major.
+	 *
+	 * @codeCoverageIgnore - Deprecated.
 	 */
 	public function init() {
 		add_action( 'admin_action_wpauth0_export_settings', array( $this, 'export_settings' ) );

--- a/lib/WP_Auth0_Routes.php
+++ b/lib/WP_Auth0_Routes.php
@@ -35,7 +35,9 @@ class WP_Auth0_Routes {
 	}
 
 	/**
-	 * TODO: Deprecate init()
+	 * @deprecated - 3.10.0, will move add_action calls out of this class in the next major.
+	 *
+	 * @codeCoverageIgnore - Deprecated.
 	 */
 	public function init() {
 		add_action( 'parse_request', array( $this, 'custom_requests' ) );

--- a/lib/WP_Auth0_Settings_Section.php
+++ b/lib/WP_Auth0_Settings_Section.php
@@ -21,7 +21,9 @@ class WP_Auth0_Settings_Section {
 	}
 
 	/**
-	 * TODO: Deprecate init()
+	 * @deprecated - 3.10.0, will move add_action calls out of this class in the next major.
+	 *
+	 * @codeCoverageIgnore - Deprecated.
 	 */
 	public function init() {
 		add_action( 'admin_menu', array( $this, 'init_menu' ), 95.55, 0 );

--- a/lib/WP_Auth0_WooCommerceOverrides.php
+++ b/lib/WP_Auth0_WooCommerceOverrides.php
@@ -19,6 +19,11 @@ class WP_Auth0_WooCommerceOverrides {
 		}
 	}
 
+	/**
+	 * @deprecated - 3.10.0, will move add_action calls out of this class in the next major.
+	 *
+	 * @codeCoverageIgnore - Deprecated.
+	 */
 	public function init() {
 		add_filter( 'woocommerce_checkout_login_message', array( $this, 'override_woocommerce_checkout_login_form' ) );
 		add_filter( 'woocommerce_before_customer_login_form', array( $this, 'override_woocommerce_login_form' ) );

--- a/lib/admin/WP_Auth0_Admin.php
+++ b/lib/admin/WP_Auth0_Admin.php
@@ -13,6 +13,11 @@ class WP_Auth0_Admin {
 		$this->router     = $router;
 	}
 
+	/**
+	 * @deprecated - 3.10.0, will move add_action calls out of this class in the next major.
+	 *
+	 * @codeCoverageIgnore - Deprecated.
+	 */
 	public function init() {
 		add_action( 'admin_init', array( $this, 'init_admin' ) );
 		add_action( 'admin_enqueue_scripts', array( $this, 'admin_enqueue' ), 1 );

--- a/lib/initial-setup/WP_Auth0_InitialSetup.php
+++ b/lib/initial-setup/WP_Auth0_InitialSetup.php
@@ -21,6 +21,11 @@ class WP_Auth0_InitialSetup {
 		$this->end_step                   = new WP_Auth0_InitialSetup_End( $this->a0_options );
 	}
 
+	/**
+	 * @deprecated - 3.10.0, will move add_action calls out of this class in the next major.
+	 *
+	 * @codeCoverageIgnore - Deprecated.
+	 */
 	public function init() {
 
 		add_action( 'init', array( $this, 'init_setup' ), 1 );

--- a/lib/profile/WP_Auth0_Profile_Change_Email.php
+++ b/lib/profile/WP_Auth0_Profile_Change_Email.php
@@ -31,7 +31,9 @@ class WP_Auth0_Profile_Change_Email {
 	/**
 	 * Add actions for the update user process.
 	 *
-	 * @codeCoverageIgnore - Tested in TestProfileChangeEmail::testInitHooks()
+	 * @deprecated - 3.10.0, will move add_action calls out of this class in the next major.
+	 *
+	 * @codeCoverageIgnore - Deprecated.
 	 */
 	public function init() {
 

--- a/lib/profile/WP_Auth0_Profile_Change_Password.php
+++ b/lib/profile/WP_Auth0_Profile_Change_Password.php
@@ -31,7 +31,9 @@ class WP_Auth0_Profile_Change_Password {
 	/**
 	 * Add actions and filters for the profile page.
 	 *
-	 * @codeCoverageIgnore - Tested in TestProfileChangePassword::testInitHooks()
+	 * @deprecated - 3.10.0, will move add_action calls out of this class in the next major.
+	 *
+	 * @codeCoverageIgnore - Deprecated.
 	 */
 	public function init() {
 

--- a/lib/profile/WP_Auth0_Profile_Delete_Data.php
+++ b/lib/profile/WP_Auth0_Profile_Delete_Data.php
@@ -32,7 +32,9 @@ class WP_Auth0_Profile_Delete_Data {
 	/**
 	 * Add actions and filters for the profile page.
 	 *
-	 * @codeCoverageIgnore - Tested in TestProfileDeleteData::testInitHooks()
+	 * @deprecated - 3.10.0, will move add_action calls out of this class in the next major.
+	 *
+	 * @codeCoverageIgnore - Deprecated.
 	 */
 	public function init() {
 		add_action( 'edit_user_profile', array( $this, 'show_delete_identity' ) );


### PR DESCRIPTION
### Changes

Deprecates `init()` methods that call `add_action` or `add_filter`. These will be moved to global functions in the next major release to allow un-hooking when needed.
