### PR TITLE
Translate plugin links and remove error log

### DIFF
--- a/WP_Auth0.php
+++ b/WP_Auth0.php
@@ -21,7 +21,7 @@ define( 'WPA0_PLUGIN_IMG_URL', WPA0_PLUGIN_URL . 'assets/img/' );
 define( 'WPA0_PLUGIN_LIB_URL', WPA0_PLUGIN_URL . 'assets/lib/' );
 define( 'WPA0_PLUGIN_BS_URL', WPA0_PLUGIN_URL . 'assets/bootstrap/' );
 
-define( 'WPA0_LOCK_CDN_URL', 'https://cdn.auth0.com/js/lock/11.15/lock.min.js' );
+define( 'WPA0_LOCK_CDN_URL', 'https://cdn.auth0.com/js/lock/11.16/lock.min.js' );
 define( 'WPA0_AUTH0_JS_CDN_URL', 'https://cdn.auth0.com/js/auth0/9.10/auth0.min.js' );
 
 define( 'WPA0_AUTH0_LOGIN_FORM_ID', 'auth0-login-form' );
@@ -309,19 +309,24 @@ class WP_Auth0 {
 	 */
 	public function wp_add_plugin_settings_link( $links ) {
 
-		$settings_link = '<a href="admin.php?page=wpa0-errors">Error Log</a>';
-		array_unshift( $links, $settings_link );
+		array_unshift(
+			$links,
+			sprintf(
+				'<a href="%s">%s</a>',
+				admin_url( 'admin.php?page=wpa0' ),
+				__( 'Settings', 'wp-auth0' )
+			)
+		);
 
-		$settings_link = '<a href="admin.php?page=wpa0">Settings</a>';
-		array_unshift( $links, $settings_link );
-
-		$client_id     = $this->a0_options->get( 'client_id' );
-		$client_secret = $this->a0_options->get( 'client_secret' );
-		$domain        = $this->a0_options->get( 'domain' );
-
-		if ( ( ! $client_id ) || ( ! $client_secret ) || ( ! $domain ) ) {
-			$settings_link = '<a href="admin.php?page=wpa0-setup">Quick Setup</a>';
-			array_unshift( $links, $settings_link );
+		if ( ! self::ready() ) {
+			array_unshift(
+				$links,
+				sprintf(
+					'<a href="%s">%s</a>',
+					admin_url( 'admin.php?page=wpa0-setup' ),
+					__( 'Setup Wizard', 'wp-auth0' )
+				)
+			);
 		}
 
 		return $links;

--- a/tests/testWPAuth0DbMigrations.php
+++ b/tests/testWPAuth0DbMigrations.php
@@ -102,7 +102,7 @@ class TestWPAuth0DbMigrations extends WP_Auth0_Test_Case {
 		$db_manager->install_db( $test_version );
 
 		// Check that Lock URL was updated.
-		$this->assertEquals( 'https://cdn.auth0.com/js/lock/11.15/lock.min.js', self::$opts->get( 'cdn_url' ) );
+		$this->assertEquals( WPA0_LOCK_CDN_URL, self::$opts->get( 'cdn_url' ) );
 		$this->assertNull( self::$opts->get( 'custom_cdn_url' ) );
 
 		self::$opts->reset();

--- a/tests/testWPAuth0Helpers.php
+++ b/tests/testWPAuth0Helpers.php
@@ -33,4 +33,40 @@ class TestWPAuth0Helpers extends WP_Auth0_Test_Case {
 		$this->assertEquals( 'orange@au', WP_Auth0::get_tenant( 'orange.au.auth0.com' ) );
 		$this->assertEquals( 'mango@xx', WP_Auth0::get_tenant( 'mango.xx.auth0.com' ) );
 	}
+
+	/**
+	 * Test that the correct plugin links are shown when the plugin has NOT been configured.
+	 */
+	public function testThatPluginSettingsLinksAreCorrectWhenNotReady() {
+		$wp_auth0     = new WP_Auth0();
+		$plugin_links = $wp_auth0->wp_add_plugin_settings_link( [] );
+
+		$this->assertCount( 2, $plugin_links );
+
+		$this->assertContains(
+			'<a href="http://example.org/wp-admin/admin.php?page=wpa0">Settings</a>',
+			$plugin_links
+		);
+
+		$this->assertContains(
+			'<a href="http://example.org/wp-admin/admin.php?page=wpa0-setup">Setup Wizard</a>',
+			$plugin_links
+		);
+	}
+
+	/**
+	 * Test that the correct plugin links are shown when the plugin has been configured.
+	 */
+	public function testThatPluginSettingsLinksAreCorrectWhenReady() {
+		$wp_auth0 = new WP_Auth0();
+		self::auth0Ready( true );
+		$plugin_links = $wp_auth0->wp_add_plugin_settings_link( [] );
+
+		$this->assertCount( 1, $plugin_links );
+
+		$this->assertContains(
+			'<a href="http://example.org/wp-admin/admin.php?page=wpa0">Settings</a>',
+			$plugin_links
+		);
+	}
 }


### PR DESCRIPTION
### Changes

- Update Lock to 11.16
- Translate plugin link text
- Remove plugin link to error log

### References

[Lock v11.16 release](https://github.com/auth0/lock/releases/tag/v11.16.0)
