### PR TITLE
Namespace user IDs and use DB configuration for new user migration installs

### DIFF
--- a/lib/WP_Auth0_Api_Operations.php
+++ b/lib/WP_Auth0_Api_Operations.php
@@ -135,12 +135,10 @@ class WP_Auth0_Api_Operations {
 	 *
 	 * @param string $name  - Database script name.
 	 *
-	 * @return bool|string
+	 * @return string
 	 */
 	protected function get_script( $name ) {
-		$script = (string) file_get_contents( WPA0_PLUGIN_DIR . 'lib/scripts-js/db-' . $name . '.js' );
-		$script = str_replace( '{AUTH0_ACTION}', 'migration-ws-' . $name, $script );
-		return $script;
+		return (string) file_get_contents( WPA0_PLUGIN_DIR . 'lib/scripts-js/db-' . $name . '.js' );
 	}
 
 	/*

--- a/lib/WP_Auth0_Api_Operations.php
+++ b/lib/WP_Auth0_Api_Operations.php
@@ -78,8 +78,13 @@ class WP_Auth0_Api_Operations {
 					),
 				),
 				'customScripts'                => array(
-					'login'    => $this->get_script( 'login', $migration_token ),
-					'get_user' => $this->get_script( 'get-user', $migration_token ),
+					'login'    => $this->get_script( 'login' ),
+					'get_user' => $this->get_script( 'get-user' ),
+				),
+				'bareConfiguration'            => array(
+					'endpointUrl'    => site_url( 'index.php?a0_action=' ),
+					'migrationToken' => $migration_token,
+					'userNamespace'  => get_auth0_curatedBlogName(),
 				),
 			);
 
@@ -129,14 +134,12 @@ class WP_Auth0_Api_Operations {
 	 * Get JS to use in the custom database script.
 	 *
 	 * @param string $name  - Database script name.
-	 * @param string $token - Migration token.
 	 *
 	 * @return bool|string
 	 */
-	protected function get_script( $name, $token ) {
+	protected function get_script( $name ) {
 		$script = (string) file_get_contents( WPA0_PLUGIN_DIR . 'lib/scripts-js/db-' . $name . '.js' );
-		$script = str_replace( '{THE_WS_TOKEN}', $token, $script );
-		$script = str_replace( '{THE_WS_URL}', site_url( 'index.php?a0_action=migration-ws-' . $name ), $script );
+		$script = str_replace( '{AUTH0_ACTION}', 'migration-ws-' . $name, $script );
 		return $script;
 	}
 

--- a/lib/scripts-js/db-get-user.js
+++ b/lib/scripts-js/db-get-user.js
@@ -1,18 +1,27 @@
-/* globals require */
+/* globals require, configuration */
 
+/**
+ * This script will be executed when the user wishes to change their password to test if the user exists.
+ * This needs a global configuration option with the following properties:
+ *    {string} endpointUrl - Site URL with an empty "a0_action" parameter appended.
+ *    {string} migrationToken - Migration token found in the plugin settings
+ *    {string} userNamespace - Formatted site name to avoid user ID overlapping.
+ *
+ * @param {string} email - User email address, provided on login.
+ * @param {function} callback - Function to call when the script has completed.
+ */
 function getByEmail (email, callback) {
 
   var request = require('request');
 
   request.post(
     // The string below should be replaced with the WP site's migration URL like:
-    // https://yourdomain.com/index.php?a0_action=migration-ws-get-user
-    '{THE_WS_URL}',
+    // configuration.endpointUrl + 'migration-ws-get-user'
+    configuration.endpointUrl + '{AUTH0_ACTION}',
     {
       form: {
         username: email,
-        // The string below should be replaced with the migration token found in the plugin settings.
-        access_token: '{THE_WS_TOKEN}'
+        access_token: configuration.migrationToken
       }
     },
     function(error, response, body) {
@@ -31,10 +40,10 @@ function getByEmail (email, callback) {
 
       // Use WordPress profile data to populate Auth0 account.
       var profile = {
-        user_id:        wpUser.data.ID,
-        username:       wpUser.data.user_login,
-        email:          wpUser.data.user_email,
-        name:           wpUser.data.display_name,
+        user_id: configuration.userNamespace + '|' + wpUser.data.ID,
+        username: wpUser.data.user_login,
+        email: wpUser.data.user_email,
+        name: wpUser.data.display_name,
         email_verified: true
       };
 

--- a/lib/scripts-js/db-get-user.js
+++ b/lib/scripts-js/db-get-user.js
@@ -15,9 +15,7 @@ function getByEmail (email, callback) {
   var request = require('request');
 
   request.post(
-    // The string below should be replaced with the WP site's migration URL like:
-    // configuration.endpointUrl + 'migration-ws-get-user'
-    configuration.endpointUrl + '{AUTH0_ACTION}',
+    configuration.endpointUrl + 'migration-ws-get-user',
     {
       form: {
         username: email,

--- a/lib/scripts-js/db-login.js
+++ b/lib/scripts-js/db-login.js
@@ -1,19 +1,29 @@
-/* globals require */
+/* globals require, configuration */
 
+/**
+ * This script will be executed each time a user attempts to login to a custom database.
+ * This needs a global configuration option with the following properties:
+ *    {string} endpointUrl - Site URL with an empty "a0_action" parameter appended.
+ *    {string} migrationToken - Migration token found in the plugin settings
+ *    {string} userNamespace - Formatted site name to avoid user ID overlapping.
+ *
+ * @param {string} email - User email address, provided on login.
+ * @param {string} password - User password, provided on login.
+ * @param {function} callback - Function to call when the script has completed.
+ */
 function login (email, password, callback) {
 
   var request = require('request');
 
   request.post(
     // The string below should be replaced with the WP site's migration URL like:
-    // https://yourdomain.com/index.php?a0_action=migration-ws-login
-    '{THE_WS_URL}',
+    // configuration.endpointUrl + 'migration-ws-login'
+    configuration.endpointUrl + '{AUTH0_ACTION}',
     {
       form: {
         username:     email,
         password:     password,
-        // The string below should be replaced with the migration token found in the plugin settings.
-        access_token: '{THE_WS_TOKEN}'
+        access_token: configuration.migrationToken
       }
     },
     function(error, response, body) {
@@ -32,10 +42,10 @@ function login (email, password, callback) {
 
       // Use WordPress profile data to populate Auth0 account.
       var profile = {
-        user_id:        wpUser.data.ID,
-        username:       wpUser.data.user_login,
-        email:          wpUser.data.user_email,
-        name:           wpUser.data.display_name,
+        user_id: configuration.userNamespace + '|' + wpUser.data.ID,
+        username: wpUser.data.user_login,
+        email: wpUser.data.user_email,
+        name: wpUser.data.display_name,
         email_verified: true
       };
 

--- a/lib/scripts-js/db-login.js
+++ b/lib/scripts-js/db-login.js
@@ -16,9 +16,7 @@ function login (email, password, callback) {
   var request = require('request');
 
   request.post(
-    // The string below should be replaced with the WP site's migration URL like:
-    // configuration.endpointUrl + 'migration-ws-login'
-    configuration.endpointUrl + '{AUTH0_ACTION}',
+    configuration.endpointUrl + 'migration-ws-login',
     {
       form: {
         username:     email,


### PR DESCRIPTION
### Changes

This PR adds name-spacing for the user ID when using a custom database. It also moves configuration data (URL, namespace, and migration token) to the configuration manager. This will change how new user migration sites work but will not break or change existing ones. 

### References

- [WordPress support forum thread](https://wordpress.org/support/topic/important-error-mixing-identities/)
- [Docs PR commit](https://github.com/auth0/docs/pull/7594/commits/bb620bbc459d99f6ad51c5e4effcd1605f0fb88c)

### Testing

This can be tested by:

1. Installing this version of the plugin from scratch
2. Running the Setup Wizard for user migrations ([docs](https://auth0.com/docs/cms/wordpress/installation#option-2-user-migration-setup))
3. Completing the process and logging in to create the Auth0 user
4. Attempting a password change and an email address change

* [x] I included manual testing steps above, if applicable
* [x] This change adds unit test coverage ([failing tests](https://github.com/auth0/wp-auth0/pull/681/commits/9aca7999d27faa895a166cbd84aaef43bd02fd4c))
* [x] This change has been tested on WP 5.1.1

### Checklist

* [x] All existing and new tests complete without errors
* [x] All code quality tools/guidelines in the [Contribution guide](CONTRIBUTION.md) have been run/followed
* [x] All active GitHub CI checks have passed
