### PR TITLE
Use existing migration token during setup

### DIFF
--- a/lib/initial-setup/WP_Auth0_InitialSetup_Consent.php
+++ b/lib/initial-setup/WP_Auth0_InitialSetup_Consent.php
@@ -170,9 +170,12 @@ class WP_Auth0_InitialSetup_Consent {
 		if ( $should_create_and_update_connection ) {
 
 			if ( $connection_exists === false ) {
-				$migration_token = JWT::urlsafeB64Encode( openssl_random_pseudo_bytes( 64 ) );
-				$operations      = new WP_Auth0_Api_Operations( $this->a0_options );
-				$response        = $operations->create_wordpress_connection(
+				$migration_token = $this->a0_options->get( 'migration_token' );
+				if ( empty( $migration_token ) ) {
+					$migration_token = JWT::urlsafeB64Encode( openssl_random_pseudo_bytes( 64 ) );
+				}
+				$operations = new WP_Auth0_Api_Operations( $this->a0_options );
+				$response   = $operations->create_wordpress_connection(
 					$this->access_token,
 					$this->hasInternetConnection,
 					'fair',

--- a/tests/testInitialSetupConsent.php
+++ b/tests/testInitialSetupConsent.php
@@ -199,6 +199,7 @@ class TestInitialSetupConsent extends WP_Auth0_Test_Case {
 		$this->assertEquals( 'TEST_CLIENT_SECRET', self::$opts->get( 'client_secret' ) );
 		$this->assertEquals( 1, self::$opts->get( 'db_connection_enabled' ) );
 		$this->assertEquals( 'TEST_CREATED_CONN_ID', self::$opts->get( 'db_connection_id' ) );
+		$this->assertGreaterThan( 64, strlen( self::$opts->get( 'migration_token' ) ) );
 		$this->assertEquals( 'DB-' . get_auth0_curatedBlogName(), self::$opts->get( 'db_connection_name' ) );
 
 		$this->assertCount( 1, self::$error_log->get() );

--- a/tests/testInitialSetupConsent.php
+++ b/tests/testInitialSetupConsent.php
@@ -204,6 +204,60 @@ class TestInitialSetupConsent extends WP_Auth0_Test_Case {
 		$this->assertCount( 1, self::$error_log->get() );
 	}
 
+	/**
+	 * Test that an connection is created and the Client Grant fails.
+	 */
+	public function testThatNewConnectionIsCreatedWithExistingMigrationToken() {
+		$this->startHttpMocking();
+		$this->startRedirectHalting();
+
+		$setup_consent = new WP_Auth0_InitialSetup_Consent( self::$opts );
+		$test_token    = implode( '.', [ uniqid(), uniqid(), uniqid() ] );
+
+		self::$opts->set( 'client_signing_algorithm', 'HS256' );
+		self::$opts->set( 'migration_token', 'TEST_MIGRATION_TOKEN' );
+
+		// Mock consecutive HTTP calls.
+		$this->http_request_type = [
+			// Successful client creation.
+			'success_create_client',
+			// Get en existing connection enabled for this client.
+			'success_get_connections',
+			// Connection updated successfully.
+			'success_update_connection',
+			// Connection created successfully.
+			'success_create_connection',
+			// Client grant created successfully.
+			'success_create_client_grant',
+		];
+
+		$caught_redirect = [];
+		try {
+			$setup_consent->callback_with_token( 'test-wp.auth0.com', $test_token, 'social' );
+		} catch ( Exception $e ) {
+			$caught_redirect = unserialize( $e->getMessage() );
+		}
+
+		$this->assertNotEmpty( $caught_redirect );
+		$this->assertEquals( 302, $caught_redirect['status'] );
+
+		$redirect_url = parse_url( $caught_redirect['location'] );
+
+		$this->assertEquals( '/wp-admin/admin.php', $redirect_url['path'] );
+		$this->assertContains( 'page=wpa0-setup', $redirect_url['query'] );
+		$this->assertContains( 'step=2', $redirect_url['query'] );
+		$this->assertContains( 'profile=social', $redirect_url['query'] );
+
+		$this->assertEquals( 'TEST_CLIENT_ID', self::$opts->get( 'client_id' ) );
+		$this->assertEquals( 'TEST_CLIENT_SECRET', self::$opts->get( 'client_secret' ) );
+		$this->assertEquals( 1, self::$opts->get( 'db_connection_enabled' ) );
+		$this->assertEquals( 'TEST_CREATED_CONN_ID', self::$opts->get( 'db_connection_id' ) );
+		$this->assertEquals( 'TEST_MIGRATION_TOKEN', self::$opts->get( 'migration_token' ) );
+		$this->assertEquals( 'DB-' . get_auth0_curatedBlogName(), self::$opts->get( 'db_connection_name' ) );
+
+		$this->assertEmpty( self::$error_log->get() );
+	}
+
 	/*
 	 * Test helper functions.
 	 */
@@ -211,7 +265,9 @@ class TestInitialSetupConsent extends WP_Auth0_Test_Case {
 	/**
 	 * Specific mock API responses for this suite.
 	 *
-	 * @return array|null|WP_Error
+	 * @return array|WP_Error
+	 *
+	 * @throws Exception If asked to do so.
 	 */
 	public function httpMock() {
 		$response_type = $this->getResponseType();
@@ -227,6 +283,14 @@ class TestInitialSetupConsent extends WP_Auth0_Test_Case {
 					'body'     => '[{"id":"TEST_CONN_ID","name":"DB-' . get_auth0_curatedBlogName() .
 						'","enabled_clients":["TEST_CLIENT_ID"],"options":{"passwordPolicy":"good"}}]',
 					'response' => [ 'code' => 200 ],
+				];
+
+			case 'success_create_client_grant':
+				$audience = 'https://' . self::$opts->get( 'domain' ) . '/api/v2/';
+				return [
+					'body'     => '{"id": "TEST_CLIENT_GRANT_ID","client_id": "TEST_CLIENT_ID",
+						"audience": "' . $audience . '","scope": ["read:users","update:users"]}',
+					'response' => [ 'code' => 201 ],
 				];
 		}
 


### PR DESCRIPTION
### Changes

This PR fixes an issue when a migration token exists (set in a constant) but does not get saved to the custom DB scripts. 

### Testing

* [x] This change adds unit test coverage
* [x] This change has been tested on WP 5.1.1

### Checklist

* [x] All existing and new tests complete without errors
* [x] All code quality tools/guidelines in the [Contribution guide](CONTRIBUTION.md) have been run/followed
* [x] All active GitHub CI checks have passed
