### PR TITLE
Fix Auth0 logout redirect

### DIFF
--- a/lib/WP_Auth0_LoginManager.php
+++ b/lib/WP_Auth0_LoginManager.php
@@ -560,12 +560,12 @@ class WP_Auth0_LoginManager {
 	 * @link https://codex.wordpress.org/Plugin_API/Action_Reference/wp_logout
 	 */
 	public function logout() {
-		$is_sso        = (bool) $this->a0_options->get( 'sso' );
-		$is_slo        = (bool) $this->a0_options->get( 'singlelogout' );
-		$is_auto_login = (bool) $this->a0_options->get( 'auto_login' );
+		if ( ! WP_Auth0::ready() ) {
+			return;
+		}
 
 		// If SSO/SLO is in use, redirect to Auth0 to logout there as well.
-		if ( $is_sso || $is_slo ) {
+		if ( $this->a0_options->get( 'sso' ) || $this->a0_options->get( 'singlelogout' ) ) {
 			$return_to    = apply_filters( 'auth0_slo_return_to', home_url() );
 			$redirect_url = $this->auth0_logout_url( $return_to );
 			$redirect_url = apply_filters( 'auth0_logout_url', $redirect_url );
@@ -574,7 +574,7 @@ class WP_Auth0_LoginManager {
 		}
 
 		// If auto-login is in use, cannot redirect back to login page.
-		if ( $is_auto_login ) {
+		if ( (bool) $this->a0_options->get( 'auto_login' ) ) {
 			wp_redirect( home_url() );
 			exit;
 		}

--- a/lib/WP_Auth0_LoginManager.php
+++ b/lib/WP_Auth0_LoginManager.php
@@ -574,7 +574,7 @@ class WP_Auth0_LoginManager {
 		}
 
 		// If auto-login is in use, cannot redirect back to login page.
-		if ( (bool) $this->a0_options->get( 'auto_login' ) ) {
+		if ( $this->a0_options->get( 'auto_login' ) ) {
 			wp_redirect( home_url() );
 			exit;
 		}

--- a/tests/testLoginManagerLogout.php
+++ b/tests/testLoginManagerLogout.php
@@ -4,7 +4,7 @@
  *
  * @package WP-Auth0
  *
- * @since 3.10.0
+ * @since 3.11.0
  */
 
 /**

--- a/tests/testLoginManagerLogout.php
+++ b/tests/testLoginManagerLogout.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * Contains Class TestLoginManagerLogout.
+ *
+ * @package WP-Auth0
+ *
+ * @since 3.10.0
+ */
+
+/**
+ * Class TestLoginManagerLogout.
+ * Test the WP_Auth0_LoginManager::logout() method.
+ */
+class TestLoginManagerLogout extends WP_Auth0_Test_Case {
+
+	use DomDocumentHelpers;
+
+	use RedirectHelpers;
+
+	use UsersHelper;
+
+	/**
+	 * WP_Auth0_LoginManager instance to test.
+	 *
+	 * @var WP_Auth0_LoginManager
+	 */
+	protected $login;
+
+	/**
+	 * Runs before each test method.
+	 */
+	public function setUp() {
+		parent::setUp();
+		$this->login = new WP_Auth0_LoginManager( new WP_Auth0_UsersRepo( self::$opts ), self::$opts );
+	}
+
+	/**
+	 *
+	 */
+	public function testThatNothingHappensIfNotReadyOrNotSsoSlo() {
+		$this->assertNull( $this->login->logout() );
+//		$_REQUEST['auth0'] = 1;
+//		$this->assertFalse( $this->login->init_auth0() );
+//		self::auth0Ready( true );
+//		unset( $_REQUEST['auth0'] );
+//		$this->assertFalse( $this->login->init_auth0() );
+//
+//		$output = '';
+//		try {
+//			$_REQUEST['auth0'] = 1;
+//			$this->login->init_auth0();
+//		} catch ( Exception $e ) {
+//			$output = $e->getMessage();
+//		}
+//
+//		$this->assertNotEmpty( $output );
+	}
+}

--- a/tests/testLoginManagerLogout.php
+++ b/tests/testLoginManagerLogout.php
@@ -13,11 +13,7 @@
  */
 class TestLoginManagerLogout extends WP_Auth0_Test_Case {
 
-	use DomDocumentHelpers;
-
 	use RedirectHelpers;
-
-	use UsersHelper;
 
 	/**
 	 * WP_Auth0_LoginManager instance to test.
@@ -35,24 +31,92 @@ class TestLoginManagerLogout extends WP_Auth0_Test_Case {
 	}
 
 	/**
-	 *
+	 * Test that logout does not redirect to Auth0 if the plugin is not ready (no domain or client ID).
+	 * This is the default state before the tests run.
 	 */
-	public function testThatNothingHappensIfNotReadyOrNotSsoSlo() {
+	public function testThatNothingHappensIfNotReady() {
+		$this->startRedirectHalting();
+
 		$this->assertNull( $this->login->logout() );
-//		$_REQUEST['auth0'] = 1;
-//		$this->assertFalse( $this->login->init_auth0() );
-//		self::auth0Ready( true );
-//		unset( $_REQUEST['auth0'] );
-//		$this->assertFalse( $this->login->init_auth0() );
-//
-//		$output = '';
-//		try {
-//			$_REQUEST['auth0'] = 1;
-//			$this->login->init_auth0();
-//		} catch ( Exception $e ) {
-//			$output = $e->getMessage();
-//		}
-//
-//		$this->assertNotEmpty( $output );
+	}
+
+	/**
+	 * Test that logout does not redirect to Auth0 if SSO or SLO is not on.
+	 */
+	public function testThatNothingHappensIfNotSsoSlo() {
+		$this->startRedirectHalting();
+		self::auth0Ready( true );
+		self::$opts->set( 'sso', 0 );
+		self::$opts->set( 'singlelogout', 0 );
+		self::$opts->set( 'auto_login', 0 );
+
+		$this->assertNull( $this->login->logout() );
+	}
+
+	/**
+	 * Test that a redirect to the Auth0 logout URL happens if SSO or SLO is turned on.
+	 */
+	public function testThatRedirectHappensIfSsoSlo() {
+		$this->startRedirectHalting();
+		self::$opts->set( 'domain', 'test.auth0.com' );
+		self::$opts->set( 'client_id', '__test_client_id__' );
+		self::$opts->set( 'client_secret', '__test_client_secret__' );
+		self::$opts->set( 'sso', 0 );
+		self::$opts->set( 'singlelogout', 1 );
+
+		$redirect_data_slo = [];
+		try {
+			$this->login->logout();
+		} catch ( Exception $e ) {
+			$redirect_data_slo = unserialize( $e->getMessage() );
+		}
+
+		$this->assertEquals( 302, $redirect_data_slo['status'] );
+		$this->assertNotEmpty( $redirect_data_slo['location'] );
+
+		$logout_url_slo = parse_url( $redirect_data_slo['location'] );
+		$this->assertNotFalse( $logout_url_slo );
+		$this->assertEquals( 'https', $logout_url_slo['scheme'] );
+		$this->assertEquals( 'test.auth0.com', $logout_url_slo['host'] );
+		$this->assertEquals( '/v2/logout', $logout_url_slo['path'] );
+		$this->assertContains( 'client_id=__test_client_id__', $logout_url_slo['query'] );
+		$this->assertContains( 'returnTo=' . rawurlencode( home_url() ), $logout_url_slo['query'] );
+
+		// Test that SSO has the same behavior.
+		self::$opts->set( 'sso', 1 );
+		self::$opts->set( 'singlelogout', 0 );
+
+		$redirect_data_sso = [];
+		try {
+			$this->login->logout();
+		} catch ( Exception $e ) {
+			$redirect_data_sso = unserialize( $e->getMessage() );
+		}
+
+		$this->assertEquals( 302, $redirect_data_sso['status'] );
+		$this->assertEquals( $redirect_data_slo['location'], $redirect_data_sso['location'] );
+	}
+
+	/**
+	 * Test that a redirect to the homepage happens if ULP is turned on.
+	 */
+	public function testThatRedirectHappensIfUlp() {
+		$this->startRedirectHalting();
+		self::$opts->set( 'domain', 'test.auth0.com' );
+		self::$opts->set( 'client_id', '__test_client_id__' );
+		self::$opts->set( 'client_secret', '__test_client_secret__' );
+		self::$opts->set( 'sso', 0 );
+		self::$opts->set( 'singlelogout', 0 );
+		self::$opts->set( 'auto_login', 1 );
+
+		$redirect_data = [];
+		try {
+			$this->login->logout();
+		} catch ( Exception $e ) {
+			$redirect_data = unserialize( $e->getMessage() );
+		}
+
+		$this->assertEquals( 302, $redirect_data['status'] );
+		$this->assertEquals( home_url(), $redirect_data['location'] );
 	}
 }


### PR DESCRIPTION
### Changes

Fix logout redirect if the plugin is not ready (no domain name or client ID)

### Testing

* [x] This change adds unit test coverage
* [x] This change has been tested on WP 5.1.1

### Checklist

* [x] All existing and new tests complete without errors
* [x] All code quality tools/guidelines in the [Contribution guide](CONTRIBUTION.md) have been run/followed
* [x] All active GitHub CI checks have passed
