### PR TITLE
Remove small social icons

### DIFF
--- a/WP_Auth0.php
+++ b/WP_Auth0.php
@@ -9,8 +9,8 @@
  * Text Domain: wp-auth0
  */
 
-define( 'WPA0_VERSION', '3.10.0' );
-define( 'AUTH0_DB_VERSION', 21 );
+define( 'WPA0_VERSION', '3.11.0-beta' );
+define( 'AUTH0_DB_VERSION', 22 );
 
 define( 'WPA0_PLUGIN_FILE', __FILE__ );
 define( 'WPA0_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );

--- a/composer.json
+++ b/composer.json
@@ -9,8 +9,8 @@
     "require-dev": {
         "dealerdirect/phpcodesniffer-composer-installer": "^0.4.3",
         "wp-coding-standards/wpcs": "^1",
-        "phpunit/phpunit": "^5.7.26 || ^6.5.0",
-        "phpcompatibility/phpcompatibility-wp": "*"
+        "phpcompatibility/phpcompatibility-wp": "*",
+        "phpunit/phpunit": "^5.0 || ^6.0"
     },
     "authors": [
         {
@@ -41,9 +41,9 @@
         "test-group": "\"vendor/bin/phpunit\" --coverage-text --group",
         "test-ci": "\"vendor/bin/phpunit\" --coverage-clover=coverage.xml",
         "pre-commit-no-tests": [ "@compat", "@phpcs-i18n", "@phpcbf", "@phpcbf-tests", "@phpcs-tests" ],
-        "pre-commit": [ "@compat", "@phpcs-i18n", "@phpcbf", "@phpcbf-tests", "@phpcs-tests", "@test" ]
+        "pre-commit": [ "@phpcbf", "@phpcbf-tests", "@phpcs-tests", "@compat", "@phpcs-i18n", "@test" ]
     },
-    "autoload": {
+    "autoload-dev": {
         "classmap": ["tests/classes/", "tests/traits/"]
     }
 }

--- a/lib/WP_Auth0_DBManager.php
+++ b/lib/WP_Auth0_DBManager.php
@@ -178,6 +178,11 @@ class WP_Auth0_DBManager {
 			delete_option( 'wp_auth0_grant_types_success' );
 		}
 
+		// 3.11.0
+		if ( ( $this->current_db_version < 22 && 0 !== $this->current_db_version ) || 22 === $version_to_install ) {
+			$options->remove( 'social_big_buttons' );
+		}
+
 		$options->update_all();
 
 		$this->current_db_version = AUTH0_DB_VERSION;

--- a/lib/WP_Auth0_Lock10_Options.php
+++ b/lib/WP_Auth0_Lock10_Options.php
@@ -111,9 +111,8 @@ class WP_Auth0_Lock10_Options {
 
 		}
 
-		if ( $this->_is_valid( $settings, 'social_big_buttons' ) ) {
-			$options_obj['socialButtonStyle'] = $settings['social_big_buttons'] ? 'big' : 'small';
-		}
+		$options_obj['socialButtonStyle'] = 'big';
+
 		if ( isset( $settings['gravatar'] ) && empty( $settings['gravatar'] ) ) {
 			$options_obj['avatar'] = null;
 		}

--- a/lib/WP_Auth0_Lock_Options.php
+++ b/lib/WP_Auth0_Lock_Options.php
@@ -153,9 +153,8 @@ class WP_Auth0_Lock_Options {
 			$options_obj['dict'] = $settings['language'];
 		}
 
-		if ( $this->_is_valid( $settings, 'social_big_buttons' ) ) {
-			$options_obj['socialBigButtons'] = $this->_get_boolean( $settings['social_big_buttons'] );
-		}
+		$options_obj['socialButtonStyle'] = 'big';
+
 		if ( $this->_is_valid( $settings, 'gravatar' ) ) {
 			$options_obj['gravatar'] = $this->_get_boolean( $settings['gravatar'] );
 		}

--- a/lib/WP_Auth0_Options.php
+++ b/lib/WP_Auth0_Options.php
@@ -248,7 +248,6 @@ class WP_Auth0_Options extends WP_Auth0_Options_Generic {
 			// Appearance
 			'icon_url'                  => '',
 			'form_title'                => '',
-			'social_big_buttons'        => false,
 			'gravatar'                  => true,
 			'username_style'            => '',
 			'primary_color'             => '',

--- a/lib/admin/WP_Auth0_Admin_Appearance.php
+++ b/lib/admin/WP_Auth0_Admin_Appearance.php
@@ -52,12 +52,6 @@ class WP_Auth0_Admin_Appearance extends WP_Auth0_Admin_Generic {
 				'function' => 'render_form_title',
 			),
 			array(
-				'name'     => __( 'Large Social Buttons', 'wp-auth0' ),
-				'opt'      => 'social_big_buttons',
-				'id'       => 'wpa0_social_big_buttons',
-				'function' => 'render_social_big_buttons',
-			),
-			array(
 				'name'     => __( 'Enable Gravatar Integration', 'wp-auth0' ),
 				'opt'      => 'gravatar',
 				'id'       => 'wpa0_gravatar',
@@ -257,6 +251,8 @@ class WP_Auth0_Admin_Appearance extends WP_Auth0_Admin_Generic {
 	/**
 	 * Render form field and description for the `social_big_buttons` option.
 	 * IMPORTANT: Internal callback use only, do not call this function directly!
+	 *
+	 * TODO: Deprecate, option being removed in Lock
 	 *
 	 * @param array $args - callback args passed in from add_settings_field().
 	 *
@@ -472,19 +468,18 @@ class WP_Auth0_Admin_Appearance extends WP_Auth0_Admin_Generic {
 	}
 
 	public function basic_validation( $old_options, $input ) {
-		$input['form_title']         = sanitize_text_field( $input['form_title'] );
-		$input['icon_url']           = esc_url( $input['icon_url'], array( 'http', 'https' ) );
-		$input['social_big_buttons'] = ( isset( $input['social_big_buttons'] ) ? $input['social_big_buttons'] : 0 );
-		$input['gravatar']           = ( isset( $input['gravatar'] ) ? $input['gravatar'] : 0 );
-		$input['language']           = sanitize_text_field( $input['language'] );
-		$input['primary_color']      = sanitize_text_field( $input['primary_color'] );
+		$input['form_title']    = empty( $input['form_title'] ) ? '' : sanitize_text_field( $input['form_title'] );
+		$input['icon_url']      = empty( $input['icon_url'] ) ? '' : esc_url( $input['icon_url'], array( 'http', 'https' ) );
+		$input['gravatar']      = isset( $input['gravatar'] ) ? $input['gravatar'] : 0;
+		$input['language']      = empty( $input['language'] ) ? '' : sanitize_text_field( $input['language'] );
+		$input['primary_color'] = empty( $input['primary_color'] ) ? '' : sanitize_text_field( $input['primary_color'] );
 
 		$input['language_dictionary'] = isset( $input['language_dictionary'] ) ? trim( $input['language_dictionary'] ) : '';
 		if ( ! empty( $input['language_dictionary'] ) ) {
 			if ( json_decode( $input['language_dictionary'] ) === null ) {
-				$error = __( 'The language dictionary parameter should be a valid json object.', 'wp-auth0' );
+				$error = __( 'The language dictionary parameter should be a valid JSON object.', 'wp-auth0' );
 				$this->add_validation_error( $error );
-				$input['language'] = $old_options['language'];
+				$input['language_dictionary'] = isset( $old_options['language_dictionary'] ) ? $old_options['language_dictionary'] : '';
 			}
 		}
 		return $input;

--- a/readme.txt
+++ b/readme.txt
@@ -74,7 +74,6 @@ Like widgets, shortcode login forms will use the main plugins settings. It can b
 - `form_title` - Text to appear at top of the login form
 - `gravatar` - Display the user's Gravatar; set to `1` for yes
 - `redirect_to` - A direct URL to use after successful login
-- `social_big_buttons` - Display full-width social login buttons; set to `1` for yes
 - `custom_css` - Valid CSS to alter the login form
 - `custom_js` - Valid JS to alter the login form
 - `dict` - Valid JSON to override form text ([see options here](https://github.com/auth0/lock/blob/master/src/i18n/en.js))
@@ -84,7 +83,7 @@ Like widgets, shortcode login forms will use the main plugins settings. It can b
 
 Example:
 
-    [auth0 show_as_modal="1" social_big_buttons="1" modal_trigger_name="Login button: This text is configurable!"]
+    [auth0 show_as_modal="1" modal_trigger_name="Login button: This text is configurable!"]
 
 == Frequently Asked Questions ==
 

--- a/templates/a0-widget-setup-form.php
+++ b/templates/a0-widget-setup-form.php
@@ -1,13 +1,12 @@
 <?php
-$form_title         = isset( $instance['form_title'] ) ? $instance['form_title'] : '';
-$social_big_buttons = isset( $instance['social_big_buttons'] ) ? $instance['social_big_buttons'] : '';
-$gravatar           = isset( $instance['gravatar'] ) ? $instance['gravatar'] : '';
-$icon_url           = isset( $instance['icon_url'] ) ? $instance['icon_url'] : '';
-$dict               = isset( $instance['dict'] ) ? $instance['dict'] : '';
-$extra_conf         = isset( $instance['extra_conf'] ) ? $instance['extra_conf'] : '';
-$custom_css         = isset( $instance['custom_css'] ) ? $instance['custom_css'] : '';
-$custom_js          = isset( $instance['custom_js'] ) ? $instance['custom_js'] : '';
-$redirect_to        = isset( $instance['redirect_to'] ) ? $instance['redirect_to'] : '';
+$form_title  = isset( $instance['form_title'] ) ? $instance['form_title'] : '';
+$gravatar    = isset( $instance['gravatar'] ) ? $instance['gravatar'] : '';
+$icon_url    = isset( $instance['icon_url'] ) ? $instance['icon_url'] : '';
+$dict        = isset( $instance['dict'] ) ? $instance['dict'] : '';
+$extra_conf  = isset( $instance['extra_conf'] ) ? $instance['extra_conf'] : '';
+$custom_css  = isset( $instance['custom_css'] ) ? $instance['custom_css'] : '';
+$custom_js   = isset( $instance['custom_js'] ) ? $instance['custom_js'] : '';
+$redirect_to = isset( $instance['redirect_to'] ) ? $instance['redirect_to'] : '';
 
 if ( $this->showAsModal() ) :
 	$modal_trigger_name = isset( $instance['modal_trigger_name'] ) ? $instance['modal_trigger_name'] : '';
@@ -30,26 +29,6 @@ if ( $this->showAsModal() ) :
 	<input class="widefat" id="<?php echo $this->get_field_id( 'redirect_to' ); ?>"
 		   name="<?php echo $this->get_field_name( 'redirect_to' ); ?>"
 		   type="text" value="<?php echo esc_attr( $redirect_to ); ?>" />
-</p>
-<p>
-	<label><?php _e( 'Show big social buttons:' ); ?></label>
-	<br>
-	<div class="radio-wrapper">
-		<input id="<?php echo $this->get_field_id( 'social_big_buttons' ); ?>_yes"
-			   name="<?php echo $this->get_field_name( 'social_big_buttons' ); ?>"
-			   type="radio" value="1" <?php echo esc_attr( $social_big_buttons ) == 1 ? 'checked="true"' : ''; ?> />
-		<label for="<?php echo $this->get_field_id( 'social_big_buttons' ); ?>_yes"><?php _e( 'Yes' ); ?></label>
-		&nbsp;
-		<input id="<?php echo $this->get_field_id( 'social_big_buttons' ); ?>_no"
-			   name="<?php echo $this->get_field_name( 'social_big_buttons' ); ?>"
-			   type="radio" value="0" <?php echo esc_attr( $social_big_buttons ) == 0 ? 'checked="true"' : ''; ?> />
-		<label for="<?php echo $this->get_field_id( 'social_big_buttons' ); ?>_no"><?php _e( 'No' ); ?></label>
-		&nbsp;
-		<input id="<?php echo $this->get_field_id( 'social_big_buttons' ); ?>_inherit"
-			   name="<?php echo $this->get_field_name( 'social_big_buttons' ); ?>"
-			   type="radio" value="" <?php echo esc_attr( $social_big_buttons ) === '' ? 'checked="true"' : ''; ?> />
-		<label for="<?php echo $this->get_field_id( 'social_big_buttons' ); ?>_no"><?php _e( 'Default Setting' ); ?></label>
-	</div>
 </p>
 <p>
 	<label><?php _e( 'Enable Gravatar integration:' ); ?></label>

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -36,4 +36,4 @@ if ( ! file_exists( $_tests_dir . '/includes/bootstrap.php' ) ) {
 }
 
 require $_tests_dir . '/includes/bootstrap.php';
-require dirname( __FILE__ ) . '/../vendor/autoload.php';
+require dirname( dirname( __FILE__ ) ) . '/vendor/autoload.php';

--- a/tests/testAdminAppearanceValidation.php
+++ b/tests/testAdminAppearanceValidation.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * Contains Class TestAdminAppearanceValidation.
+ *
+ * @package WP-Auth0
+ *
+ * @since 3.11.0
+ */
+
+/**
+ * Class TestAdminAppearanceValidation.
+ */
+class TestAdminAppearanceValidation extends WP_Auth0_Test_Case {
+
+	use DomDocumentHelpers;
+
+	/**
+	 * WP_Auth0_Admin_Appearance instance.
+	 *
+	 * @var WP_Auth0_Admin_Appearance
+	 */
+	public static $admin;
+
+	/**
+	 * Run before the test suite starts.
+	 */
+	public static function setUpBeforeClass() {
+		parent::setUpBeforeClass();
+		self::$admin = new WP_Auth0_Admin_Appearance( self::$opts );
+	}
+
+	/**
+	 * Test that the social_big_buttons option is gone.
+	 */
+	public function testThatSocialBigButtonsIsNotAdded() {
+		$validated = self::$admin->basic_validation( [], [] );
+		$this->assertArrayNotHasKey( 'social_big_buttons', $validated );
+	}
+}

--- a/tests/testAdminAppearanceValidation.php
+++ b/tests/testAdminAppearanceValidation.php
@@ -30,6 +30,89 @@ class TestAdminAppearanceValidation extends WP_Auth0_Test_Case {
 	}
 
 	/**
+	 * Test that the form_title setting is skipped if empty and removes HTML.
+	 */
+	public function testThatFormTitleIsValidatedProperly() {
+		$validated = self::$admin->basic_validation( [], [] );
+		$this->assertEquals( '', $validated['form_title'] );
+
+		$validated = self::$admin->basic_validation( [], [ 'form_title' => '<script>alert("hi")</script>' ] );
+		$this->assertNotContains( '<script>', $validated['form_title'] );
+	}
+
+	/**
+	 * Test that the icon_url setting is skipped if empty and tries to create a valid URL for display.
+	 */
+	public function testThatIconUrlIsValidatedProperly() {
+		$validated = self::$admin->basic_validation( [], [] );
+		$this->assertEquals( '', $validated['icon_url'] );
+
+		$validated = self::$admin->basic_validation( [], [ 'icon_url' => 'example.org' ] );
+		$this->assertEquals( 'http://example.org', $validated['icon_url'] );
+	}
+
+	/**
+	 * Test that the language setting is skipped if empty and removes HTML.
+	 */
+	public function testThatLanguageIsValidatedProperly() {
+		$validated = self::$admin->basic_validation( [], [] );
+		$this->assertEquals( '', $validated['language'] );
+
+		$validated = self::$admin->basic_validation( [], [ 'language' => '<script>alert("hi")</script>' ] );
+		$this->assertNotContains( '<script>', $validated['language'] );
+	}
+
+	/**
+	 * Test that the primary_color setting is skipped if empty and removes HTML.
+	 */
+	public function testThatPrimaryColorIsValidatedProperly() {
+		$validated = self::$admin->basic_validation( [], [] );
+		$this->assertEquals( '', $validated['primary_color'] );
+
+		$validated = self::$admin->basic_validation( [], [ 'primary_color' => '<script>alert("hi")</script>' ] );
+		$this->assertNotContains( '<script>', $validated['primary_color'] );
+	}
+
+	/**
+	 * Test that the language_dictionary setting is skipped if empty and removes HTML.
+	 */
+	public function testThatLanguageDictIsBlankIfNotSet() {
+		$validated = self::$admin->basic_validation( [], [] );
+		$this->assertEquals( '', $validated['language_dictionary'] );
+	}
+
+	/**
+	 * Test that the language_dictionary setting is blank and error is set if invalid JSON and no fallback value.
+	 */
+	public function testThatLanguageDictIsBlankIfInvalidJson() {
+		$validated = self::$admin->basic_validation( [], [ 'language_dictionary' => uniqid() ] );
+		$this->assertEquals( '', $validated['language_dictionary'] );
+
+		global $wp_settings_errors;
+		$this->assertCount( 1, $wp_settings_errors );
+		$this->assertEquals( 'wp_auth0_settings', $wp_settings_errors[0]['setting'] );
+		$this->assertEquals( 'error', $wp_settings_errors[0]['type'] );
+		$this->assertEquals( 'The language dictionary parameter should be a valid JSON object', $wp_settings_errors[0]['message'] );
+	}
+
+	/**
+	 * Test that the language_dictionary setting is set to the previous value and an error is set if invalid JSON.
+	 */
+	public function testThatLanguageDictIsPreviousValIfInvalidJson() {
+		$validated = self::$admin->basic_validation(
+			[ 'language_dictionary' => '{"previous":"value"}' ],
+			[ 'language_dictionary' => uniqid() ]
+		);
+		$this->assertEquals( '{"previous":"value"}', $validated['language_dictionary'] );
+
+		global $wp_settings_errors;
+		$this->assertCount( 1, $wp_settings_errors );
+		$this->assertEquals( 'wp_auth0_settings', $wp_settings_errors[0]['setting'] );
+		$this->assertEquals( 'error', $wp_settings_errors[0]['type'] );
+		$this->assertEquals( 'The language dictionary parameter should be a valid JSON object', $wp_settings_errors[0]['message'] );
+	}
+
+	/**
 	 * Test that the social_big_buttons option is gone.
 	 */
 	public function testThatSocialBigButtonsIsNotAdded() {

--- a/tests/testAdminAppearanceValidation.php
+++ b/tests/testAdminAppearanceValidation.php
@@ -92,7 +92,7 @@ class TestAdminAppearanceValidation extends WP_Auth0_Test_Case {
 		$this->assertCount( 1, $wp_settings_errors );
 		$this->assertEquals( 'wp_auth0_settings', $wp_settings_errors[0]['setting'] );
 		$this->assertEquals( 'error', $wp_settings_errors[0]['type'] );
-		$this->assertEquals( 'The language dictionary parameter should be a valid JSON object', $wp_settings_errors[0]['message'] );
+		$this->assertEquals( 'The language dictionary parameter should be a valid JSON object.', $wp_settings_errors[0]['message'] );
 	}
 
 	/**
@@ -109,7 +109,7 @@ class TestAdminAppearanceValidation extends WP_Auth0_Test_Case {
 		$this->assertCount( 1, $wp_settings_errors );
 		$this->assertEquals( 'wp_auth0_settings', $wp_settings_errors[0]['setting'] );
 		$this->assertEquals( 'error', $wp_settings_errors[0]['type'] );
-		$this->assertEquals( 'The language dictionary parameter should be a valid JSON object', $wp_settings_errors[0]['message'] );
+		$this->assertEquals( 'The language dictionary parameter should be a valid JSON object.', $wp_settings_errors[0]['message'] );
 	}
 
 	/**

--- a/tests/testLockOptions.php
+++ b/tests/testLockOptions.php
@@ -62,4 +62,25 @@ class TestLockOptions extends WP_Auth0_Test_Case {
 		$this->assertEquals( $lock_options->get_state_obj(), $sso_opts['state'] );
 		$this->assertArrayNotHasKey( 'authParams', $sso_opts );
 	}
+
+	/**
+	 * Test that the social_big_buttons option is not used.
+	 */
+	public function testThatSocialButtonStyleStaysBig() {
+		self::$opts->set( 'social_big_buttons', false );
+		$lock_options = new WP_Auth0_Lock10_Options( [], self::$opts );
+
+		$lock_opts = $lock_options->get_lock_options();
+		$this->assertEquals( 'big', $lock_opts['socialButtonStyle'] );
+	}
+
+	/**
+	 * Test that the social_big_buttons option cannot be overridden.
+	 */
+	public function testThatSocialButtonStyleCannotBeOverridden() {
+		$lock_options = new WP_Auth0_Lock10_Options( [ 'social_big_buttons' => false ], self::$opts );
+
+		$lock_opts = $lock_options->get_lock_options();
+		$this->assertEquals( 'big', $lock_opts['socialButtonStyle'] );
+	}
 }

--- a/tests/testWPAuth0DbMigrations.php
+++ b/tests/testWPAuth0DbMigrations.php
@@ -30,7 +30,7 @@ class TestWPAuth0DbMigrations extends WP_Auth0_Test_Case {
 		self::$opts->set( 'migration_ips', '1.2.3.4,2.3.4.5,34.195.142.251,35.160.3.103,34.253.4.94,13.54.254.182' );
 
 		// Run the update.
-		$db_manager->install_db( $test_version, null );
+		$db_manager->install_db( $test_version );
 
 		// Check that the correct IPs were removed.
 		$remaining_ips = explode( ',', self::$opts->get( 'migration_ips' ) );
@@ -66,7 +66,7 @@ class TestWPAuth0DbMigrations extends WP_Auth0_Test_Case {
 		update_option( 'wp_auth0_grant_types_success', 1 );
 
 		// Run the update.
-		$db_manager->install_db( $test_version, null );
+		$db_manager->install_db( $test_version );
 
 		// Check that unused settings were nullified.
 		$this->assertNull( self::$opts->get( 'auth0js-cdn' ) );
@@ -99,7 +99,7 @@ class TestWPAuth0DbMigrations extends WP_Auth0_Test_Case {
 		// Set the previous default CDN URL.
 		self::$opts->set( 'cdn_url', 'https://cdn.auth0.com/js/lock/11.5/lock.min.js' );
 
-		$db_manager->install_db( $test_version, null );
+		$db_manager->install_db( $test_version );
 
 		// Check that Lock URL was updated.
 		$this->assertEquals( 'https://cdn.auth0.com/js/lock/11.15/lock.min.js', self::$opts->get( 'cdn_url' ) );
@@ -113,7 +113,7 @@ class TestWPAuth0DbMigrations extends WP_Auth0_Test_Case {
 		// Set CDN URL to something other than previous version.
 		self::$opts->set( 'cdn_url', 'https://cdn.auth0.com/js/lock/12.0/lock.min.js' );
 
-		$db_manager->install_db( $test_version, null );
+		$db_manager->install_db( $test_version );
 
 		// Check that Lock URL was not updated.
 		$this->assertEquals( 'https://cdn.auth0.com/js/lock/12.0/lock.min.js', self::$opts->get( 'cdn_url' ) );
@@ -131,16 +131,31 @@ class TestWPAuth0DbMigrations extends WP_Auth0_Test_Case {
 		$db_manager->init();
 
 		self::$opts->set( 'wordpress_login_enabled', 1 );
-		$db_manager->install_db( $test_version, null );
+		$db_manager->install_db( $test_version );
 		$wle_code_1 = self::$opts->get( 'wle_code' );
 		$this->assertEquals( 'link', self::$opts->get( 'wordpress_login_enabled' ) );
 		$this->assertGreaterThan( 24, strlen( $wle_code_1 ) );
 
 		self::$opts->set( 'wordpress_login_enabled', 0 );
 		self::$opts->set( 'wle_code', '' );
-		$db_manager->install_db( $test_version, null );
+		$db_manager->install_db( $test_version );
 		$this->assertEquals( 'isset', self::$opts->get( 'wordpress_login_enabled' ) );
 		$this->assertGreaterThan( 24, strlen( self::$opts->get( 'wle_code' ) ) );
 		$this->assertNotEquals( $wle_code_1, self::$opts->get( 'wle_code' ) );
+	}
+
+	/**
+	 * Test that 21 -> 22 DB migration removes the social_big_buttons option.
+	 */
+	public function testThatV22RemovesSocialBigButtons() {
+		$test_version = 22;
+
+		update_option( 'auth0_db_version', $test_version - 1 );
+		$db_manager = new WP_Auth0_DBManager( self::$opts );
+		$db_manager->init();
+
+		self::$opts->set( 'social_big_buttons', '__test_val__' );
+		$db_manager->install_db( $test_version );
+		$this->assertNull( self::$opts->get( 'social_big_buttons' ) );
 	}
 }

--- a/tests/testWPAuth0Options.php
+++ b/tests/testWPAuth0Options.php
@@ -20,7 +20,7 @@ class TestWPAuth0Options extends WP_Auth0_Test_Case {
 	/**
 	 * Total number of options.
 	 */
-	const DEFAULT_OPTIONS_COUNT = 45;
+	const DEFAULT_OPTIONS_COUNT = 44;
 
 	/**
 	 * Test the basic options functionality.


### PR DESCRIPTION
### Changes

- Remove small social button option
- Fix Embedded setting validation

### References

[Lock removing small social button config option](https://github.com/auth0/lock/pull/1637)

### Testing

* [x] This change adds unit test coverage
* [x] This change has been tested on WP 5.1.1

### Checklist

* [x] All existing and new tests complete without errors
* [x] All code quality tools/guidelines in the [Contribution guide](CONTRIBUTION.md) have been run/followed
* [x] All active GitHub CI checks have passed
