### PR TITLE
Deprecate WP_Auth0_Api_Client methods

### DIFF
--- a/lib/WP_Auth0_Api_Client.php
+++ b/lib/WP_Auth0_Api_Client.php
@@ -103,7 +103,7 @@ class WP_Auth0_Api_Client {
 	}
 
 	/**
-	 * TODO: Deprecate
+	 * @deprecated - 3.11.0, use WP_Auth0_Api_Client_Credentials instead.
 	 *
 	 * @codeCoverageIgnore - Deprecated
 	 */
@@ -207,7 +207,7 @@ class WP_Auth0_Api_Client {
 	}
 
 	/**
-	 * TODO: Deprecate
+	 * @deprecated - 3.11.0, use WP_Auth0_Api_Get_User instead.
 	 *
 	 * @codeCoverageIgnore - Deprecated
 	 */


### PR DESCRIPTION
Deprecates:

- `WP_Auth0_Api_Client::get_token()` (use `WP_Auth0_Api_Client_Credentials` instead)
- `WP_Auth0_Api_Client::get_user()` (use `WP_Auth0_Api_Get_User` instead)