### PR TITLE
Improve WordPress core login override for security and UX

### DIFF
--- a/WP_Auth0.php
+++ b/WP_Auth0.php
@@ -3,7 +3,7 @@
  * Plugin Name: Login by Auth0
  * Plugin URL: https://auth0.com/docs/cms/wordpress
  * Description: Login by Auth0 provides improved username/password login, Passwordless login, Social login, MFA, and Single Sign On for all your sites.
- * Version: 3.10.0
+ * Version: 3.11.0-beta
  * Author: Auth0
  * Author URI: https://auth0.com
  * Text Domain: wp-auth0
@@ -573,33 +573,32 @@ $a0_plugin->init();
  */
 
 /**
- * Redirect the lost password submission to a login override page.
+ * Redirect a successful lost password submission to a login override page.
  *
  * @param string $location - Redirect in process.
  *
  * @return string
  */
 function wp_auth0_filter_wp_redirect_lostpassword( $location ) {
-	// Make sure we're going to the check email action on the login page.
+	// Make sure we're going to the check email action on the wp-login page.
 	if ( 'wp-login.php?checkemail=confirm' !== $location ) {
 		return $location;
 	}
 
-	// Make sure we're on the lost password action on the login page.
+	// Make sure we're on the lost password action on the wp-login page.
 	if ( ! wp_auth0_is_current_login_action( array( 'lostpassword' ) ) ) {
 		return $location;
 	}
 
-	// Make sure we can allow core WP login form overrides
+	// Make sure plugin settings allow core WP login form overrides
 	if ( 'never' === wp_auth0_get_option( 'wordpress_login_enabled' ) ) {
 		return $location;
 	}
 
+	// Make sure we're coming from an override page.
 	$required_referrer = remove_query_arg( 'wle', wp_login_url() );
 	$required_referrer = add_query_arg( 'action', 'lostpassword', $required_referrer );
 	$required_referrer = wp_auth0_login_override_url( $required_referrer );
-
-	// Make sure we're coming from an override page.
 	if ( ! isset( $_SERVER['HTTP_REFERER'] ) || $required_referrer !== $_SERVER['HTTP_REFERER'] ) {
 		return $location;
 	}
@@ -632,7 +631,7 @@ add_filter( 'lostpassword_url', 'wp_auth0_filter_login_override_url', 100 );
 add_filter( 'login_url', 'wp_auth0_filter_login_override_url', 100 );
 
 /**
- * Add the core WP form override to the lost password form.
+ * Add the core WP form override to the lost password and login forms.
  */
 function wp_auth0_filter_login_override_form() {
 	if ( WP_Auth0_Options::Instance()->can_show_wp_login_form() && isset( $_REQUEST['wle'] ) ) {

--- a/assets/css/login.css
+++ b/assets/css/login.css
@@ -59,6 +59,8 @@ body.a0-widget-open>* {
 
 #registerform,
 #loginform,
+#lostpasswordform,
+#login_error,
 #login #nav,
 .woocommerce-checkout .woocommerce-info,
 .woocommerce-account .woocommerce h2,
@@ -68,6 +70,8 @@ body.a0-widget-open>* {
 
 .a0-show-core-login #registerform,
 .a0-show-core-login #loginform,
+.a0-show-core-login #lostpasswordform,
+.a0-show-core-login #login_error,
 .a0-show-core-login #login #nav,
 .a0-show-core-login.woocommerce-checkout .woocommerce-info,
 .a0-show-core-login.woocommerce-account .woocommerce h2,

--- a/functions.php
+++ b/functions.php
@@ -20,11 +20,15 @@ function wp_auth0_get_option( $key, $default = null ) {
 }
 
 /**
- * @param array $action
+ * Determine if we're on the wp-login.php page and if the current action matches a given set.
+ *
+ * @since 3.11.0
+ *
+ * @param array $actions - An array of actions to check the current action against.
  *
  * @return bool
  */
-function wp_auth0_is_current_login_action( array $action ) {
+function wp_auth0_is_current_login_action( array $actions ) {
 
 	// Not on wp-login.php.
 	if ( ! isset( $GLOBALS['pagenow'] ) || 'wp-login.php' !== $GLOBALS['pagenow'] ) {
@@ -32,9 +36,16 @@ function wp_auth0_is_current_login_action( array $action ) {
 	}
 
 	$current_action = isset( $_REQUEST['action'] ) ? $_REQUEST['action'] : null;
-	return in_array( $current_action, $action );
+	return in_array( $current_action, $actions );
 }
 
+/**
+ * Generate a valid WordPress login override URL, if plugin settings allow.
+ *
+ * @param null $login_url - An existing URL to modify; default is wp-login.php.
+ *
+ * @return string
+ */
 function wp_auth0_login_override_url( $login_url = null ) {
 	$wle = WP_Auth0_Options::Instance()->get( 'wordpress_login_enabled' );
 	if ( 'no' === $wle ) {

--- a/functions.php
+++ b/functions.php
@@ -19,6 +19,36 @@ function wp_auth0_get_option( $key, $default = null ) {
 	return WP_Auth0_Options::Instance()->get( $key, $default );
 }
 
+/**
+ * @param array $action
+ *
+ * @return bool
+ */
+function wp_auth0_is_current_login_action( array $action ) {
+
+	// Not on wp-login.php.
+	if ( ! isset( $GLOBALS['pagenow'] ) || 'wp-login.php' !== $GLOBALS['pagenow'] ) {
+		return false;
+	}
+
+	$current_action = isset( $_REQUEST['action'] ) ? $_REQUEST['action'] : null;
+	return in_array( $current_action, $action );
+}
+
+function wp_auth0_login_override_url( $login_url = null ) {
+	$wle = WP_Auth0_Options::Instance()->get( 'wordpress_login_enabled' );
+	if ( 'no' === $wle ) {
+		return '';
+	}
+
+	$wle_code = '';
+	if ( 'code' === $wle ) {
+		$wle_code = WP_Auth0_Options::Instance()->get( 'wle_code' );
+	}
+
+	$login_url = $login_url ?: wp_login_url();
+	return add_query_arg( 'wle', $wle_code, $login_url );
+}
 
 if ( ! function_exists( 'get_auth0userinfo' ) ) {
 	function get_auth0userinfo( $user_id ) {

--- a/lib/WP_Auth0_Lock10_Options.php
+++ b/lib/WP_Auth0_Lock10_Options.php
@@ -141,7 +141,7 @@ class WP_Auth0_Lock10_Options {
 		}
 		if ( $this->signup_mode ) {
 			$options_obj['allowLogin'] = false;
-		} elseif ( isset( $_GET['action'] ) && $_GET['action'] == 'register' ) {
+		} elseif ( wp_auth0_is_current_login_action( array( 'register' ) ) ) {
 			$options_obj['allowLogin'] = true;
 		}
 		return $options_obj;
@@ -219,7 +219,7 @@ class WP_Auth0_Lock10_Options {
 			$options_obj['disableSignupAction'] = true;
 		}
 
-		if ( function_exists( 'login_header' ) && isset( $_GET['action'] ) && 'register' === $_GET['action'] ) {
+		if ( wp_auth0_is_current_login_action( array( 'register' ) ) ) {
 			$options_obj['initialScreen'] = 'signUp';
 		}
 

--- a/lib/WP_Auth0_Lock10_Options.php
+++ b/lib/WP_Auth0_Lock10_Options.php
@@ -139,11 +139,7 @@ class WP_Auth0_Lock10_Options {
 			$extra_conf_arr = json_decode( $settings['extra_conf'], true );
 			$options_obj    = array_merge_recursive( $extra_conf_arr, $options_obj );
 		}
-		if ( $this->signup_mode ) {
-			$options_obj['allowLogin'] = false;
-		} elseif ( wp_auth0_is_current_login_action( array( 'register' ) ) ) {
-			$options_obj['allowLogin'] = true;
-		}
+
 		return $options_obj;
 	}
 

--- a/lib/WP_Auth0_LoginManager.php
+++ b/lib/WP_Auth0_LoginManager.php
@@ -105,17 +105,12 @@ class WP_Auth0_LoginManager {
 	public function login_auto() {
 
 		// Do not redirect anywhere if this is a logout action.
-		if ( isset( $_GET['action'] ) && 'logout' === $_GET['action'] ) {
+		if ( wp_auth0_is_current_login_action( array( 'logout' ) ) ) {
 			return false;
 		}
 
 		// Do not redirect login page override.
 		if ( $this->a0_options->can_show_wp_login_form() ) {
-			return false;
-		}
-
-		// Do not redirect non-GET requests.
-		if ( strtolower( $_SERVER['REQUEST_METHOD'] ) !== 'get' ) {
 			return false;
 		}
 
@@ -132,7 +127,7 @@ class WP_Auth0_LoginManager {
 		}
 
 		// Do not use the ULP if the setting is off or if the plugin is not configured.
-		if ( ! $this->a0_options->get( 'auto_login', false ) || ! WP_Auth0::ready() ) {
+		if ( ! $this->a0_options->get( 'auto_login', false ) ) {
 			return false;
 		}
 

--- a/lib/WP_Auth0_Options.php
+++ b/lib/WP_Auth0_Options.php
@@ -194,7 +194,16 @@ class WP_Auth0_Options extends WP_Auth0_Options_Generic {
 	 */
 	public function can_show_wp_login_form() {
 
-		if ( ! isset( $_GET['wle'] ) ) {
+		if ( ! WP_Auth0::ready() ) {
+			return true;
+		}
+
+		$current_login_action = isset( $_REQUEST['action'] ) ? $_REQUEST['action'] : null;
+		if ( in_array( $current_login_action, array( 'resetpass', 'rp' ) ) ) {
+			return true;
+		}
+
+		if ( ! isset( $_REQUEST['wle'] ) ) {
 			return false;
 		}
 
@@ -208,7 +217,7 @@ class WP_Auth0_Options extends WP_Auth0_Options_Generic {
 		}
 
 		$wle_code = $this->get( 'wle_code' );
-		if ( 'code' === $wle_setting && $wle_code === $_GET['wle'] ) {
+		if ( 'code' === $wle_setting && $wle_code === $_REQUEST['wle'] ) {
 			return true;
 		}
 

--- a/lib/WP_Auth0_Options.php
+++ b/lib/WP_Auth0_Options.php
@@ -190,38 +190,12 @@ class WP_Auth0_Options extends WP_Auth0_Options_Generic {
 	}
 
 	/**
+	 * TODO: Deprecate
+	 *
 	 * @return bool
 	 */
 	public function can_show_wp_login_form() {
-
-		if ( ! WP_Auth0::ready() ) {
-			return true;
-		}
-
-		$current_login_action = isset( $_REQUEST['action'] ) ? $_REQUEST['action'] : null;
-		if ( in_array( $current_login_action, array( 'resetpass', 'rp' ) ) ) {
-			return true;
-		}
-
-		if ( ! isset( $_REQUEST['wle'] ) ) {
-			return false;
-		}
-
-		$wle_setting = $this->get( 'wordpress_login_enabled' );
-		if ( 'no' === $wle_setting ) {
-			return false;
-		}
-
-		if ( in_array( $wle_setting, array( 'link', 'isset' ) ) ) {
-			return true;
-		}
-
-		$wle_code = $this->get( 'wle_code' );
-		if ( 'code' === $wle_setting && $wle_code === $_REQUEST['wle'] ) {
-			return true;
-		}
-
-		return false;
+		return wp_auth0_can_show_wp_login_form();
 	}
 
 	/**

--- a/phpcs-test-ruleset.xml
+++ b/phpcs-test-ruleset.xml
@@ -38,5 +38,8 @@
             <property name="text_domain" type="array" value="wp-auth0" />
         </properties>
     </rule>
+    <rule ref="Squiz.Commenting.FunctionComment">
+        <exclude name="Squiz.Commenting.FunctionComment.Missing"/>
+    </rule>
 
 </ruleset>

--- a/tests/testEditProfile.php
+++ b/tests/testEditProfile.php
@@ -83,11 +83,11 @@ class TestEditProfile extends WP_Auth0_Test_Case {
 		$pagenow = 'profile.php';
 		$this->clear_hooks( 'admin_enqueue_scripts' );
 		self::$editProfile->init();
-		$this->assertHooked( 'admin_enqueue_scripts', 'WP_Auth0_EditProfile', $expect_hooked );
+		$this->assertHookedClass( 'admin_enqueue_scripts', 'WP_Auth0_EditProfile', $expect_hooked );
 
 		$pagenow = 'user-edit.php';
 		$this->clear_hooks( 'admin_enqueue_scripts' );
 		self::$editProfile->init();
-		$this->assertHooked( 'admin_enqueue_scripts', 'WP_Auth0_EditProfile', $expect_hooked );
+		$this->assertHookedClass( 'admin_enqueue_scripts', 'WP_Auth0_EditProfile', $expect_hooked );
 	}
 }

--- a/tests/testFunctionIsCurrentLoginAction.php
+++ b/tests/testFunctionIsCurrentLoginAction.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * Contains Class TestFunctionIsCurrentLoginAction.
+ *
+ * @package WP-Auth0
+ *
+ * @since 3.11.0
+ */
+
+/**
+ * Class TestFunctionIsCurrentLoginAction.
+ */
+class TestFunctionIsCurrentLoginAction extends WP_Auth0_Test_Case {
+
+	public function testThatCurrentActionIsFalseIfNotOnWpLogin() {
+		unset( $GLOBALS['pagenow'] );
+		$this->assertFalse( wp_auth0_is_current_login_action( [] ) );
+
+		$GLOBALS['pagenow'] = uniqid();
+		$this->assertFalse( wp_auth0_is_current_login_action( [] ) );
+	}
+
+	public function testThatCurrentActionIsFalseIfActionNotSet() {
+		$GLOBALS['pagenow'] = 'wp-login.php';
+		unset( $_REQUEST['action'] );
+		$this->assertFalse( wp_auth0_is_current_login_action( [] ) );
+	}
+
+	public function testThatCurrentActionIsFalseIfActionDoesNotMatch() {
+		$GLOBALS['pagenow'] = 'wp-login.php';
+		$_REQUEST['action'] = '__invalid_action__';
+		$this->assertFalse( wp_auth0_is_current_login_action( [ '__valid_action__' ] ) );
+	}
+
+	public function testThatCurrentActionIsTrueIfActionDoesMatch() {
+		$GLOBALS['pagenow'] = 'wp-login.php';
+		$_REQUEST['action'] = '__valid_action__';
+		$this->assertTrue( wp_auth0_is_current_login_action( [ '__valid_action__' ] ) );
+	}
+}

--- a/tests/testFunctionLoginOverrideUrl.php
+++ b/tests/testFunctionLoginOverrideUrl.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * Contains Class TestFunctionLoginOverrideUrl.
+ *
+ * @package WP-Auth0
+ *
+ * @since 3.11.0
+ */
+
+/**
+ * Class TestFunctionLoginOverrideUrl.
+ */
+class TestFunctionLoginOverrideUrl extends WP_Auth0_Test_Case {
+
+	public function testThatOverrideUrlIsEmptyIfWleOff() {
+		self::$opts->set( 'wordpress_login_enabled', 'no' );
+		$this->assertEmpty( wp_auth0_login_override_url() );
+		$this->assertEmpty( wp_auth0_login_override_url( uniqid() ) );
+	}
+
+	public function testThatOverrideUrlIsCorrectIfWleIsLink() {
+		self::$opts->set( 'wordpress_login_enabled', 'link' );
+		$this->assertEquals( 'http://example.org/wp-login.php?wle', wp_auth0_login_override_url() );
+		$this->assertEquals(
+			'http://example.org/login?wle',
+			wp_auth0_login_override_url( 'http://example.org/login' )
+		);
+	}
+
+	public function testThatOverrideUrlIsCorrectIfWleIsCode() {
+		self::$opts->set( 'wordpress_login_enabled', 'code' );
+		self::$opts->set( 'wle_code', '__test_wle_code__' );
+		$this->assertEquals(
+			'http://example.org/wp-login.php?wle=__test_wle_code__',
+			wp_auth0_login_override_url()
+		);
+		$this->assertEquals(
+			'http://example.org/login?wle=__test_wle_code__',
+			wp_auth0_login_override_url( 'http://example.org/login' )
+		);
+	}
+}

--- a/tests/testLoginManager.php
+++ b/tests/testLoginManager.php
@@ -231,7 +231,8 @@ class TestLoginManager extends WP_Auth0_Test_Case {
 		// First, check that a redirect is happening.
 		self::$opts->set( 'auto_login', 1 );
 		self::auth0Ready( true );
-		$caught_redirect = [];
+		$_SERVER['REQUEST_METHOD'] = 'POST';
+		$caught_redirect           = [];
 		try {
 			// Need to hide error messages here because a cookie is set.
 			// phpcs:ignore
@@ -240,13 +241,6 @@ class TestLoginManager extends WP_Auth0_Test_Case {
 			$caught_redirect = unserialize( $e->getMessage() );
 		}
 		$this->assertEquals( 302, $caught_redirect['status'] );
-
-		// Test that request method will stop redirect.
-		$_SERVER['REQUEST_METHOD'] = 'POST';
-		$this->assertFalse( $login_manager->login_auto() );
-
-		$_SERVER['REQUEST_METHOD'] = 'PATCH';
-		$this->assertFalse( $login_manager->login_auto() );
 	}
 
 	/**
@@ -272,7 +266,7 @@ class TestLoginManager extends WP_Auth0_Test_Case {
 		$this->assertEquals( 302, $caught_redirect['status'] );
 
 		// Test that WP login override will skip the redirect.
-		$_GET['wle'] = 1;
+		$_REQUEST['wle'] = 1;
 		$this->assertFalse( $login_manager->login_auto() );
 	}
 
@@ -299,7 +293,8 @@ class TestLoginManager extends WP_Auth0_Test_Case {
 		$this->assertEquals( 302, $caught_redirect['status'] );
 
 		// Test that logout will skip the redirect.
-		$_GET['action'] = 'logout';
+		$GLOBALS['pagenow'] = 'wp-login.php';
+		$_REQUEST['action'] = 'logout';
 		$this->assertFalse( $login_manager->login_auto() );
 	}
 }

--- a/tests/testOptionCanShowWpLogin.php
+++ b/tests/testOptionCanShowWpLogin.php
@@ -69,27 +69,6 @@ class TestOptionCanShowWpLogin extends WP_Auth0_Test_Case {
 		$_REQUEST['wle'] = '__invalid_wle_code__';
 		self::$opts->set( 'wordpress_login_enabled', 'code' );
 		self::$opts->set( 'wle_code', '__test_wle_code__' );
-		$this->assertTrue( self::$opts->can_show_wp_login_form() );
-	}
-
-	public function testThatCanShowWpLoginFormReturnsCorrectly() {
-
-		$this->assertEquals( 'link', self::$opts->get( 'wordpress_login_enabled' ) );
-		$_GET['wle'] = '';
-		$this->assertTrue( self::$opts->can_show_wp_login_form() );
-
-		self::$opts->set( 'wordpress_login_enabled', 'isset' );
-		$this->assertTrue( self::$opts->can_show_wp_login_form() );
-
-		self::$opts->set( 'wordpress_login_enabled', 'code' );
-		$wle_code = uniqid();
-		self::$opts->set( 'wle_code', $wle_code );
-		$this->assertFalse( self::$opts->can_show_wp_login_form() );
-
-		$_GET['wle'] = $wle_code;
-		$this->assertTrue( self::$opts->can_show_wp_login_form() );
-
-		self::$opts->set( 'wordpress_login_enabled', 'no' );
 		$this->assertFalse( self::$opts->can_show_wp_login_form() );
 	}
 }

--- a/tests/testOptionCanShowWpLogin.php
+++ b/tests/testOptionCanShowWpLogin.php
@@ -13,7 +13,7 @@
 class TestOptionCanShowWpLogin extends WP_Auth0_Test_Case {
 
 	public function testThatWpLoginCanBeShownIfPluginNotReady() {
-		$this->assertTrue( self::$opts->can_show_wp_login_form() );
+		$this->assertTrue( wp_auth0_can_show_wp_login_form() );
 	}
 
 	public function testThatWpLoginCanBeShownIfOnResetpassPage() {
@@ -21,7 +21,7 @@ class TestOptionCanShowWpLogin extends WP_Auth0_Test_Case {
 		$GLOBALS['pagenow'] = 'wp-login.php';
 		$_REQUEST['action'] = 'resetpass';
 		self::$opts->set( 'wordpress_login_enabled', 'link' );
-		$this->assertTrue( self::$opts->can_show_wp_login_form() );
+		$this->assertTrue( wp_auth0_can_show_wp_login_form() );
 	}
 
 	public function testThatWpLoginCanBeShownIfOnRpPage() {
@@ -29,20 +29,20 @@ class TestOptionCanShowWpLogin extends WP_Auth0_Test_Case {
 		$GLOBALS['pagenow'] = 'wp-login.php';
 		$_REQUEST['action'] = 'rp';
 		self::$opts->set( 'wordpress_login_enabled', 'link' );
-		$this->assertTrue( self::$opts->can_show_wp_login_form() );
+		$this->assertTrue( wp_auth0_can_show_wp_login_form() );
 	}
 
 	public function testThatWpLoginCannotBeShownIfNotWle() {
 		self::auth0Ready();
 		self::$opts->set( 'wordpress_login_enabled', 'link' );
-		$this->assertFalse( self::$opts->can_show_wp_login_form() );
+		$this->assertFalse( wp_auth0_can_show_wp_login_form() );
 	}
 
 	public function testThatWpLoginCannotBeShownIfWleOff() {
 		self::auth0Ready();
 		$_REQUEST['wle'] = '__test_wle_code__';
 		self::$opts->set( 'wordpress_login_enabled', 'no' );
-		$this->assertFalse( self::$opts->can_show_wp_login_form() );
+		$this->assertFalse( wp_auth0_can_show_wp_login_form() );
 	}
 
 	public function testThatWpLoginCanBeShownIfWlePresent() {
@@ -50,10 +50,10 @@ class TestOptionCanShowWpLogin extends WP_Auth0_Test_Case {
 		$_REQUEST['wle'] = '';
 
 		self::$opts->set( 'wordpress_login_enabled', 'link' );
-		$this->assertTrue( self::$opts->can_show_wp_login_form() );
+		$this->assertTrue( wp_auth0_can_show_wp_login_form() );
 
 		self::$opts->set( 'wordpress_login_enabled', 'isset' );
-		$this->assertTrue( self::$opts->can_show_wp_login_form() );
+		$this->assertTrue( wp_auth0_can_show_wp_login_form() );
 	}
 
 	public function testThatWpLoginCanBeShownIfWleCodeMatches() {
@@ -61,7 +61,7 @@ class TestOptionCanShowWpLogin extends WP_Auth0_Test_Case {
 		$_REQUEST['wle'] = '__test_wle_code__';
 		self::$opts->set( 'wordpress_login_enabled', 'code' );
 		self::$opts->set( 'wle_code', '__test_wle_code__' );
-		$this->assertTrue( self::$opts->can_show_wp_login_form() );
+		$this->assertTrue( wp_auth0_can_show_wp_login_form() );
 	}
 
 	public function testThatWpLoginCannotBeShownIfWleCodeNotMatches() {
@@ -69,6 +69,6 @@ class TestOptionCanShowWpLogin extends WP_Auth0_Test_Case {
 		$_REQUEST['wle'] = '__invalid_wle_code__';
 		self::$opts->set( 'wordpress_login_enabled', 'code' );
 		self::$opts->set( 'wle_code', '__test_wle_code__' );
-		$this->assertFalse( self::$opts->can_show_wp_login_form() );
+		$this->assertFalse( wp_auth0_can_show_wp_login_form() );
 	}
 }

--- a/tests/testOptionCanShowWpLogin.php
+++ b/tests/testOptionCanShowWpLogin.php
@@ -1,0 +1,95 @@
+<?php
+/**
+ * Contains Class TestOptionCanShowWpLogin.
+ *
+ * @package WP-Auth0
+ *
+ * @since 3.11.0
+ */
+
+/**
+ * Class TestOptionCanShowWpLogin.
+ */
+class TestOptionCanShowWpLogin extends WP_Auth0_Test_Case {
+
+	public function testThatWpLoginCanBeShownIfPluginNotReady() {
+		$this->assertTrue( self::$opts->can_show_wp_login_form() );
+	}
+
+	public function testThatWpLoginCanBeShownIfOnResetpassPage() {
+		self::auth0Ready();
+		$GLOBALS['pagenow'] = 'wp-login.php';
+		$_REQUEST['action'] = 'resetpass';
+		self::$opts->set( 'wordpress_login_enabled', 'link' );
+		$this->assertTrue( self::$opts->can_show_wp_login_form() );
+	}
+
+	public function testThatWpLoginCanBeShownIfOnRpPage() {
+		self::auth0Ready();
+		$GLOBALS['pagenow'] = 'wp-login.php';
+		$_REQUEST['action'] = 'rp';
+		self::$opts->set( 'wordpress_login_enabled', 'link' );
+		$this->assertTrue( self::$opts->can_show_wp_login_form() );
+	}
+
+	public function testThatWpLoginCannotBeShownIfNotWle() {
+		self::auth0Ready();
+		self::$opts->set( 'wordpress_login_enabled', 'link' );
+		$this->assertFalse( self::$opts->can_show_wp_login_form() );
+	}
+
+	public function testThatWpLoginCannotBeShownIfWleOff() {
+		self::auth0Ready();
+		$_REQUEST['wle'] = '__test_wle_code__';
+		self::$opts->set( 'wordpress_login_enabled', 'no' );
+		$this->assertFalse( self::$opts->can_show_wp_login_form() );
+	}
+
+	public function testThatWpLoginCanBeShownIfWlePresent() {
+		self::auth0Ready();
+		$_REQUEST['wle'] = '';
+
+		self::$opts->set( 'wordpress_login_enabled', 'link' );
+		$this->assertTrue( self::$opts->can_show_wp_login_form() );
+
+		self::$opts->set( 'wordpress_login_enabled', 'isset' );
+		$this->assertTrue( self::$opts->can_show_wp_login_form() );
+	}
+
+	public function testThatWpLoginCanBeShownIfWleCodeMatches() {
+		self::auth0Ready();
+		$_REQUEST['wle'] = '__test_wle_code__';
+		self::$opts->set( 'wordpress_login_enabled', 'code' );
+		self::$opts->set( 'wle_code', '__test_wle_code__' );
+		$this->assertTrue( self::$opts->can_show_wp_login_form() );
+	}
+
+	public function testThatWpLoginCannotBeShownIfWleCodeNotMatches() {
+		self::auth0Ready();
+		$_REQUEST['wle'] = '__invalid_wle_code__';
+		self::$opts->set( 'wordpress_login_enabled', 'code' );
+		self::$opts->set( 'wle_code', '__test_wle_code__' );
+		$this->assertTrue( self::$opts->can_show_wp_login_form() );
+	}
+
+	public function testThatCanShowWpLoginFormReturnsCorrectly() {
+
+		$this->assertEquals( 'link', self::$opts->get( 'wordpress_login_enabled' ) );
+		$_GET['wle'] = '';
+		$this->assertTrue( self::$opts->can_show_wp_login_form() );
+
+		self::$opts->set( 'wordpress_login_enabled', 'isset' );
+		$this->assertTrue( self::$opts->can_show_wp_login_form() );
+
+		self::$opts->set( 'wordpress_login_enabled', 'code' );
+		$wle_code = uniqid();
+		self::$opts->set( 'wle_code', $wle_code );
+		$this->assertFalse( self::$opts->can_show_wp_login_form() );
+
+		$_GET['wle'] = $wle_code;
+		$this->assertTrue( self::$opts->can_show_wp_login_form() );
+
+		self::$opts->set( 'wordpress_login_enabled', 'no' );
+		$this->assertFalse( self::$opts->can_show_wp_login_form() );
+	}
+}

--- a/tests/testProfileChangeEmail.php
+++ b/tests/testProfileChangeEmail.php
@@ -46,7 +46,7 @@ class TestProfileChangeEmail extends WP_Auth0_Test_Case {
 				'accepted_args' => 2,
 			],
 		];
-		$this->assertHooked( 'profile_update', 'WP_Auth0_Profile_Change_Email', $expect_hooked );
+		$this->assertHookedClass( 'profile_update', 'WP_Auth0_Profile_Change_Email', $expect_hooked );
 	}
 
 	/**

--- a/tests/testProfileChangePassword.php
+++ b/tests/testProfileChangePassword.php
@@ -74,9 +74,9 @@ class TestProfileChangePassword extends WP_Auth0_Test_Case {
 		];
 		// Same method hooked to all 3 actions.
 		$class_name = 'WP_Auth0_Profile_Change_Password';
-		$this->assertHooked( 'user_profile_update_errors', $class_name, $expect_hooked );
-		$this->assertHooked( 'validate_password_reset', $class_name, $expect_hooked );
-		$this->assertHooked( 'woocommerce_save_account_details_errors', $class_name, $expect_hooked );
+		$this->assertHookedClass( 'user_profile_update_errors', $class_name, $expect_hooked );
+		$this->assertHookedClass( 'validate_password_reset', $class_name, $expect_hooked );
+		$this->assertHookedClass( 'woocommerce_save_account_details_errors', $class_name, $expect_hooked );
 	}
 
 	/**

--- a/tests/testProfileDeleteData.php
+++ b/tests/testProfileDeleteData.php
@@ -49,8 +49,8 @@ class TestProfileDeleteData extends WP_Auth0_Test_Case {
 			],
 		];
 		// Same method hooked to both actions.
-		$this->assertHooked( 'edit_user_profile', 'WP_Auth0_Profile_Delete_Data', $expect_hooked );
-		$this->assertHooked( 'show_user_profile', 'WP_Auth0_Profile_Delete_Data', $expect_hooked );
+		$this->assertHookedClass( 'edit_user_profile', 'WP_Auth0_Profile_Delete_Data', $expect_hooked );
+		$this->assertHookedClass( 'show_user_profile', 'WP_Auth0_Profile_Delete_Data', $expect_hooked );
 
 		$expect_hooked = [
 			'delete_user_data' => [
@@ -58,7 +58,7 @@ class TestProfileDeleteData extends WP_Auth0_Test_Case {
 				'accepted_args' => 1,
 			],
 		];
-		$this->assertHooked( 'wp_ajax_auth0_delete_data', 'WP_Auth0_Profile_Delete_Data', $expect_hooked );
+		$this->assertHookedClass( 'wp_ajax_auth0_delete_data', 'WP_Auth0_Profile_Delete_Data', $expect_hooked );
 	}
 
 	/**

--- a/tests/testRenderForm.php
+++ b/tests/testRenderForm.php
@@ -13,66 +13,28 @@
  */
 class TestRenderForm extends WP_Auth0_Test_Case {
 
-	use RedirectHelpers;
-
-	use UsersHelper;
-
-	/**
-	 * WP_Auth0 instance.
-	 *
-	 * @var WP_Auth0
-	 */
-	public static $wp_auth0;
-
-	/**
-	 * Initial HTML value for render_form filter value.
-	 *
-	 * @var string
-	 */
-	public static $html = '__initial_html__';
-
-	/**
-	 * Run before test suite.
-	 */
-	public static function setUpBeforeClass() {
-		parent::setUpBeforeClass();
-		self::$wp_auth0 = new WP_Auth0( self::$opts );
+	public function testThatRenderFormPassesThroughIfPluginNotReady() {
+		$wp_auth0 = new WP_Auth0( self::$opts );
+		$this->assertEquals( '__initial_html__', $wp_auth0->render_form( '__initial_html__' ) );
 	}
 
-	/**
-	 * Test that a specific region and domain return the correct number of IP addresses.
-	 */
-	public function testThatRenderFormPassesThrough() {
-		self::auth0Ready( false );
-
-		$this->assertArrayNotHasKey( 'action', $_GET );
-
-		// Should pass through initially because WP-Auth0 is not configured.
-		$this->assertEquals( self::$html, self::$wp_auth0->render_form( self::$html ) );
-
-		// Configure Auth0.
-		self::auth0Ready();
-		$this->assertTrue( WP_Auth0::ready() );
-
-		// Should pass through for certain core WP login conditions.
-		$_GET['action'] = 'lostpassword';
-		$this->assertEquals( self::$html, self::$wp_auth0->render_form( self::$html ) );
-		$_GET['action'] = 'rp';
-		$this->assertEquals( self::$html, self::$wp_auth0->render_form( self::$html ) );
-	}
-
-	/**
-	 * Test that a specific region and domain return the correct number of IP addresses.
-	 */
-	public function testThatFormRendersWhenAuth0IsReady() {
-
-		// Should pass through initially because WP-Auth0 is not configured.
-		$this->assertEquals( self::$html, self::$wp_auth0->render_form( self::$html ) );
-
-		// Configure Auth0.
+	public function testThatHtmlIsIgnoredIfAuth0ParamSet() {
+		$wp_auth0 = new WP_Auth0( self::$opts );
 		$this->auth0Ready();
-		$this->assertTrue( WP_Auth0::ready() );
+		$_GET['auth0'] = 1;
+		$this->assertNotEquals( '__initial_html__', $wp_auth0->render_form( '__initial_html__' ) );
+	}
 
-		$this->assertContains( 'auth0-login-form', self::$wp_auth0->render_form( self::$html ) );
+	public function testThatHtmlIsIgnoredIfLostpasswordParamSet() {
+		$wp_auth0 = new WP_Auth0( self::$opts );
+		$this->auth0Ready();
+		$_GET['action'] = 'lostpassword';
+		$this->assertNotEquals( '__initial_html__', $wp_auth0->render_form( '__initial_html__' ) );
+	}
+
+	public function testThatHtmlIsIgnoredWhenAuth0IsReady() {
+		$wp_auth0 = new WP_Auth0( self::$opts );
+		$this->auth0Ready();
+		$this->assertNotEquals( '__initial_html__', $wp_auth0->render_form( '__initial_html__' ) );
 	}
 }

--- a/tests/testWPAuth0Options.php
+++ b/tests/testWPAuth0Options.php
@@ -198,29 +198,4 @@ class TestWPAuth0Options extends WP_Auth0_Test_Case {
 		$db_options = get_option( $opts->get_options_name() );
 		$this->assertEquals( '__test_domain__', $db_options['domain'] );
 	}
-
-	/**
-	 * Test that the can_show_wp_login_form returns the right bool depending on settings and globals.
-	 */
-	public function testThatCanShowWpLoginFormReturnsCorrectly() {
-		$this->assertFalse( self::$opts->can_show_wp_login_form() );
-
-		$this->assertEquals( 'link', self::$opts->get( 'wordpress_login_enabled' ) );
-		$_GET['wle'] = '';
-		$this->assertTrue( self::$opts->can_show_wp_login_form() );
-
-		self::$opts->set( 'wordpress_login_enabled', 'isset' );
-		$this->assertTrue( self::$opts->can_show_wp_login_form() );
-
-		self::$opts->set( 'wordpress_login_enabled', 'code' );
-		$wle_code = uniqid();
-		self::$opts->set( 'wle_code', $wle_code );
-		$this->assertFalse( self::$opts->can_show_wp_login_form() );
-
-		$_GET['wle'] = $wle_code;
-		$this->assertTrue( self::$opts->can_show_wp_login_form() );
-
-		self::$opts->set( 'wordpress_login_enabled', 'no' );
-		$this->assertFalse( self::$opts->can_show_wp_login_form() );
-	}
 }

--- a/tests/testWpLoginHooks.php
+++ b/tests/testWpLoginHooks.php
@@ -33,22 +33,22 @@ class TestWpLoginHooks extends WP_Auth0_Test_Case {
 	public function testThatWpRedirectIsNotChangedIfNotLostpasswordAction() {
 		$GLOBALS['pagenow'] = 'wp-login.php';
 		$_REQUEST['action'] = '__not_lostpassword__';
-		$location = 'wp-login.php?checkemail=confirm';
+		$location           = 'wp-login.php?checkemail=confirm';
 		$this->assertEquals( $location, wp_auth0_filter_wp_redirect_lostpassword( $location ) );
 	}
 
 	public function testThatWpRedirectIsNotChangedIfIncorrectReferrer() {
-		$GLOBALS['pagenow'] = 'wp-login.php';
-		$_REQUEST['action'] = 'lostpassword';
-		$location = 'wp-login.php?checkemail=confirm';
+		$GLOBALS['pagenow']      = 'wp-login.php';
+		$_REQUEST['action']      = 'lostpassword';
+		$location                = 'wp-login.php?checkemail=confirm';
 		$_SERVER['HTTP_REFERER'] = '__incorrect_referrer__';
 		$this->assertEquals( $location, wp_auth0_filter_wp_redirect_lostpassword( $location ) );
 	}
 
 	public function testThatWpRedirectIsChangedIfCorrectReferrer() {
-		$GLOBALS['pagenow'] = 'wp-login.php';
-		$_REQUEST['action'] = 'lostpassword';
-		$location = 'wp-login.php?checkemail=confirm';
+		$GLOBALS['pagenow']      = 'wp-login.php';
+		$_REQUEST['action']      = 'lostpassword';
+		$location                = 'wp-login.php?checkemail=confirm';
 		$_SERVER['HTTP_REFERER'] = wp_login_url() . '?action=lostpassword&wle';
 		$this->assertEquals( $location . '&wle', wp_auth0_filter_wp_redirect_lostpassword( $location ) );
 	}

--- a/tests/testWpLoginHooks.php
+++ b/tests/testWpLoginHooks.php
@@ -1,0 +1,125 @@
+<?php
+/**
+ * Contains Class TestWpLoginHooks.
+ *
+ * @package WP-Auth0
+ *
+ * @since 3.11.0
+ */
+
+/**
+ * Class TestWpLoginHooks.
+ * Tests that wp-login.php hook work as expected.
+ */
+class TestWpLoginHooks extends WP_Auth0_Test_Case {
+
+	use HookHelpers;
+
+	public function testThatWpRedirectHookIsSet() {
+		$expect_hooked = [
+			'wp_auth0_filter_wp_redirect_lostpassword' => [
+				'priority'      => 100,
+				'accepted_args' => 1,
+			],
+		];
+		$this->assertHookedFunction( 'wp_redirect', $expect_hooked );
+	}
+
+	public function testThatWpRedirectIsNotChangedIfNotCheckEmailLocation() {
+		$location = '__test_location__';
+		$this->assertEquals( $location, wp_auth0_filter_wp_redirect_lostpassword( $location ) );
+	}
+
+	public function testThatWpRedirectIsNotChangedIfNotLostpasswordAction() {
+		$GLOBALS['pagenow'] = 'wp-login.php';
+		$_REQUEST['action'] = '__not_lostpassword__';
+		$location = 'wp-login.php?checkemail=confirm';
+		$this->assertEquals( $location, wp_auth0_filter_wp_redirect_lostpassword( $location ) );
+	}
+
+	public function testThatWpRedirectIsNotChangedIfIncorrectReferrer() {
+		$GLOBALS['pagenow'] = 'wp-login.php';
+		$_REQUEST['action'] = 'lostpassword';
+		$location = 'wp-login.php?checkemail=confirm';
+		$_SERVER['HTTP_REFERER'] = '__incorrect_referrer__';
+		$this->assertEquals( $location, wp_auth0_filter_wp_redirect_lostpassword( $location ) );
+	}
+
+	public function testThatWpRedirectIsChangedIfCorrectReferrer() {
+		$GLOBALS['pagenow'] = 'wp-login.php';
+		$_REQUEST['action'] = 'lostpassword';
+		$location = 'wp-login.php?checkemail=confirm';
+		$_SERVER['HTTP_REFERER'] = wp_login_url() . '?action=lostpassword&wle';
+		$this->assertEquals( $location . '&wle', wp_auth0_filter_wp_redirect_lostpassword( $location ) );
+	}
+
+	public function testThatWpLoginOverrideUrlHooksAreSet() {
+		$expect_hooked = [
+			'wp_auth0_filter_login_override_url' => [
+				'priority'      => 100,
+				'accepted_args' => 1,
+			],
+		];
+		$this->assertHookedFunction( 'lostpassword_url', $expect_hooked );
+		$this->assertHookedFunction( 'login_url', $expect_hooked );
+	}
+
+	public function testThatWpLoginOverrideUrlIsNotModifiedIfNoWle() {
+		$this->assertEquals( '__test_url__', wp_auth0_filter_login_override_url( '__test_url__' ) );
+	}
+
+	public function testThatWpLoginOverrideUrlIsModifiedIfWle() {
+		$_REQUEST['wle'] = '__test_wle_code__';
+		$this->assertEquals(
+			'http://login.org?wle=__test_wle_code__',
+			wp_auth0_filter_login_override_url( 'http://login.org' )
+		);
+	}
+
+	public function testThatWpLoginOverrideUrlIsModifiedIfResetPassPage() {
+		$GLOBALS['pagenow'] = 'wp-login.php';
+		$_REQUEST['action'] = 'resetpass';
+		$this->assertEquals( 'http://login.org?wle', wp_auth0_filter_login_override_url( 'http://login.org' ) );
+	}
+
+	public function testThatWpLoginFormHooksAreSet() {
+		$expect_hooked = [
+			'wp_auth0_filter_login_override_form' => [
+				'priority'      => 100,
+				'accepted_args' => 1,
+			],
+		];
+		$this->assertHookedFunction( 'login_form', $expect_hooked );
+		$this->assertHookedFunction( 'lostpassword_form', $expect_hooked );
+	}
+
+	public function testThatWpLoginFormHookReturnsNothingIfPluginNotReady() {
+		ob_start();
+		wp_auth0_filter_login_override_form();
+		$this->assertEmpty( ob_get_clean() );
+	}
+
+	public function testThatWpLoginFormHookReturnsNothingIfPluginReadyNoWle() {
+		self::auth0Ready();
+		ob_start();
+		wp_auth0_filter_login_override_form();
+		$this->assertEmpty( ob_get_clean() );
+	}
+
+	public function testThatWpLoginFormHookReturnsInputIfWlePresent() {
+		self::auth0Ready();
+		$_REQUEST['wle'] = '';
+		ob_start();
+		wp_auth0_filter_login_override_form();
+		$this->assertEquals( '<input type="hidden" name="wle" value="" />', ob_get_clean() );
+	}
+
+	public function testThatWpLoginFormHookReturnsInputIfWleCode() {
+		self::auth0Ready();
+		$_REQUEST['wle'] = '__test_wle_code__';
+		ob_start();
+		wp_auth0_filter_login_override_form();
+		$this->assertEquals( '<input type="hidden" name="wle" value="__test_wle_code__" />', ob_get_clean() );
+	}
+
+}

--- a/tests/testWpLoginHooks.php
+++ b/tests/testWpLoginHooks.php
@@ -46,11 +46,13 @@ class TestWpLoginHooks extends WP_Auth0_Test_Case {
 	}
 
 	public function testThatWpRedirectIsChangedIfCorrectReferrer() {
+		self::$opts->set( 'wordpress_login_enabled', 'code' );
+		self::$opts->set( 'wle_code', 'test_wle_code' );
 		$GLOBALS['pagenow']      = 'wp-login.php';
 		$_REQUEST['action']      = 'lostpassword';
 		$location                = 'wp-login.php?checkemail=confirm';
-		$_SERVER['HTTP_REFERER'] = wp_login_url() . '?action=lostpassword&wle';
-		$this->assertEquals( $location . '&wle', wp_auth0_filter_wp_redirect_lostpassword( $location ) );
+		$_SERVER['HTTP_REFERER'] = wp_login_url() . '?action=lostpassword&wle=test_wle_code';
+		$this->assertEquals( $location . '&wle=test_wle_code', wp_auth0_filter_wp_redirect_lostpassword( $location ) );
 	}
 
 	public function testThatWpLoginOverrideUrlHooksAreSet() {

--- a/tests/traits/hookHelpers.php
+++ b/tests/traits/hookHelpers.php
@@ -79,12 +79,11 @@ trait HookHelpers {
 	 *
 	 * @return void
 	 */
-	public function assertHooked( $hook_name, $function, array $hooked ) {
+	public function assertHookedClass( $hook_name, $function, array $hooked ) {
 		$hooks = $this->get_hook( $hook_name );
 		$found = 0;
 
 		foreach ( $hooks as $hook ) {
-			$method_name = $hook['function'][1];
 
 			if ( ! is_array( $hook['function'] ) ) {
 				continue;
@@ -94,9 +93,40 @@ trait HookHelpers {
 				continue;
 			}
 
+			$method_name = $hook['function'][1];
+
 			if ( ! empty( $hooked[ $method_name ] ) ) {
 				$this->assertEquals( $hooked[ $method_name ]['priority'], $hook['priority'] );
 				$this->assertEquals( $hooked[ $method_name ]['accepted_args'], $hook['accepted_args'] );
+				$found++;
+			}
+		}
+		$this->assertEquals( count( $hooked ), $found );
+	}
+
+	/**
+	 * Assert that hooked functions exists with the correct priority and arg numbers.
+	 *
+	 * @param string $hook_name - Hook name in WP.
+	 * @param array  $hooked - Array of functions to check.
+	 *
+	 * @return void
+	 */
+	public function assertHookedFunction( $hook_name, array $hooked ) {
+		$hooks = $this->get_hook( $hook_name );
+		$found = 0;
+
+		foreach ( $hooks as $hook ) {
+
+			if ( is_array( $hook['function'] ) ) {
+				continue;
+			}
+
+			$function_name = $hook['function'];
+
+			if ( ! empty( $hooked[ $function_name ] ) ) {
+				$this->assertEquals( $hooked[ $function_name ]['priority'], $hook['priority'] );
+				$this->assertEquals( $hooked[ $function_name ]['accepted_args'], $hook['accepted_args'] );
 				$found++;
 			}
 		}


### PR DESCRIPTION
### Changes

Summary of changes:

- Makes password reset process function end-to-end without ULP redirect or embedded form showing
- Stops all WP core login form requests when WP login is set to "never"
- Adds `wp_auth0_is_current_login_action()` to check if the current request is wp-login.php and if the user is attempting a specific action.
- Adds `wp_auth0_login_override_url()` to build a WordPress login override URL based on current settings.
- Adds `wp_auth0_can_show_wp_login_form()` to check if the core WP login form can be shown.

### Testing

Whether using ULP or not, if navigating to a core WP login page and the WordPress Login Enabled is anything but "Never," you should be able to login (with feedback if login was incorrect) and reset password (with feedback if user not found). 

* [x] I included manual testing steps above, if applicable
* [x] This change adds unit test coverage
* [x] This change has been tested on WP 5.2.0

### Checklist

* [x] All existing and new tests complete without errors
* [x] All code quality tools/guidelines in the [Contribution guide](CONTRIBUTION.md) have been run/followed
* [x] All active GitHub CI checks have passed
