### PR TITLE
Deprecate WP_Auth0_Options_Generic

### DIFF
--- a/lib/WP_Auth0_Api_Operations.php
+++ b/lib/WP_Auth0_Api_Operations.php
@@ -3,7 +3,7 @@ class WP_Auth0_Api_Operations {
 
 	protected $a0_options;
 
-	public function __construct( WP_Auth0_Options_Generic $a0_options ) {
+	public function __construct( WP_Auth0_Options $a0_options ) {
 		$this->a0_options = $a0_options;
 	}
 

--- a/lib/WP_Auth0_Options_Generic.php
+++ b/lib/WP_Auth0_Options_Generic.php
@@ -7,6 +7,8 @@
 
 /**
  * Class WP_Auth0_Options_Generic.
+ *
+ * @deprecated - 3.10.0, will be merged into WP_Auth0_Options on the next major.
  */
 class WP_Auth0_Options_Generic {
 
@@ -34,6 +36,8 @@ class WP_Auth0_Options_Generic {
 	/**
 	 * WP_Auth0_Options_Generic constructor.
 	 * Finds and stores all constant-defined settings values.
+	 *
+	 * @deprecated - 3.10.0, will be merged into WP_Auth0_Options on the next major.
 	 */
 	public function __construct() {
 		$option_keys = $this->get_defaults( true );

--- a/lib/admin/WP_Auth0_Admin_Advanced.php
+++ b/lib/admin/WP_Auth0_Admin_Advanced.php
@@ -22,10 +22,10 @@ class WP_Auth0_Admin_Advanced extends WP_Auth0_Admin_Generic {
 	/**
 	 * WP_Auth0_Admin_Advanced constructor.
 	 *
-	 * @param WP_Auth0_Options_Generic $options
-	 * @param WP_Auth0_Routes          $router
+	 * @param WP_Auth0_Options $options
+	 * @param WP_Auth0_Routes  $router
 	 */
-	public function __construct( WP_Auth0_Options_Generic $options, WP_Auth0_Routes $router ) {
+	public function __construct( WP_Auth0_Options $options, WP_Auth0_Routes $router ) {
 		parent::__construct( $options );
 		$this->router       = $router;
 		$this->_description = __( 'Settings related to specific scenarios.', 'wp-auth0' );

--- a/lib/admin/WP_Auth0_Admin_Appearance.php
+++ b/lib/admin/WP_Auth0_Admin_Appearance.php
@@ -16,9 +16,9 @@ class WP_Auth0_Admin_Appearance extends WP_Auth0_Admin_Generic {
 	/**
 	 * WP_Auth0_Admin_Appearance constructor.
 	 *
-	 * @param WP_Auth0_Options_Generic $options
+	 * @param WP_Auth0_Options $options
 	 */
-	public function __construct( WP_Auth0_Options_Generic $options ) {
+	public function __construct( WP_Auth0_Options $options ) {
 		parent::__construct( $options );
 		$this->_description =
 			__( 'Change the how the embedded Auth0 login form is displayed. ', 'wp-auth0' ) .

--- a/lib/admin/WP_Auth0_Admin_Basic.php
+++ b/lib/admin/WP_Auth0_Admin_Basic.php
@@ -19,9 +19,9 @@ class WP_Auth0_Admin_Basic extends WP_Auth0_Admin_Generic {
 	/**
 	 * WP_Auth0_Admin_Basic constructor.
 	 *
-	 * @param WP_Auth0_Options_Generic $options
+	 * @param WP_Auth0_Options $options
 	 */
-	public function __construct( WP_Auth0_Options_Generic $options ) {
+	public function __construct( WP_Auth0_Options $options ) {
 		parent::__construct( $options );
 		$this->_description = __( 'Basic settings related to the Auth0 integration.', 'wp-auth0' );
 	}

--- a/lib/admin/WP_Auth0_Admin_Dashboard.php
+++ b/lib/admin/WP_Auth0_Admin_Dashboard.php
@@ -22,9 +22,9 @@ class WP_Auth0_Admin_Dashboard extends WP_Auth0_Admin_Generic {
 	 *
 	 * @deprecated - 3.6.0, the plugin no longer supports the dashboard widgets functionality.
 	 *
-	 * @param WP_Auth0_Options_Generic $options
+	 * @param WP_Auth0_Options $options
 	 */
-	public function __construct( WP_Auth0_Options_Generic $options ) {
+	public function __construct( WP_Auth0_Options $options ) {
 		// phpcs:ignore
 		@trigger_error( sprintf( __( 'Class %s is deprecated.', 'wp-auth0' ), __CLASS__ ), E_USER_DEPRECATED );
 		parent::__construct( $options );

--- a/lib/admin/WP_Auth0_Admin_Features.php
+++ b/lib/admin/WP_Auth0_Admin_Features.php
@@ -16,9 +16,9 @@ class WP_Auth0_Admin_Features extends WP_Auth0_Admin_Generic {
 	/**
 	 * WP_Auth0_Admin_Features constructor.
 	 *
-	 * @param WP_Auth0_Options_Generic $options
+	 * @param WP_Auth0_Options $options
 	 */
-	public function __construct( WP_Auth0_Options_Generic $options ) {
+	public function __construct( WP_Auth0_Options $options ) {
 		parent::__construct( $options );
 		$this->_description = __( 'Settings related to specific features provided by the plugin.', 'wp-auth0' );
 	}

--- a/lib/admin/WP_Auth0_Admin_Generic.php
+++ b/lib/admin/WP_Auth0_Admin_Generic.php
@@ -15,9 +15,9 @@ class WP_Auth0_Admin_Generic {
 	/**
 	 * WP_Auth0_Admin_Generic constructor.
 	 *
-	 * @param WP_Auth0_Options_Generic $options
+	 * @param WP_Auth0_Options $options
 	 */
-	public function __construct( WP_Auth0_Options_Generic $options ) {
+	public function __construct( WP_Auth0_Options $options ) {
 		$this->options      = $options;
 		$this->_option_name = $options->get_options_name();
 	}

--- a/tests/testConstantSettings.php
+++ b/tests/testConstantSettings.php
@@ -18,7 +18,7 @@ class TestConstantSettings extends WP_Auth0_Test_Case {
 	/**
 	 * Default constant setting prefix.
 	 *
-	 * @see WP_Auth0_Options_Generic::get_constant_name()
+	 * @see WP_Auth0_Options::get_constant_name()
 	 */
 	const CONSTANT_PREFIX = 'AUTH0_ENV_';
 

--- a/tests/testWPAuth0Options.php
+++ b/tests/testWPAuth0Options.php
@@ -34,9 +34,6 @@ class TestWPAuth0Options extends WP_Auth0_Test_Case {
 		// Make sure the number of options has not changed unintentionally.
 		$this->assertEquals( self::DEFAULT_OPTIONS_COUNT, count( $opts->get_options() ) );
 		$this->assertEquals( self::DEFAULT_OPTIONS_COUNT, count( $opts->get_defaults() ) );
-
-		$opts_generic = new WP_Auth0_Options_Generic();
-		$this->assertEmpty( $opts_generic->get_defaults() );
 	}
 
 	/**


### PR DESCRIPTION
### Changes

Official deprecation for the `WP_Auth0_Options_Generic` parent class. All active methods will be merged into `WP_Auth0_Options` child class in the next major. 