### PR TITLE
Fix PHP notice when there is no language_dictionary

### DIFF
--- a/lib/admin/WP_Auth0_Admin_Advanced.php
+++ b/lib/admin/WP_Auth0_Admin_Advanced.php
@@ -588,18 +588,6 @@ class WP_Auth0_Admin_Advanced extends WP_Auth0_Admin_Generic {
 			self::add_validation_error( __( 'The Lock JS CDN URL used is not a valid URL.', 'wp-auth0' ) );
 		}
 
-		$input['social_twitter_key'] = isset( $input['social_twitter_key'] ) ?
-			sanitize_text_field( $input['social_twitter_key'] ) : '';
-
-		$input['social_twitter_secret'] = isset( $input['social_twitter_secret'] ) ?
-			sanitize_text_field( $input['social_twitter_secret'] ) : '';
-
-		$input['social_facebook_key'] = isset( $input['social_facebook_key'] ) ?
-			sanitize_text_field( $input['social_facebook_key'] ) : '';
-
-		$input['social_facebook_secret'] = isset( $input['social_facebook_secret'] ) ?
-			sanitize_text_field( $input['social_facebook_secret'] ) : '';
-
 		$input['migration_ips_filter'] = ( ! empty( $input['migration_ips_filter'] ) ? 1 : 0 );
 
 		$input['migration_ips'] = isset( $input['migration_ips'] ) ?

--- a/lib/admin/WP_Auth0_Admin_Appearance.php
+++ b/lib/admin/WP_Auth0_Admin_Appearance.php
@@ -479,7 +479,8 @@ class WP_Auth0_Admin_Appearance extends WP_Auth0_Admin_Generic {
 		$input['language']           = sanitize_text_field( $input['language'] );
 		$input['primary_color']      = sanitize_text_field( $input['primary_color'] );
 
-		if ( trim( $input['language_dictionary'] ) !== '' ) {
+		$input['language_dictionary'] = isset( $input['language_dictionary'] ) ? trim( $input['language_dictionary'] ) : '';
+		if ( ! empty( $input['language_dictionary'] ) ) {
 			if ( json_decode( $input['language_dictionary'] ) === null ) {
 				$error = __( 'The language dictionary parameter should be a valid json object.', 'wp-auth0' );
 				$this->add_validation_error( $error );


### PR DESCRIPTION
### Changes

- Fix a PHP notice that occurs when there is no `language_dictionary` field during settings save
- Remove validation for removed settings
