### PR TITLE
Check for email update in migration-ws-get-user endpoint

### DIFF
--- a/lib/WP_Auth0_Routes.php
+++ b/lib/WP_Auth0_Routes.php
@@ -181,7 +181,7 @@ class WP_Auth0_Routes {
 			$user = wp_authenticate( $_POST['username'], $_POST['password'] );
 
 			if ( is_wp_error( $user ) ) {
-				throw new Exception( __( 'Invalid Credentials', 'wp-auth0' ), 401 );
+				throw new Exception( __( 'Invalid credentials', 'wp-auth0' ), 401 );
 			}
 
 			unset( $user->data->user_pass );
@@ -198,6 +198,7 @@ class WP_Auth0_Routes {
 
 	/**
 	 * User migration get user route used by custom database Login script.
+	 * This is used for email changes made in Auth0.
 	 *
 	 * @return array
 	 *
@@ -221,7 +222,15 @@ class WP_Auth0_Routes {
 			}
 
 			if ( ! $user ) {
-				throw new Exception( __( 'Invalid Credentials', 'wp-auth0' ), 401 );
+				throw new Exception( __( 'User not found', 'wp-auth0' ), 401 );
+			}
+
+			$updated_email = WP_Auth0_UsersRepo::get_meta( $user->ID, WP_Auth0_Profile_Change_Email::UPDATED_EMAIL );
+			if ( $updated_email === $user->data->user_email ) {
+				return array(
+					'status' => 200,
+					'error'  => 'Email update in process',
+				);
 			}
 
 			unset( $user->data->user_pass );

--- a/lib/WP_Auth0_UsersRepo.php
+++ b/lib/WP_Auth0_UsersRepo.php
@@ -219,16 +219,14 @@ class WP_Auth0_UsersRepo {
 	 * @param stdClass $userinfo - User profile object from Auth0.
 	 */
 	public function update_auth0_object( $user_id, $userinfo ) {
-		global $wpdb;
-
 		$auth0_user_id = isset( $userinfo->user_id ) ? $userinfo->user_id : $userinfo->sub;
-		update_user_meta( $user_id, $wpdb->prefix . 'auth0_id', $auth0_user_id );
+		self::update_meta( $user_id, 'auth0_id', $auth0_user_id );
 
 		$userinfo_encoded = WP_Auth0_Serializer::serialize( $userinfo );
 		$userinfo_encoded = wp_slash( $userinfo_encoded );
-		update_user_meta( $user_id, $wpdb->prefix . 'auth0_obj', $userinfo_encoded );
+		self::update_meta( $user_id, 'auth0_obj', $userinfo_encoded );
 
-		update_user_meta( $user_id, $wpdb->prefix . 'last_update', date( 'c' ) );
+		self::update_meta( $user_id, 'last_update', date( 'c' ) );
 	}
 
 	/**
@@ -237,10 +235,10 @@ class WP_Auth0_UsersRepo {
 	 * @param int $user_id - WordPress user ID.
 	 */
 	public function delete_auth0_object( $user_id ) {
-		global $wpdb;
-		delete_user_meta( $user_id, $wpdb->prefix . 'auth0_id' );
-		delete_user_meta( $user_id, $wpdb->prefix . 'auth0_obj' );
-		delete_user_meta( $user_id, $wpdb->prefix . 'last_update' );
+		self::delete_meta( $user_id, 'auth0_id' );
+		self::delete_meta( $user_id, 'auth0_obj' );
+		self::delete_meta( $user_id, 'last_update' );
+		self::delete_meta( $user_id, 'auth0_transient_email_update' );
 	}
 
 	/**
@@ -256,5 +254,36 @@ class WP_Auth0_UsersRepo {
 	public static function get_meta( $user_id, $key ) {
 		global $wpdb;
 		return get_user_meta( $user_id, $wpdb->prefix . $key, true );
+	}
+
+	/**
+	 * Update a user's Auth0 meta data.
+	 *
+	 * @param integer $user_id - WordPress user ID.
+	 * @param string  $key - Usermeta key to update.
+	 * @param mixed   $value - Usermeta value to use.
+	 *
+	 * @return int|bool
+	 *
+	 * @since 3.11.0
+	 */
+	public static function update_meta( $user_id, $key, $value ) {
+		global $wpdb;
+		return update_user_meta( $user_id, $wpdb->prefix . $key, $value );
+	}
+
+	/**
+	 * Delete a user's Auth0 meta data.
+	 *
+	 * @param integer $user_id - WordPress user ID.
+	 * @param string  $key - Usermeta key to delete.
+	 *
+	 * @return bool
+	 *
+	 * @since 3.11.0
+	 */
+	public static function delete_meta( $user_id, $key ) {
+		global $wpdb;
+		return delete_user_meta( $user_id, $wpdb->prefix . $key );
 	}
 }

--- a/tests/testRoutesLogin.php
+++ b/tests/testRoutesLogin.php
@@ -212,7 +212,7 @@ class TestRoutesLogin extends WP_Auth0_Test_Case {
 		$output = json_decode( self::$routes->custom_requests( self::$wp, true ) );
 
 		$this->assertEquals( 401, $output->status );
-		$this->assertEquals( 'Invalid Credentials', $output->error );
+		$this->assertEquals( 'Invalid credentials', $output->error );
 
 		$log = self::$error_log->get();
 		$this->assertCount( 1, $log );

--- a/tests/testUserRepoMeta.php
+++ b/tests/testUserRepoMeta.php
@@ -94,20 +94,19 @@ class TestUserRepoMeta extends WP_Auth0_Test_Case {
 	 */
 	public function testThatDeleteMetaDeletesData() {
 		$users_repo = new WP_Auth0_UsersRepo( self::$opts );
-		$this->assertEmpty( $users_repo::get_meta( 1, 'auth0_id' ) );
-		$this->assertEmpty( $users_repo::get_meta( 1, 'auth0_obj' ) );
-		$this->assertEmpty( $users_repo::get_meta( 1, 'last_update' ) );
-
 		$this->storeAuth0Data( 1 );
+		update_user_meta( 1, 'wp_auth0_transient_email_update', uniqid() );
 
 		$this->assertNotEmpty( $users_repo::get_meta( 1, 'auth0_id' ) );
 		$this->assertNotEmpty( $users_repo::get_meta( 1, 'auth0_obj' ) );
 		$this->assertNotEmpty( $users_repo::get_meta( 1, 'last_update' ) );
+		$this->assertNotEmpty( $users_repo::get_meta( 1, 'auth0_transient_email_update' ) );
 
 		$users_repo->delete_auth0_object( 1 );
 
 		$this->assertEmpty( $users_repo::get_meta( 1, 'auth0_id' ) );
 		$this->assertEmpty( $users_repo::get_meta( 1, 'auth0_obj' ) );
 		$this->assertEmpty( $users_repo::get_meta( 1, 'last_update' ) );
+		$this->assertEmpty( $users_repo::get_meta( 1, 'auth0_transient_email_update' ) );
 	}
 }

--- a/tests/testUserRepoMeta.php
+++ b/tests/testUserRepoMeta.php
@@ -95,7 +95,7 @@ class TestUserRepoMeta extends WP_Auth0_Test_Case {
 	public function testThatDeleteMetaDeletesData() {
 		$users_repo = new WP_Auth0_UsersRepo( self::$opts );
 		$this->storeAuth0Data( 1 );
-		update_user_meta( 1, 'wp_auth0_transient_email_update', uniqid() );
+		$users_repo::update_meta( 1, 'auth0_transient_email_update', uniqid() );
 
 		$this->assertNotEmpty( $users_repo::get_meta( 1, 'auth0_id' ) );
 		$this->assertNotEmpty( $users_repo::get_meta( 1, 'auth0_obj' ) );


### PR DESCRIPTION
### Changes

Fixes an issue where sites using a custom database could not update user email addresses from the WordPress profile. 

### References

[WP.org support forum thread](https://wordpress.org/support/topic/cant-change-email-using-profile-page-once-again/)

### Testing

[Tests for user meta changes](https://github.com/auth0/wp-auth0/pull/674/commits/b2e62c27058486b01631ebf30399d3d489344f14)

[Tests for email update flag](https://github.com/auth0/wp-auth0/pull/674/commits/2f193aa13730c4988b7119fdee2d4ab08c89fb78)

[Tests for get user route](https://github.com/auth0/wp-auth0/pull/674/commits/0e215dee9ea5313b897a84842b87e4eeb821067b)

* [x] This change adds unit test coverage
* [x] This change has been tested on WP 5.1.1

### Checklist

* [x] All existing and new tests complete without errors
* [x] All code quality tools/guidelines in the [Contribution guide](CONTRIBUTION.md) have been run/followed
* [x] All active GitHub CI checks have passed
