### PR TITLE
Refactor Auth Code login and add tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,31 +49,31 @@ commands:
             dockerize -wait tcp://127.0.0.1:3306 -timeout 120s
             bash bin/install-wp-tests.sh wordpress_test root '' 127.0.0.1 latest
       - run: composer test-ci
-      - run: 
+      - run:
           command: bash <(curl -s https://codecov.io/bash)
           when: on_success
 
-jobs: 
-  php_5: 
-    docker: 
+jobs:
+  php_5:
+    docker:
       - image: circleci/php:5.6
       - image: circleci/mysql:5.6
         environment:
           MYSQL_ALLOW_EMPTY_PASSWORD: true
     steps:
       - prepare
-      - run-formatting
       - run-tests
-  php_7: 
-    docker: 
+      - run-formatting
+  php_7:
+    docker:
       - image: circleci/php:7.1
       - image: circleci/mysql:5.6
         environment:
           MYSQL_ALLOW_EMPTY_PASSWORD: true
     steps:
       - prepare
-      - run-formatting
       - run-tests
+      - run-formatting
   snyk:
     docker:
       - image: snyk/snyk-cli:composer
@@ -102,6 +102,6 @@ workflows:
       - php_7
       - snyk:
           # Must define SNYK_TOKEN env
-          context: snyk-env 
-          requires: 
-            - php_7 
+          context: snyk-env
+          requires:
+            - php_7

--- a/composer.json
+++ b/composer.json
@@ -40,6 +40,7 @@
         "test": "\"vendor/bin/phpunit\" --coverage-text",
         "test-group": "\"vendor/bin/phpunit\" --coverage-text --group",
         "test-ci": "\"vendor/bin/phpunit\" --coverage-clover=coverage.xml",
+        "pre-commit-no-tests": [ "@compat", "@phpcs-i18n", "@phpcbf", "@phpcbf-tests", "@phpcs-tests" ],
         "pre-commit": [ "@compat", "@phpcs-i18n", "@phpcbf", "@phpcbf-tests", "@phpcs-tests", "@test" ]
     },
     "autoload": {

--- a/lib/WP_Auth0_Api_Client.php
+++ b/lib/WP_Auth0_Api_Client.php
@@ -102,6 +102,11 @@ class WP_Auth0_Api_Client {
 		return $headers;
 	}
 
+	/**
+	 * TODO: Deprecate
+	 *
+	 * @codeCoverageIgnore - Deprecated
+	 */
 	public static function get_token( $domain, $client_id, $client_secret, $grantType = 'client_credentials', $extraBody = null ) {
 		if ( ! is_array( $extraBody ) ) {
 			$body = array();
@@ -201,6 +206,11 @@ class WP_Auth0_Api_Client {
 		);
 	}
 
+	/**
+	 * TODO: Deprecate
+	 *
+	 * @codeCoverageIgnore - Deprecated
+	 */
 	public static function get_user( $domain, $jwt, $user_id ) {
 		$endpoint = "https://$domain/api/v2/users/" . urlencode( $user_id );
 

--- a/lib/WP_Auth0_Api_Client.php
+++ b/lib/WP_Auth0_Api_Client.php
@@ -260,15 +260,8 @@ class WP_Auth0_Api_Client {
 
 	public static function get_required_scopes() {
 		return array(
-			'update:clients',
-			'update:connections',
-			'create:connections',
-			'read:connections',
-			'create:rules',
-			'delete:rules',
 			'read:users',
 			'update:users',
-			'update:guardian_factors',
 		);
 	}
 

--- a/lib/WP_Auth0_LoginManager.php
+++ b/lib/WP_Auth0_LoginManager.php
@@ -238,9 +238,8 @@ class WP_Auth0_LoginManager {
 		$decoded_token = $jwt_verifier->decode();
 
 		// Attempt to authenticate with the Management API, if allowed.
-		$userinfo     = null;
-		$is_migration = $this->a0_options->get( 'migration_ws' );
-		if ( apply_filters( 'wp_auth0_use_management_api_for_userinfo', ! $is_migration ) ) {
+		$userinfo = null;
+		if ( apply_filters( 'wp_auth0_use_management_api_for_userinfo', true ) ) {
 			$cc_api        = new WP_Auth0_Api_Client_Credentials( $this->a0_options );
 			$get_user_api  = new WP_Auth0_Api_Get_User( $this->a0_options, $cc_api );
 			$get_user_resp = $get_user_api->call( $decoded_token->sub );

--- a/lib/WP_Auth0_LoginManager.php
+++ b/lib/WP_Auth0_LoginManager.php
@@ -244,7 +244,7 @@ class WP_Auth0_LoginManager {
 			$cc_api        = new WP_Auth0_Api_Client_Credentials( $this->a0_options );
 			$get_user_api  = new WP_Auth0_Api_Get_User( $this->a0_options, $cc_api );
 			$get_user_resp = $get_user_api->call( $decoded_token->sub );
-			$userinfo      = ! empty( $get_user_resp ) ? json_decode( $get_user_resp ) : $get_user_resp;
+			$userinfo      = ! empty( $get_user_resp ) ? json_decode( $get_user_resp ) : null;
 		}
 
 		// Management API call failed, fallback to ID token.

--- a/lib/api/WP_Auth0_Api_Abstract.php
+++ b/lib/api/WP_Auth0_Api_Abstract.php
@@ -117,12 +117,13 @@ abstract class WP_Auth0_Api_Abstract {
 	 * WP_Auth0_Api_Abstract constructor.
 	 *
 	 * @param WP_Auth0_Options $options - WP_Auth0_Options instance.
+	 * @param string|null      $domain - Domain to use.
 	 */
-	public function __construct( WP_Auth0_Options $options ) {
+	public function __construct( WP_Auth0_Options $options, $domain = null ) {
 		$this->options = $options;
 
 		// Required settings in the plugin.
-		$this->domain        = $this->options->get( 'domain' );
+		$this->domain        = $domain ?: $this->options->get( 'domain' );
 		$this->client_id     = $this->options->get( 'client_id' );
 		$this->client_secret = $this->options->get( 'client_secret' );
 

--- a/lib/api/WP_Auth0_Api_Exchange_Code.php
+++ b/lib/api/WP_Auth0_Api_Exchange_Code.php
@@ -1,0 +1,85 @@
+<?php
+/**
+ * Contains WP_Auth0_Api_Exchange_Code.
+ *
+ * @package WP-Auth0
+ *
+ * @since 3.11.0
+ */
+
+/**
+ * Class WP_Auth0_Api_Exchange_Code
+ * Exchange an authorization code for tokens.
+ *
+ * @see https://auth0.com/docs/api/authentication#authorization-code-flow
+ */
+class WP_Auth0_Api_Exchange_Code extends WP_Auth0_Api_Abstract {
+
+	/**
+	 * Default value to return on failure.
+	 */
+	const RETURN_ON_FAILURE = null;
+
+	/**
+	 * Make the API call and handle the response.
+	 *
+	 * @param string|null $code - Authorization code to exchange for tokens.
+	 * @param string|null $client_id - Client ID to use.
+	 * @param string|null $redirect_uri - Redirect URI to use.
+	 *
+	 * @return null|string
+	 */
+	public function call( $code = null, $client_id = null, $redirect_uri = null ) {
+
+		if ( empty( $code ) ) {
+			return self::RETURN_ON_FAILURE;
+		}
+
+		$client_id = $client_id ?: $this->options->get( 'client_id' );
+		if ( empty( $client_id ) ) {
+			return self::RETURN_ON_FAILURE;
+		}
+
+		$client_secret = $this->options->get( 'client_secret' ) ?: '';
+		$redirect_uri  = $redirect_uri ?: $this->options->get_wp_auth0_url();
+
+		return $this
+			->set_path( 'oauth/token' )
+			->add_body( 'grant_type', 'authorization_code' )
+			->add_body( 'code', $code )
+			->add_body( 'redirect_uri', $redirect_uri )
+			->add_body( 'client_id', $client_id )
+			->add_body( 'client_secret', $client_secret )
+			->post()
+			->handle_response( __METHOD__ );
+	}
+
+	/**
+	 * Handle API response.
+	 *
+	 * @param string $method - Method that called the API.
+	 *
+	 * @return integer
+	 */
+	protected function handle_response( $method ) {
+
+		if ( 401 == $this->response_code ) {
+			WP_Auth0_ErrorManager::insert_auth0_error(
+				__METHOD__ . ' L:' . __LINE__,
+				__( 'An /oauth/token call triggered a 401 response from Auth0. ', 'wp-auth0' ) .
+				__( 'Please check the Client Secret saved in the Auth0 plugin settings. ', 'wp-auth0' )
+			);
+			return self::RETURN_ON_FAILURE;
+		}
+
+		if ( $this->handle_wp_error( $method ) ) {
+			return self::RETURN_ON_FAILURE;
+		}
+
+		if ( $this->handle_failed_response( $method ) ) {
+			return self::RETURN_ON_FAILURE;
+		}
+
+		return $this->response_body;
+	}
+}

--- a/lib/api/WP_Auth0_Api_Get_User.php
+++ b/lib/api/WP_Auth0_Api_Get_User.php
@@ -1,0 +1,82 @@
+<?php
+/**
+ * Contains WP_Auth0_Api_Get_User.
+ *
+ * @package WP-Auth0
+ *
+ * @since 3.11.0
+ */
+
+/**
+ * Class WP_Auth0_Api_Get_User
+ * Get user information for an Auth0 user ID.
+ */
+class WP_Auth0_Api_Get_User extends WP_Auth0_Api_Abstract {
+
+	/**
+	 * Default value to return on failure.
+	 */
+	const RETURN_ON_FAILURE = null;
+
+	/**
+	 * Required scope for Management API token.
+	 */
+	const API_SCOPE = 'read:users';
+
+	/**
+	 * WP_Auth0_Api_Get_User constructor.
+	 *
+	 * @param WP_Auth0_Options                $options - WP_Auth0_Options instance.
+	 * @param WP_Auth0_Api_Client_Credentials $api_client_creds - WP_Auth0_Api_Client_Credentials instance.
+	 */
+	public function __construct(
+		WP_Auth0_Options $options,
+		WP_Auth0_Api_Client_Credentials $api_client_creds
+	) {
+		parent::__construct( $options );
+		$this->api_client_creds = $api_client_creds;
+	}
+
+	/**
+	 * Check the user_id, make the API call, and handle the response.
+	 *
+	 * @param string|null $user_id - Auth0 user ID to get.
+	 *
+	 * @return null|string
+	 */
+	public function call( $user_id = null ) {
+
+		if ( empty( $user_id ) ) {
+			return self::RETURN_ON_FAILURE;
+		}
+
+		if ( ! $this->set_bearer( self::API_SCOPE ) ) {
+			return self::RETURN_ON_FAILURE;
+		}
+
+		return $this
+			->set_path( 'api/v2/users/' . rawurlencode( $user_id ) )
+			->get()
+			->handle_response( __METHOD__ );
+	}
+
+	/**
+	 * Handle API response.
+	 *
+	 * @param string $method - Method that called the API.
+	 *
+	 * @return integer
+	 */
+	protected function handle_response( $method ) {
+
+		if ( $this->handle_wp_error( $method ) ) {
+			return self::RETURN_ON_FAILURE;
+		}
+
+		if ( $this->handle_failed_response( $method ) ) {
+			return self::RETURN_ON_FAILURE;
+		}
+
+		return $this->response_body;
+	}
+}

--- a/lib/initial-setup/WP_Auth0_InitialSetup_Consent.php
+++ b/lib/initial-setup/WP_Auth0_InitialSetup_Consent.php
@@ -75,29 +75,18 @@ class WP_Auth0_InitialSetup_Consent {
 			return null;
 		}
 
-		$code         = $_REQUEST['code'];
-		$callback_url = urlencode( admin_url( 'admin.php?page=wpa0-setup&step=2' ) );
+		$client_id    = site_url();
+		$redirect_uri = home_url();
 
-		$client_id = get_bloginfo( 'url' );
+		$exchange_api       = new WP_Auth0_Api_Exchange_Code( $this->a0_options, $this->domain );
+		$exchange_resp_body = $exchange_api->call( $_REQUEST['code'], $client_id, $redirect_uri );
 
-		$response = WP_Auth0_Api_Client::get_token(
-			$this->domain,
-			$client_id,
-			null,
-			'authorization_code',
-			array(
-				'redirect_uri' => home_url(),
-				'code'         => $code,
-			)
-		);
-
-		$obj = json_decode( $response['body'] );
-
-		if ( isset( $obj->error ) ) {
+		if ( ! $exchange_resp_body ) {
 			return null;
 		}
 
-		return $obj->access_token;
+		$tokens = json_decode( $exchange_resp_body );
+		return isset( $tokens->access_token ) ? $tokens->access_token : null;
 	}
 
 	/**

--- a/tests/testApiAbstract.php
+++ b/tests/testApiAbstract.php
@@ -268,7 +268,7 @@ class TestApiAbstract extends WP_Auth0_Test_Case {
 		$log = self::$error_log->get();
 		$this->assertCount( 2, $log );
 		$this->assertEquals( 'caught_callback_error', $log[0]['code'] );
-		$this->assertEquals( 'Error returned - Error', $log[0]['message'] );
+		$this->assertEquals( 'Error returned - Auth0 callback error', $log[0]['message'] );
 	}
 
 	/**

--- a/tests/testApiChangeEmail.php
+++ b/tests/testApiChangeEmail.php
@@ -194,7 +194,7 @@ class TestApiChangeEmail extends WP_Auth0_Test_Case {
 		$this->assertTrue( $api->call( uniqid(), uniqid() ) );
 
 		$this->assertEquals( '__test_access_token__', get_transient( 'auth0_api_token' ) );
-		$this->assertEquals( 'update:users', get_transient( 'auth0_api_token_scope' ) );
+		$this->assertEquals( 'update:users read:users', get_transient( 'auth0_api_token_scope' ) );
 	}
 
 	/*

--- a/tests/testApiClientCredentials.php
+++ b/tests/testApiClientCredentials.php
@@ -116,7 +116,7 @@ class TestApiClientCredentials extends WP_Auth0_Test_Case {
 		$timeout                 = time() + 1000;
 		$this->assertEquals( '__test_access_token__', $api_client_creds->call() );
 		$this->assertEquals( '__test_access_token__', get_transient( 'auth0_api_token' ) );
-		$this->assertEquals( 'update:users', get_transient( 'auth0_api_token_scope' ) );
+		$this->assertEquals( 'update:users read:users', get_transient( 'auth0_api_token_scope' ) );
 		$this->assertLessThan( $timeout, (int) get_transient( '_transient_timeout_auth0_api_token_scope' ) );
 		$this->assertLessThan( $timeout, (int) get_transient( '_transient_timeout_auth0_api_token' ) );
 		$log = self::$error_log->get();

--- a/tests/testApiGetUser.php
+++ b/tests/testApiGetUser.php
@@ -23,13 +23,6 @@ class TestApiGetUser extends WP_Auth0_Test_Case {
 	protected static $api_client_creds;
 
 	/**
-	 * WP_Auth0_Api_Get_User instance.
-	 *
-	 * @var WP_Auth0_Api_Get_User
-	 */
-	protected static $get_user_api;
-
-	/**
 	 * Run before the test suite.
 	 */
 	public static function setUpBeforeClass() {
@@ -71,7 +64,7 @@ class TestApiGetUser extends WP_Auth0_Test_Case {
 
 		$this->assertEquals( 'https://test.auth0.com/api/v2/users/__test_user_id__', $http_data['url'] );
 		$this->assertEquals(
-			'eyJuYW1lIjoid3AtYXV0aDAiLCJ2ZXJzaW9uIjoiMy4xMC4wIiwiZW52Ijp7InBocCI6IjcuMS4yNyIsIndwIjoiNS4xLjEifX0=',
+			WP_Auth0_Api_Abstract::get_info_headers()['Auth0-Client'],
 			$http_data['headers']['Auth0-Client']
 		);
 		$this->assertEquals( 'Bearer __test_access_token__', $http_data['headers']['Authorization'] );

--- a/tests/testApiGetUser.php
+++ b/tests/testApiGetUser.php
@@ -1,0 +1,100 @@
+<?php
+/**
+ * Contains Class TestApiGetUser.
+ *
+ * @package WP-Auth0
+ *
+ * @since 3.11.0
+ */
+
+/**
+ * Class TestApiGetUser.
+ * Test the WP_Auth0_Api_Get_User class.
+ */
+class TestApiGetUser extends WP_Auth0_Test_Case {
+
+	use HttpHelpers;
+
+	/**
+	 * WP_Auth0_Api_Client_Credentials instance.
+	 *
+	 * @var WP_Auth0_Api_Client_Credentials
+	 */
+	protected static $api_client_creds;
+
+	/**
+	 * WP_Auth0_Api_Get_User instance.
+	 *
+	 * @var WP_Auth0_Api_Get_User
+	 */
+	protected static $get_user_api;
+
+	/**
+	 * Run before the test suite.
+	 */
+	public static function setUpBeforeClass() {
+		parent::setUpBeforeClass();
+		self::$api_client_creds = new WP_Auth0_Api_Client_Credentials( self::$opts );
+	}
+
+	/**
+	 * Test that pre-API calls fail.
+	 */
+	public function testThatPreflightChecksAreMade() {
+		$get_user_api = new WP_Auth0_Api_Get_User( self::$opts, self::$api_client_creds );
+
+		// Should fail with a missing user_id.
+		$this->assertNull( $get_user_api->call() );
+
+		// Should fail if no existing API token.
+		$this->assertNull( $get_user_api->call( uniqid() ) );
+	}
+
+	/**
+	 * Test that the API request is made correctly.
+	 */
+	public function testThatApiRequestIsCorrect() {
+		$this->startHttpHalting();
+
+		set_transient( WP_Auth0_Api_Client_Credentials::TOKEN_TRANSIENT_KEY, '__test_access_token__', 9999 );
+		set_transient( WP_Auth0_Api_Client_Credentials::SCOPE_TRANSIENT_KEY, 'read:users', 9990 );
+
+		self::$opts->set( 'domain', 'test.auth0.com' );
+		$get_user_api = new WP_Auth0_Api_Get_User( self::$opts, self::$api_client_creds );
+
+		try {
+			$http_data = [];
+			$get_user_api->call( '__test_user_id__' );
+		} catch ( Exception $e ) {
+			$http_data = unserialize( $e->getMessage() );
+		}
+
+		$this->assertEquals( 'https://test.auth0.com/api/v2/users/__test_user_id__', $http_data['url'] );
+		$this->assertEquals(
+			'eyJuYW1lIjoid3AtYXV0aDAiLCJ2ZXJzaW9uIjoiMy4xMC4wIiwiZW52Ijp7InBocCI6IjcuMS4yNyIsIndwIjoiNS4xLjEifX0=',
+			$http_data['headers']['Auth0-Client']
+		);
+		$this->assertEquals( 'Bearer __test_access_token__', $http_data['headers']['Authorization'] );
+		$this->assertEquals( 'GET', $http_data['method'] );
+	}
+
+	/**
+	 * Test that a network error (caught by WP and returned as a WP_Error) is handled properly.
+	 */
+	public function testThatNetworkErrorIsHandled() {
+		$this->startHttpMocking();
+		$this->http_request_type = 'wp_error';
+
+		set_transient( WP_Auth0_Api_Client_Credentials::TOKEN_TRANSIENT_KEY, '__test_access_token__', 9999 );
+		set_transient( WP_Auth0_Api_Client_Credentials::SCOPE_TRANSIENT_KEY, 'read:users', 9990 );
+
+		self::$opts->set( 'domain', 'test.auth0.com' );
+		$get_user_api = new WP_Auth0_Api_Get_User( self::$opts, self::$api_client_creds );
+
+		$this->assertNull( $get_user_api->call( '__test_user_id__' ) );
+
+		$log = self::$error_log->get();
+		$this->assertCount( 1, $log );
+		$this->assertEquals( 'WP_Auth0_Api_Get_User::call', $log[0]['section'] );
+	}
+}

--- a/tests/testInitialSetupConsentExchangeCode.php
+++ b/tests/testInitialSetupConsentExchangeCode.php
@@ -1,0 +1,89 @@
+<?php
+/**
+ * Contains Class TestInitialSetupConsentExchangeCode.
+ *
+ * @package WP-Auth0
+ *
+ * @since 3.11.0
+ */
+
+/**
+ * Class TestInitialSetupConsentExchangeCode.
+ */
+class TestInitialSetupConsentExchangeCode extends WP_Auth0_Test_Case {
+
+	use HttpHelpers;
+
+	/**
+	 * Test that a missing code parameter will return null.
+	 */
+	public function testThatMissingCodeReturnsNull() {
+		$setup_consent = new WP_Auth0_InitialSetup_Consent( self::$opts );
+		$this->assertNull( $setup_consent->exchange_code() );
+	}
+
+	/**
+	 * Test that the exchange code call is formatted properly.
+	 */
+	public function testThatExchangeTokenCallIsCorrect() {
+		$this->startHttpHalting();
+
+		$_REQUEST['code'] = uniqid();
+
+		$setup_consent = new WP_Auth0_InitialSetup_Consent( self::$opts );
+
+		try {
+			$http_data = [];
+			$setup_consent->exchange_code();
+		} catch ( Exception $e ) {
+			$http_data = unserialize( $e->getMessage() );
+		}
+
+		$this->assertNotEmpty( $http_data );
+		$this->assertEquals( 'https://auth0.auth0.com/oauth/token', $http_data['url'] );
+		$this->assertEquals( home_url(), $http_data['body']['redirect_uri'] );
+		$this->assertEquals( $_REQUEST['code'], $http_data['body']['code'] );
+		$this->assertEquals( site_url(), $http_data['body']['client_id'] );
+		$this->assertEmpty( $http_data['body']['client_secret'] );
+		$this->assertEquals( 'authorization_code', $http_data['body']['grant_type'] );
+	}
+
+	/**
+	 * Test that an API failure will return null.
+	 */
+	public function testThatFailedApiCallReturnsNull() {
+		$this->startHttpMocking();
+		$this->http_request_type = 'wp_error';
+
+		$_REQUEST['code'] = uniqid();
+
+		$setup_consent = new WP_Auth0_InitialSetup_Consent( self::$opts );
+		$this->assertNull( $setup_consent->exchange_code() );
+	}
+
+	/**
+	 * Test that a successful call results in an access token being returned.
+	 */
+	public function testThatExchangeCodeReturnsAccessToken() {
+		$this->startHttpMocking();
+		$this->http_request_type = 'success_code_exchange';
+
+		$_REQUEST['code'] = uniqid();
+
+		$setup_consent = new WP_Auth0_InitialSetup_Consent( self::$opts );
+		$this->assertEquals( '__test_access_token__', $setup_consent->exchange_code() );
+	}
+
+	/**
+	 * Test that there are no errors generated and null is returned for a malformed success response.
+	 */
+	public function testThatExchangeCodeReturnsNullIfNoAccessToken() {
+		$this->startHttpMocking();
+		$this->http_request_type = 'success_get_user';
+
+		$_REQUEST['code'] = uniqid();
+
+		$setup_consent = new WP_Auth0_InitialSetup_Consent( self::$opts );
+		$this->assertNull( $setup_consent->exchange_code() );
+	}
+}

--- a/tests/testLoginManagerRedirectLogin.php
+++ b/tests/testLoginManagerRedirectLogin.php
@@ -1,0 +1,322 @@
+<?php
+/**
+ * Contains Class TestLoginManagerRedirectLogin.
+ *
+ * @package WP-Auth0
+ *
+ * @since 3.11.0
+ */
+
+/**
+ * Class TestLoginManagerRedirectLogin.
+ * Test the WP_Auth0_LoginManager::init_auth0() method.
+ */
+class TestLoginManagerRedirectLogin extends WP_Auth0_Test_Case {
+
+	use HttpHelpers {
+		httpMock as protected httpMockDefault;
+	}
+
+	use RedirectHelpers;
+
+	use UsersHelper;
+
+	/**
+	 * WP_Auth0_LoginManager instance to test.
+	 *
+	 * @var WP_Auth0_LoginManager
+	 */
+	protected $login;
+
+	/**
+	 * Runs before each test method.
+	 */
+	public function setUp() {
+		parent::setUp();
+		$this->login = new WP_Auth0_LoginManager( new WP_Auth0_UsersRepo( self::$opts ), self::$opts );
+
+		self::$opts->set( 'requires_verified_email', 0 );
+
+		self::$users_repo = new WP_Auth0_UsersRepo( self::$opts );
+		$users_repo       = self::$users_repo; // PHP 5.6.
+		$users_repo::update_meta( 1, 'auth0_id', 'auth0|1234567890' );
+
+		add_filter( 'auth0_get_wp_user', [ $this, 'auth0_get_wp_user_handler' ], 1, 2 );
+	}
+
+	/**
+	 * Runs after each test method.
+	 */
+	public function tearDown() {
+		parent::tearDown();
+		remove_filter( 'auth0_get_wp_user', [ $this, 'auth0_get_wp_user_handler' ], 1 );
+	}
+
+	/**
+	 * Stop the WP_Auth0_LoginManager::login_user() call with user info gathered.
+	 *
+	 * @param null|WP_user $user - WP_User, if one was found.
+	 * @param stdClass     $userinfo - Userinfo from Auth0.
+	 *
+	 * @throws Exception - Always.
+	 */
+	public function auth0_get_wp_user_handler( $user, $userinfo ) {
+		throw new Exception(
+			serialize(
+				[
+					'user'     => $user,
+					'userinfo' => $userinfo,
+				]
+			)
+		);
+	}
+
+	/**
+	 * Mock responses for this test suite only.
+	 *
+	 * @param string|null $response_type - HTTP response type to use.
+	 * @param array|null  $args - HTTP args.
+	 * @param string|null $url - Remote URL.
+	 *
+	 * @return array|WP_Error
+	 *
+	 * @throws Exception - If set to halt on response.
+	 */
+	public function httpMock( $response_type = null, array $args = null, $url = null ) {
+		$response_type = $response_type ?: $this->getResponseType();
+		switch ( $response_type ) {
+			case 'success_exchange_code_valid_id_token':
+				$id_token_payload = [
+					'sub' => '__test_id_token_sub__',
+					'iss' => 'https://test.auth0.com/',
+					'aud' => '__test_client_id__',
+				];
+				$id_token         = JWT::encode( $id_token_payload, '__test_client_secret__' );
+				return [
+					'body'     => sprintf(
+						'{"access_token":"__test_access_token__","id_token":"%s"}',
+						$id_token
+					),
+					'response' => [ 'code' => 200 ],
+				];
+		}
+		return $this->httpMockDefault( $response_type, $args, $url );
+	}
+
+	/**
+	 * Test that the default not ready condition fails with an invalid URL.
+	 *
+	 * @throws WP_Auth0_BeforeLoginException - Should not be encountered during this test.
+	 * @throws WP_Auth0_InvalidIdTokenException - Should not be encountered during this test.
+	 */
+	public function testThatInvalidConfigurationFailsHttpCall() {
+		try {
+			$this->login->redirect_login();
+			$caught_exception = false;
+		} catch ( WP_Auth0_LoginFlowValidationException $e ) {
+			$caught_exception = ( 'Unknown error' === $e->getMessage() );
+		}
+
+		$this->assertTrue( $caught_exception );
+
+		$error_log = self::$error_log->get();
+		$this->assertCount( 1, $error_log );
+		$this->assertEquals( 'WP_Auth0_Api_Client::get_token', $error_log[0]['section'] );
+		$this->assertEquals( 'A valid URL was not provided.', $error_log[0]['message'] );
+		$this->assertEquals( 1, $error_log[0]['count'] );
+	}
+
+	/**
+	 * Test that an access denied response when exchanging tokens triggers special error handling.
+	 *
+	 * @throws WP_Auth0_BeforeLoginException - Should not be encountered during this test.
+	 * @throws WP_Auth0_InvalidIdTokenException - Should not be encountered during this test.
+	 */
+	public function testThatAccessDeniedLogsCorrectError() {
+		$this->startHttpMocking();
+		$this->http_request_type = 'auth0_access_denied';
+
+		self::$opts->set( 'domain', 'test.auth0.com' );
+
+		try {
+			$caught_exception = false;
+			$this->login->redirect_login();
+		} catch ( WP_Auth0_LoginFlowValidationException $e ) {
+			$caught_exception = ( 'Not Authorized' === $e->getMessage() );
+		}
+
+		$this->assertTrue( $caught_exception );
+
+		$error_log = self::$error_log->get();
+		$this->assertCount( 1, $error_log );
+		$this->assertContains( 'WP_Auth0_LoginManager::redirect_login', $error_log[0]['section'] );
+		$this->assertContains( 'Please check the Client Secret', $error_log[0]['message'] );
+	}
+
+	/**
+	 * Test that the exchange code call is formatted properly.
+	 */
+	public function testThatExchangeTokenCallIsCorrect() {
+		$this->startHttpHalting();
+
+		self::$opts->set( 'domain', 'test.auth0.com' );
+		self::$opts->set( 'client_id', '__test_client_id__' );
+		self::$opts->set( 'client_secret', '__test_client_secret__' );
+		$_REQUEST['code'] = uniqid();
+
+		try {
+			$http_data = [];
+			$this->login->redirect_login();
+		} catch ( Exception $e ) {
+			$http_data = unserialize( $e->getMessage() );
+		}
+
+		$this->assertNotEmpty( $http_data );
+		$this->assertEquals( 'https://test.auth0.com/oauth/token', $http_data['url'] );
+		$this->assertEquals( site_url( '/index.php?auth0=1' ), $http_data['body']['redirect_uri'] );
+		$this->assertEquals( $_REQUEST['code'], $http_data['body']['code'] );
+		$this->assertEquals( '__test_client_id__', $http_data['body']['client_id'] );
+		$this->assertEquals( '__test_client_secret__', $http_data['body']['client_secret'] );
+		$this->assertEquals( 'authorization_code', $http_data['body']['grant_type'] );
+	}
+
+	/**
+	 * Test that an exchange code response with a missing access token halts the login process.
+	 *
+	 * @throws WP_Auth0_BeforeLoginException - Should not be encountered during this test.
+	 * @throws WP_Auth0_InvalidIdTokenException - Should not be encountered during this test.
+	 */
+	public function testThatMissingAccessTokenHaltsLogin() {
+		$this->startHttpMocking();
+		$this->http_request_type = 'auth0_callback_error';
+
+		self::$opts->set( 'domain', 'test.auth0.com' );
+
+		try {
+			$caught_exception = false;
+			$this->login->redirect_login();
+		} catch ( WP_Auth0_LoginFlowValidationException $e ) {
+			$caught_exception = ( 'Auth0 callback error' === $e->getMessage() );
+		}
+
+		$this->assertTrue( $caught_exception );
+	}
+
+	/**
+	 * Test that an invalid ID token halts the login process.
+	 *
+	 * @throws WP_Auth0_BeforeLoginException - Should not be encountered during this test.
+	 * @throws WP_Auth0_LoginFlowValidationException - Should not be encountered during this test.
+	 */
+	public function testThatInvalidIdTokenHaltsLogin() {
+		$this->startHttpMocking();
+		$this->http_request_type = 'success_code_exchange';
+
+		self::$opts->set( 'domain', 'test.auth0.com' );
+		self::$opts->set( 'client_secret', '__test_client_secret__' );
+		self::$opts->set( 'client_signing_algorithm', 'HS256' );
+
+		try {
+			$caught_exception = false;
+			$this->login->redirect_login();
+		} catch ( WP_Auth0_InvalidIdTokenException $e ) {
+			$caught_exception = ( 'Wrong number of segments' === $e->getMessage() );
+		}
+
+		$this->assertTrue( $caught_exception );
+	}
+
+	/**
+	 * Test that the user information is retrieved via the Management API.
+	 */
+	public function testThatGetUserCallIsCorrect() {
+		$this->startHttpMocking();
+		$this->http_request_type = [
+			// Mocked successful code exchange with a valid ID token.
+			'success_exchange_code_valid_id_token',
+			// Mocked successful CC grant.
+			'success_access_token',
+			// Stop the get user call.
+			'halt',
+		];
+
+		self::$opts->set( 'domain', 'test.auth0.com' );
+		self::$opts->set( 'client_id', '__test_client_id__' );
+		self::$opts->set( 'client_secret', '__test_client_secret__' );
+		self::$opts->set( 'client_signing_algorithm', 'HS256' );
+
+		try {
+			$http_data = [];
+			$this->login->redirect_login();
+		} catch ( Exception $e ) {
+			$http_data = unserialize( $e->getMessage() );
+		}
+
+		$this->assertNotEmpty( $http_data );
+		$this->assertEquals( 'https://test.auth0.com/api/v2/users/__test_id_token_sub__', $http_data['url'] );
+		$this->assertEquals( 'Bearer __test_access_token__', $http_data['headers']['Authorization'] );
+	}
+
+	/**
+	 * Test that the user information is retrieved via the Management API.
+	 */
+	public function testThatLoginUserIsCalledWithManagementApiUserinfo() {
+		$this->startHttpMocking();
+		$this->http_request_type = [
+			// Mocked successful code exchange with a valid ID token.
+			'success_exchange_code_valid_id_token',
+			// Mocked successful CC grant.
+			'success_access_token',
+			// Stop the get user call.
+			'success_get_user',
+		];
+
+		self::$opts->set( 'domain', 'test.auth0.com' );
+		self::$opts->set( 'client_id', '__test_client_id__' );
+		self::$opts->set( 'client_secret', '__test_client_secret__' );
+		self::$opts->set( 'client_signing_algorithm', 'HS256' );
+
+		try {
+			$user_data = [];
+			$this->login->redirect_login();
+		} catch ( Exception $e ) {
+			$user_data = unserialize( $e->getMessage() );
+		}
+
+		$this->assertTrue( $user_data['user'] instanceof WP_User );
+		$this->assertEquals( 1, $user_data['user']->ID );
+		$this->assertEquals( 'auth0|1234567890', $user_data['userinfo']->user_id );
+		$this->assertEquals( 'auth0|1234567890', $user_data['userinfo']->sub );
+		$this->assertNotEmpty( $user_data['userinfo']->user_metadata );
+		$this->assertNotEmpty( $user_data['userinfo']->app_metadata );
+	}
+
+	/**
+	 * Test that the user information is from the ID token if the Management API fails.
+	 */
+	public function testThatLoginUserIsCalledWithIdTokenIfNoApiAccess() {
+		$this->startHttpMocking();
+		$this->http_request_type = [
+			// Mocked successful code exchange with a valid ID token.
+			'success_exchange_code_valid_id_token',
+			// Mocked successful CC grant.
+			'auth0_api_error',
+		];
+
+		self::$opts->set( 'domain', 'test.auth0.com' );
+		self::$opts->set( 'client_id', '__test_client_id__' );
+		self::$opts->set( 'client_secret', '__test_client_secret__' );
+		self::$opts->set( 'client_signing_algorithm', 'HS256' );
+
+		try {
+			$user_data = [];
+			$this->login->redirect_login();
+		} catch ( Exception $e ) {
+			$user_data = unserialize( $e->getMessage() );
+		}
+
+		$this->assertEmpty( $user_data['user'] );
+		$this->assertEquals( '__test_id_token_sub__', $user_data['userinfo']->user_id );
+		$this->assertEquals( '__test_id_token_sub__', $user_data['userinfo']->sub );
+	}
+}

--- a/tests/testLoginManagerRedirectLogin.php
+++ b/tests/testLoginManagerRedirectLogin.php
@@ -56,6 +56,8 @@ class TestLoginManagerRedirectLogin extends WP_Auth0_Test_Case {
 
 		delete_transient( WP_Auth0_Api_Client_Credentials::TOKEN_TRANSIENT_KEY );
 		delete_transient( WP_Auth0_Api_Client_Credentials::SCOPE_TRANSIENT_KEY );
+
+		remove_filter( 'wp_auth0_use_management_api_for_userinfo', '__return_false', 10 );
 	}
 
 	/**
@@ -377,7 +379,7 @@ class TestLoginManagerRedirectLogin extends WP_Auth0_Test_Case {
 	/**
 	 * Test that the user information is from the ID token if migrations are being used.
 	 */
-	public function testThatLoginUserIsCalledWithIdTokenIfMigration() {
+	public function testThatLoginUserIsCalledWithIdTokenIfFilterIsSetToFalse() {
 		$this->startHttpMocking();
 		$this->http_request_type = [
 			// Mocked successful code exchange with a valid ID token.
@@ -390,7 +392,7 @@ class TestLoginManagerRedirectLogin extends WP_Auth0_Test_Case {
 		self::$opts->set( 'client_id', '__test_client_id__' );
 		self::$opts->set( 'client_secret', '__test_client_secret__' );
 		self::$opts->set( 'client_signing_algorithm', 'HS256' );
-		self::$opts->set( 'migration_ws', 1 );
+		add_filter( 'wp_auth0_use_management_api_for_userinfo', '__return_false', 10 );
 		$_REQUEST['code'] = uniqid();
 
 		try {

--- a/tests/traits/httpHelpers.php
+++ b/tests/traits/httpHelpers.php
@@ -42,7 +42,7 @@ trait HttpHelpers {
 				'url'     => $url,
 				'method'  => $args['method'],
 				'headers' => $args['headers'],
-				'body'    => json_decode( $args['body'], true ),
+				'body'    => is_string( $args['body'] ) ? json_decode( $args['body'], true ) : $args['body'],
 				'preempt' => $preempt,
 			]
 		);
@@ -106,8 +106,14 @@ trait HttpHelpers {
 
 			case 'auth0_callback_error':
 				return [
-					'body'     => '{"error":"caught_callback_error","error_description":"Error"}',
+					'body'     => '{"error":"caught_callback_error","error_description":"Auth0 callback error"}',
 					'response' => [ 'code' => 400 ],
+				];
+
+			case 'auth0_access_denied':
+				return [
+					'body'     => '{"error":"access_denied","error_description":"Unauthorized"}',
+					'response' => [ 'code' => 401 ],
 				];
 
 			case 'other_error':
@@ -151,9 +157,41 @@ trait HttpHelpers {
 					'response' => [ 'code' => 200 ],
 				];
 
+			case 'success_get_user':
+				return [
+					'body'     => '{
+					    "email_verified": true,
+					    "email": "user@example.org",
+					    "user_id": "auth0|1234567890",
+					    "user_metadata": {
+					        "user_meta_key": "user_meta_value"
+					    },
+					    "app_metadata": {
+					        "app_meta_key": "app_meta_value"
+					    }
+					}',
+					'response' => [ 'code' => 200 ],
+				];
+
 			case 'success_access_token':
 				return [
-					'body'     => '{"access_token":"__test_access_token__","scope":"update:users","expires_in":1000}',
+					'body'     => '{
+						"access_token":"__test_access_token__",
+						"scope":"update:users read:users",
+						"expires_in":1000
+					}',
+					'response' => [ 'code' => 200 ],
+				];
+
+			case 'success_code_exchange':
+				return [
+					'body'     => '{
+						"access_token":"__test_access_token__",
+						"id_token":"__test_id_token__",
+						"scope":"openid profile email",
+						"expires_in":86400,
+						"token_type":"Bearer"
+					}',
 					'response' => [ 'code' => 200 ],
 				];
 


### PR DESCRIPTION
### Changes

This PR refactors the auth code login flow to use the new API abstract.

**Reviewer notes:**

~650 lines of tests added, see below for specific changes.

- [Commit for tests added to cover functionality before changes](https://github.com/auth0/wp-auth0/pull/678/commits/3b6c96c4b333d82853329f028d1b4f737217f805)
- [Update tests to fail for missing new functionality](https://github.com/auth0/wp-auth0/pull/678/commits/408517d55a186e56bb799324f7a13d4afc4b3cd3)
- [Most functionality changes here](https://github.com/auth0/wp-auth0/pull/678/commits/f0cda712afebbbdf35e4e25b6e57d5300448f173)
- [Somewhat unrelated change to remove client grant scopes requested (found while testing)](https://github.com/auth0/wp-auth0/pull/678/commits/f3485e7574df6742b3157552556ec6319908782a)

### Testing

* [x] This change adds unit test coverage
* [x] This change has been tested on WP 5.1.1

### Checklist

* [x] All existing and new tests complete without errors
* [x] All code quality tools/guidelines in the [Contribution guide](CONTRIBUTION.md) have been run/followed
* [x] All active GitHub CI checks have passed
