### PR TITLE
Fix options overwriting with defaults and removing constant values on update

### DIFF
--- a/lib/WP_Auth0_DBManager.php
+++ b/lib/WP_Auth0_DBManager.php
@@ -149,22 +149,22 @@ class WP_Auth0_DBManager {
 			}
 
 			// Nullify and delete all removed options.
-			$options->remove( 'auth0js-cdn', false );
-			$options->remove( 'passwordless_cdn_url', false );
-			$options->remove( 'cdn_url_legacy', false );
+			$options->remove( 'auth0js-cdn' );
+			$options->remove( 'passwordless_cdn_url' );
+			$options->remove( 'cdn_url_legacy' );
 
-			$options->remove( 'social_twitter_key', false );
-			$options->remove( 'social_twitter_secret', false );
-			$options->remove( 'social_facebook_key', false );
-			$options->remove( 'social_facebook_secret', false );
-			$options->remove( 'connections', false );
+			$options->remove( 'social_twitter_key' );
+			$options->remove( 'social_twitter_secret' );
+			$options->remove( 'social_facebook_key' );
+			$options->remove( 'social_facebook_secret' );
+			$options->remove( 'connections' );
 
-			$options->remove( 'chart_idp_type', false );
-			$options->remove( 'chart_gender_type', false );
-			$options->remove( 'chart_age_type', false );
-			$options->remove( 'chart_age_from', false );
-			$options->remove( 'chart_age_to', false );
-			$options->remove( 'chart_age_step', false );
+			$options->remove( 'chart_idp_type' );
+			$options->remove( 'chart_gender_type' );
+			$options->remove( 'chart_age_type' );
+			$options->remove( 'chart_age_from' );
+			$options->remove( 'chart_age_to' );
+			$options->remove( 'chart_age_step' );
 
 			// Migrate WLE setting
 			$new_wle_value = $options->get( 'wordpress_login_enabled' ) ? 'link' : 'isset';

--- a/lib/WP_Auth0_Options_Generic.php
+++ b/lib/WP_Auth0_Options_Generic.php
@@ -151,13 +151,13 @@ class WP_Auth0_Options_Generic {
 	 * @return bool
 	 */
 	public function set( $key, $value, $should_update = true ) {
-		$options = $this->get_options();
 
 		// Cannot set a setting that is being overridden by a constant.
 		if ( $this->has_constant_val( $key ) ) {
 			return false;
 		}
 
+		$options         = $this->get_options();
 		$options[ $key ] = $value;
 		$this->_opts     = $options;
 
@@ -175,13 +175,13 @@ class WP_Auth0_Options_Generic {
 	 * @param string $key - Option key name to remove.
 	 */
 	public function remove( $key ) {
-		$options = $this->get_options();
 
 		// Cannot remove a setting that is being overridden by a constant.
 		if ( $this->has_constant_val( $key ) ) {
 			return;
 		}
 
+		$options = $this->get_options();
 		unset( $options[ $key ] );
 		$this->_opts = $options;
 	}

--- a/lib/WP_Auth0_Options_Generic.php
+++ b/lib/WP_Auth0_Options_Generic.php
@@ -170,12 +170,11 @@ class WP_Auth0_Options_Generic {
 	}
 
 	/**
-	 * Remove a setting from the options array.
+	 * Remove a setting from the options array in memory.
 	 *
 	 * @param string $key - Option key name to remove.
-	 * @param bool   $should_update - Flag to update DB options array with value stored in memory.
 	 */
-	public function remove( $key, $should_update = true ) {
+	public function remove( $key ) {
 		$options = $this->get_options();
 
 		// Cannot remove a setting that is being overridden by a constant.
@@ -185,10 +184,6 @@ class WP_Auth0_Options_Generic {
 
 		unset( $options[ $key ] );
 		$this->_opts = $options;
-
-		if ( $should_update ) {
-			$this->update_all();
-		}
 	}
 
 	/**

--- a/lib/WP_Auth0_Options_Generic.php
+++ b/lib/WP_Auth0_Options_Generic.php
@@ -174,7 +174,27 @@ class WP_Auth0_Options_Generic {
 		return $this->update_all();
 	}
 
-	public function remove( $key, $should_update = true ) {}
+	/**
+	 * Remove a setting from the options array.
+	 *
+	 * @param string $key - Option key name to remove.
+	 * @param bool   $should_update - Flag to update DB options array with value stored in memory.
+	 */
+	public function remove( $key, $should_update = true ) {
+		$options = $this->get_options();
+
+		// Cannot remove a setting that is being overridden by a constant.
+		if ( $this->has_constant_val( $key ) ) {
+			return;
+		}
+
+		unset( $options[ $key ] );
+		$this->_opts = $options;
+
+		if ( $should_update ) {
+			$this->update_all();
+		}
+	}
 
 	/**
 	 * Save the options array as it exists in memory.
@@ -182,10 +202,12 @@ class WP_Auth0_Options_Generic {
 	 * @return bool
 	 */
 	public function update_all() {
+		$options = $this->get_options();
+
 		foreach ( $this->get_all_constant_keys() as $key ) {
-			unset( $this->_opts[ $key ] );
+			unset( $options[ $key ] );
 		}
-		return update_option( $this->_options_name, $this->_opts );
+		return update_option( $this->_options_name, $options );
 	}
 
 	/**

--- a/lib/WP_Auth0_Options_Generic.php
+++ b/lib/WP_Auth0_Options_Generic.php
@@ -174,6 +174,8 @@ class WP_Auth0_Options_Generic {
 		return $this->update_all();
 	}
 
+	public function remove( $key, $should_update = true ) {}
+
 	/**
 	 * Save the options array as it exists in memory.
 	 *

--- a/lib/WP_Auth0_Options_Generic.php
+++ b/lib/WP_Auth0_Options_Generic.php
@@ -110,14 +110,9 @@ class WP_Auth0_Options_Generic {
 	public function get_options() {
 		if ( empty( $this->_opts ) ) {
 			$options = get_option( $this->_options_name, array() );
+			// Brand new install, no saved options so get all defaults.
 			if ( empty( $options ) || ! is_array( $options ) ) {
-
-				// Brand new install, no saved options so get all defaults.
 				$options = $this->defaults();
-			} else {
-
-				// Make sure we have settings for everything we need.
-				$options = array_merge( $this->defaults(), $options );
 			}
 
 			// Check for constant overrides and replace.

--- a/tests/testConstantSettings.php
+++ b/tests/testConstantSettings.php
@@ -88,19 +88,22 @@ class TestConstantSettings extends WP_Auth0_Test_Case {
 	 * @runInSeparateProcess
 	 */
 	public function testSetWithConstant() {
-		$opt_name     = 'domain';
 		$constant_val = rand();
 
 		// Set a constant and make sure it works.
 		define( self::CONSTANT_PREFIX . 'DOMAIN', $constant_val );
 		$opts = new WP_Auth0_Options();
-		$this->assertEquals( $constant_val, $opts->get( $opt_name ) );
+		$this->assertEquals( $constant_val, $opts->get( 'domain' ) );
 
 		// Try to set an option with the constant set.
 		$new_value  = str_shuffle( $constant_val );
-		$set_result = $opts->set( $opt_name, $new_value, false );
+		$set_result = $opts->set( 'domain', $new_value );
 		$this->assertFalse( $set_result );
-		$this->assertEquals( $constant_val, $opts->get( $opt_name ) );
+		$this->assertEquals( $constant_val, $opts->get( 'domain' ) );
+
+		// Test that the constant value remains if a new option is set.
+		$opts->set( 'client_id', $new_value );
+		$this->assertEquals( $constant_val, $opts->get( 'domain' ) );
 	}
 
 	/**

--- a/tests/testWPAuth0DbMigrations.php
+++ b/tests/testWPAuth0DbMigrations.php
@@ -14,41 +14,6 @@
 class TestWPAuth0DbMigrations extends WP_Auth0_Test_Case {
 
 	/**
-	 * Test a DB upgrade from v18 to v19.
-	 */
-	public function testV19Update() {
-		$test_version        = 19;
-		$initial_connections = [
-			'social_twitter_key'     => '__twitter_key_test__',
-			'social_twitter_secret'  => '__twitter_secret_test__',
-			'social_facebook_key'    => '__facebook_key_test__',
-			'social_facebook_secret' => '__facebook_secret_test__',
-		];
-
-		$connection_keys = array_keys( $initial_connections );
-
-			// Save a 'connections' settings array.
-		self::$opts->set( 'connections', $initial_connections );
-		$saved_connections = self::$opts->get( 'connections' );
-		$this->assertEquals( $initial_connections, $saved_connections );
-
-		// Run the migration for v19.
-		update_option( 'auth0_db_version', $test_version - 1 );
-		$db_manager = new WP_Auth0_DBManager( self::$opts );
-		$db_manager->init();
-
-		foreach ( $connection_keys as $key ) {
-			$this->assertEmpty( self::$opts->get( $key ) );
-		}
-
-		$db_manager->install_db( $test_version, null );
-
-		foreach ( $connection_keys as $key ) {
-			$this->assertEquals( $initial_connections[ $key ], self::$opts->get( $key ) );
-		}
-	}
-
-	/**
 	 * Test a DB upgrade from v19 to v20.
 	 */
 	public function testV20Update() {

--- a/tests/testWPAuth0Options.php
+++ b/tests/testWPAuth0Options.php
@@ -49,6 +49,22 @@ class TestWPAuth0Options extends WP_Auth0_Test_Case {
 	}
 
 	/**
+	 * Test that a missing option (considered an empty value) is not updated to a default "on" value.
+	 */
+	public function testThatGetOptionsDoesNotUseDefaultsWhenNotEmpty() {
+
+		$db_options = get_option( self::OPTIONS_NAME );
+		unset( $db_options['auto_login'] );
+		unset( $db_options['singlelogout'] );
+		update_option( self::OPTIONS_NAME, $db_options );
+
+		$opts = new WP_Auth0_Options();
+
+		$this->assertEmpty( $opts->get( 'auto_login' ) );
+		$this->assertEmpty( $opts->get( 'singlelogout' ) );
+	}
+
+	/**
 	 * Test the wp_auth0_get_option filter.
 	 */
 	public function testThatFiltersOverrideValues() {

--- a/tests/testWPAuth0Options.php
+++ b/tests/testWPAuth0Options.php
@@ -170,6 +170,34 @@ class TestWPAuth0Options extends WP_Auth0_Test_Case {
 	}
 
 	/**
+	 * Test that the remove method will only update options in memory when indicated.
+	 */
+	public function testThatRemoveWithoutDbUpdateStaysInMemory() {
+		$opts = new WP_Auth0_Options();
+		$opts->set( 'domain', '__test_domain__' );
+		$this->assertNotNull( $opts->get( 'domain' ) );
+
+		$opts->remove( 'domain', false );
+		$this->assertNull( $opts->get( 'domain' ) );
+		$db_options = get_option( $opts->get_options_name() );
+		$this->assertEquals( '__test_domain__', $db_options['domain'] );
+	}
+
+	/**
+	 * Test that the remove method update options in the database by default.
+	 */
+	public function testThatRemoveWithDbUpdateIsSaved() {
+		$opts = new WP_Auth0_Options();
+		$opts->set( 'client_id', '__test_client_id__' );
+		$this->assertNotNull( $opts->get( 'client_id' ) );
+
+		$opts->remove( 'client_id' );
+		$this->assertNull( $opts->get( 'client_id' ) );
+		$db_options = get_option( $opts->get_options_name() );
+		$this->assertArrayNotHasKey( 'client_id', $db_options );
+	}
+
+	/**
 	 * Test that the can_show_wp_login_form returns the right bool depending on settings and globals.
 	 */
 	public function testThatCanShowWpLoginFormReturnsCorrectly() {

--- a/tests/testWPAuth0Options.php
+++ b/tests/testWPAuth0Options.php
@@ -186,31 +186,17 @@ class TestWPAuth0Options extends WP_Auth0_Test_Case {
 	}
 
 	/**
-	 * Test that the remove method will only update options in memory when indicated.
+	 * Test that the remove method will only update options in memory.
 	 */
-	public function testThatRemoveWithoutDbUpdateStaysInMemory() {
+	public function testThatRemoveStaysInMemory() {
 		$opts = new WP_Auth0_Options();
 		$opts->set( 'domain', '__test_domain__' );
 		$this->assertNotNull( $opts->get( 'domain' ) );
 
-		$opts->remove( 'domain', false );
+		$opts->remove( 'domain' );
 		$this->assertNull( $opts->get( 'domain' ) );
 		$db_options = get_option( $opts->get_options_name() );
 		$this->assertEquals( '__test_domain__', $db_options['domain'] );
-	}
-
-	/**
-	 * Test that the remove method update options in the database by default.
-	 */
-	public function testThatRemoveWithDbUpdateIsSaved() {
-		$opts = new WP_Auth0_Options();
-		$opts->set( 'client_id', '__test_client_id__' );
-		$this->assertNotNull( $opts->get( 'client_id' ) );
-
-		$opts->remove( 'client_id' );
-		$this->assertNull( $opts->get( 'client_id' ) );
-		$db_options = get_option( $opts->get_options_name() );
-		$this->assertArrayNotHasKey( 'client_id', $db_options );
 	}
 
 	/**


### PR DESCRIPTION
### Changes

This PR fixes 2 issues that surface during database migrations. 

- Fix updating options removes constant-set values from memory
- Fix getting options replacing empty values with defaults
- Update database migrations to batch-save new options
- Add `remove()` method to remove option keys from memory and database 

### Testing

**See commit log for commits with failing tests.**

* [x] This change adds unit test coverage
* [x] This change has been tested on WP 5.2-beta

### Checklist

* [x] All existing and new tests complete without errors
* [x] All code quality tools/guidelines in the [Contribution guide](CONTRIBUTION.md) have been run/followed
* [x] All active GitHub CI checks have passed
