### PR TITLE
Redirect from Auth0 on callback error

### DIFF
--- a/lib/WP_Auth0_Options.php
+++ b/lib/WP_Auth0_Options.php
@@ -242,7 +242,7 @@ class WP_Auth0_Options extends WP_Auth0_Options_Generic {
 
 			// Features
 			'sso'                       => 0,
-			'singlelogout'              => 0,
+			'singlelogout'              => 1,
 			'override_wp_avatars'       => 1,
 
 			// Appearance

--- a/lib/admin/WP_Auth0_Admin_Features.php
+++ b/lib/admin/WP_Auth0_Admin_Features.php
@@ -32,24 +32,6 @@ class WP_Auth0_Admin_Features extends WP_Auth0_Admin_Generic {
 	public function init() {
 		$options = array(
 			array(
-				'name'     => __( 'Single Sign On (SSO)', 'wp-auth0' ),
-				'opt'      => 'sso',
-				'id'       => 'wpa0_sso',
-				'function' => 'render_sso',
-			),
-			array(
-				'name'     => __( 'Single Logout', 'wp-auth0' ),
-				'opt'      => 'singlelogout',
-				'id'       => 'wpa0_singlelogout',
-				'function' => 'render_singlelogout',
-			),
-			array(
-				'name'     => __( 'Passwordless Login', 'wp-auth0' ),
-				'opt'      => 'passwordless_enabled',
-				'id'       => 'wpa0_passwordless_enabled',
-				'function' => 'render_passwordless_enabled',
-			),
-			array(
 				'name'     => __( 'Universal Login Page', 'wp-auth0' ),
 				'opt'      => 'auto_login',
 				'id'       => 'wpa0_auto_login',
@@ -60,6 +42,24 @@ class WP_Auth0_Admin_Features extends WP_Auth0_Admin_Generic {
 				'opt'      => 'auto_login_method',
 				'id'       => 'wpa0_auto_login_method',
 				'function' => 'render_auto_login_method',
+			),
+			array(
+				'name'     => __( 'Single Logout', 'wp-auth0' ),
+				'opt'      => 'singlelogout',
+				'id'       => 'wpa0_singlelogout',
+				'function' => 'render_singlelogout',
+			),
+			array(
+				'name'     => __( 'Single Sign On (SSO)', 'wp-auth0' ),
+				'opt'      => 'sso',
+				'id'       => 'wpa0_sso',
+				'function' => 'render_sso',
+			),
+			array(
+				'name'     => __( 'Passwordless Login', 'wp-auth0' ),
+				'opt'      => 'passwordless_enabled',
+				'id'       => 'wpa0_passwordless_enabled',
+				'function' => 'render_passwordless_enabled',
 			),
 			array(
 				'name'     => __( 'Multifactor Authentication (MFA)', 'wp-auth0' ),
@@ -167,7 +167,7 @@ class WP_Auth0_Admin_Features extends WP_Auth0_Admin_Generic {
 		$this->render_switch( $args['label_for'], $args['opt_name'] );
 		$this->render_field_description(
 			__( 'This setting is deprecated and will be removed in the next major release. ', 'wp-auth0' ) .
-			__( 'To enable SSO, please use the Universal Login Page setting below. ', 'wp-auth0' )
+			__( 'To enable SSO, please use the Universal Login Page setting above', 'wp-auth0' )
 		);
 		$this->render_field_description(
 			__( 'Turning this on will attempt SSO on wp-login.php. ', 'wp-auth0' ) .

--- a/phpcs-test-ruleset.xml
+++ b/phpcs-test-ruleset.xml
@@ -21,7 +21,9 @@
     <config name="testVersion" value="7.1-"/>
     <rule ref="PHPCompatibilityWP"/>
 
-    <rule ref="Generic.CodeAnalysis"/>
+    <rule ref="Generic.CodeAnalysis">
+        <exclude name="Generic.CodeAnalysis.EmptyStatement.DetectedCatch"/>
+    </rule>
     <rule ref="Generic.Commenting.Todo"/>
     <rule ref="WordPress-Docs"/>
     <rule ref="WordPress-Core">

--- a/templates/login-form.php
+++ b/templates/login-form.php
@@ -12,7 +12,8 @@ function renderAuth0Form( $canShowLegacyLogin = true, $specialSettings = array()
 		// If we're on wp-login.php and SSO is enabled, load Auth0.js.
 		$check_sso = $GLOBALS['pagenow'] === 'wp-login.php' && $use_sso;
 		if ( $check_sso ) {
-			wp_enqueue_script( 'wpa0_auth0js', $options->get( 'auth0js-cdn' ), false, null, true );
+			$auth0_js_url = apply_filters( 'auth0_sso_auth0js_url', WPA0_AUTH0_JS_CDN_URL );
+			wp_enqueue_script( 'wpa0_auth0js', $auth0_js_url, false, null, true );
 		}
 
 		wp_enqueue_script( 'wpa0_lock', $options->get_lock_url(), array( 'jquery' ), false, true );

--- a/tests/testLoginManagerInitAuth0.php
+++ b/tests/testLoginManagerInitAuth0.php
@@ -1,0 +1,154 @@
+<?php
+/**
+ * Contains Class TestLoginManagerInitAuth0.
+ *
+ * @package WP-Auth0
+ *
+ * @since 3.10.0
+ */
+
+/**
+ * Class TestLoginManagerInitAuth0.
+ * Test the WP_Auth0_LoginManager::init_auth0() method.
+ */
+class TestLoginManagerInitAuth0 extends WP_Auth0_Test_Case {
+
+	use DomDocumentHelpers;
+
+	use RedirectHelpers;
+
+	use UsersHelper;
+
+	/**
+	 * WP_Auth0_LoginManager instance to test.
+	 *
+	 * @var WP_Auth0_LoginManager
+	 */
+	protected $login;
+
+	/**
+	 * Runs before each test method.
+	 */
+	public function setUp() {
+		parent::setUp();
+		$this->login = new WP_Auth0_LoginManager( new WP_Auth0_UsersRepo( self::$opts ), self::$opts );
+		add_filter( 'wp_die_handler', [ 'TestLoginManagerInitAuth0', 'wp_die_handler' ] );
+	}
+
+	/**
+	 * Runs after each test method.
+	 */
+	public function tearDown() {
+		parent::tearDown();
+		remove_filter( 'wp_die_handler', [ 'TestLoginManagerInitAuth0', 'wp_die_handler' ] );
+	}
+
+	/**
+	 * Provide the function to handle wp_die.
+	 *
+	 * @return array
+	 */
+	public static function wp_die_handler() {
+		return [ 'TestLoginManagerInitAuth0', 'wp_die_die' ];
+	}
+
+	/**
+	 * Handle wp_die.
+	 *
+	 * @param string $html - Passed-in HTML to display.
+	 *
+	 * @throws \Exception - Always.
+	 */
+	public static function wp_die_die( $html ) {
+		throw new Exception( $html );
+	}
+
+	/**
+	 * Test that Auth0 is not initialized if the plugin is not ready or if the callback URL is not correct.
+	 */
+	public function testThatNothingHappensIfNotReady() {
+		$this->assertFalse( $this->login->init_auth0() );
+		$_REQUEST['auth0'] = 1;
+		$this->assertFalse( $this->login->init_auth0() );
+		self::auth0Ready( true );
+		unset( $_REQUEST['auth0'] );
+		$this->assertFalse( $this->login->init_auth0() );
+
+		$output = '';
+		try {
+			$_REQUEST['auth0'] = 1;
+			$this->login->init_auth0();
+		} catch ( Exception $e ) {
+			$output = $e->getMessage();
+		}
+
+		$this->assertNotEmpty( $output );
+	}
+
+	/**
+	 * Test that an error in the URL parameter stops the callback with an error.
+	 */
+	public function testThatErrorInUrlStopsCallback() {
+		self::$opts->set( 'domain', 'test.auth0.com' );
+		self::$opts->set( 'client_id', '__test_client_id__' );
+		self::$opts->set( 'client_secret', uniqid() );
+		$_REQUEST['auth0']             = 1;
+		$_REQUEST['error']             = '__test_error_code__';
+		$_REQUEST['error_description'] = '__test_error_description__';
+
+		$output = '';
+		try {
+			$this->login->init_auth0();
+		} catch ( Exception $e ) {
+			$output = $e->getMessage();
+		}
+
+		$this->assertContains( 'There was a problem with your log in', $output );
+		$this->assertContains( '__test_error_description__', $output );
+		$this->assertContains( 'error code', $output );
+		$this->assertContains( '__test_error_code__', $output );
+		$this->assertContains( '<a href="https://test.auth0.com/v2/logout?client_id=__test_client_id__', $output );
+	}
+
+	/**
+	 * Test that a logged-in user is redirected from the callback without any processing.
+	 */
+	public function testThatLoggedInUserIsRedirected() {
+		$this->startRedirectHalting();
+		$_REQUEST['auth0'] = 1;
+		self::auth0Ready();
+		$this->setGlobalUser();
+
+		$caught_redirect = [];
+		try {
+			$this->login->init_auth0();
+		} catch ( Exception $e ) {
+			$caught_redirect = unserialize( $e->getMessage() );
+		}
+
+		$this->assertEquals( self::$opts->get( 'default_login_redirection' ), $caught_redirect['location'] );
+	}
+
+	/**
+	 * Test that invalid state stops the callback with an error.
+	 */
+	public function testThatInvalidStateStopsCallback() {
+		$_REQUEST['auth0'] = 1;
+		self::$opts->set( 'domain', 'test.auth0.com' );
+		self::$opts->set( 'client_id', '__test_client_id__' );
+		self::$opts->set( 'client_secret', uniqid() );
+
+		$output = '';
+		try {
+			$this->login->init_auth0();
+		} catch ( Exception $e ) {
+			$output = $e->getMessage();
+		}
+
+		$this->assertContains( 'There was a problem with your log in', $output );
+		$this->assertContains( 'Invalid state', $output );
+		$this->assertContains( 'error code', $output );
+		$this->assertContains( 'unknown', $output );
+		$this->assertContains( '<a href="https://test.auth0.com/v2/logout?client_id=__test_client_id__', $output );
+	}
+}

--- a/tests/testLoginManagerInitAuth0.php
+++ b/tests/testLoginManagerInitAuth0.php
@@ -95,6 +95,7 @@ class TestLoginManagerInitAuth0 extends WP_Auth0_Test_Case {
 		$_REQUEST['auth0']             = 1;
 		$_REQUEST['error']             = '__test_error_code__';
 		$_REQUEST['error_description'] = '__test_error_description__';
+		$this->setGlobalUser();
 
 		$output = '';
 		try {
@@ -108,6 +109,7 @@ class TestLoginManagerInitAuth0 extends WP_Auth0_Test_Case {
 		$this->assertContains( 'error code', $output );
 		$this->assertContains( '__test_error_code__', $output );
 		$this->assertContains( '<a href="https://test.auth0.com/v2/logout?client_id=__test_client_id__', $output );
+		$this->assertFalse( is_user_logged_in() );
 	}
 
 	/**


### PR DESCRIPTION
### Changes

- Redirect to the Auth0 logout link when attempting to re-login after a callback error occurs. This will avoid loops caused by SSO. 
- Clear the WP session when a callback error occurs.
- Set single logout on by default (to avoid login loops when ULP is on)
- Reorder options on the Features tab.

### Testing

* [x] This change adds unit test coverage
* [x] This change has been tested on WP 5.1.1

### Checklist

* [x] All existing and new tests complete without errors
* [x] All code quality tools/guidelines in the [Contribution guide](CONTRIBUTION.md) have been run/followed
* [x] All active GitHub CI checks have passed
