### PR TITLE
Set password after saving Buddypress settings

### DIFF
--- a/lib/profile/WP_Auth0_Profile_Change_Email.php
+++ b/lib/profile/WP_Auth0_Profile_Change_Email.php
@@ -44,6 +44,8 @@ class WP_Auth0_Profile_Change_Email {
 
 		// Used during profile update in wp-admin or email verification link.
 		add_action( 'profile_update', array( $this, 'update_email' ), 100, 2 );
+		// Used during Buddypress account settings save.
+		add_action( 'bp_core_general_settings_after_save', array( $this, 'update_email_for_current_user' ), 100, 0 );
 	}
 
 	/**
@@ -122,6 +124,16 @@ class WP_Auth0_Profile_Change_Email {
 		return false;
 	}
 
+	/**
+	 * Update the current user's email at Auth0
+	 * Hooked to: bp_core_general_settings_after_save
+	 * IMPORTANT: Internal callback use only, do not call this function directly!
+	 *
+	 * @return boolean
+	 */
+	public function update_email_for_current_user() {
+		return $this->update_email(new WP_Error(), get_current_user_id());
+	}
 	/**
 	 * Modify the user email change notification when the Auth0 API call fails.
 	 *

--- a/lib/profile/WP_Auth0_Profile_Change_Password.php
+++ b/lib/profile/WP_Auth0_Profile_Change_Password.php
@@ -45,6 +45,9 @@ class WP_Auth0_Profile_Change_Password {
 
 		// Used during WooCommerce edit account save.
 		add_action( 'woocommerce_save_account_details_errors', array( $this, 'validate_new_password' ), 10, 2 );
+
+		// Used during Buddypress account settings save.
+		add_action( 'bp_core_general_settings_after_save', array( $this, 'validate_new_password_for_current_user' ), 10, 0 );
 	}
 
 	/**
@@ -106,5 +109,16 @@ class WP_Auth0_Profile_Change_Password {
 		$error_msg = is_string( $result ) ? $result : __( 'Password could not be updated.', 'wp-auth0' );
 		$errors->add( 'auth0_password', $error_msg, array( 'form-field' => $field_name ) );
 		return false;
+	}
+
+	/**
+	 * Update the current user's password at Auth0
+	 * Hooked to: bp_core_general_settings_after_save
+	 * IMPORTANT: Internal callback use only, do not call this function directly!
+	 *
+	 * @return boolean
+	 */
+	public function validate_new_password_for_current_user() {
+		return $this->validate_new_password(new WP_Error(), get_current_user_id());
 	}
 }

--- a/tests/testProfileChangeEmail.php
+++ b/tests/testProfileChangeEmail.php
@@ -49,6 +49,18 @@ class TestProfileChangeEmail extends WP_Auth0_Test_Case {
 		$this->assertHookedClass( 'profile_update', 'WP_Auth0_Profile_Change_Email', $expect_hooked );
 	}
 
+	public function testBuddypressInitHooks() {
+
+		$expect_hooked = [
+			'update_email_for_current_user' => [
+				'priority'      => 100,
+				'accepted_args' => 0,
+			],
+		];
+		$this->assertHooked( 'bp_core_general_settings_after_save', 'WP_Auth0_Profile_Change_Email', $expect_hooked );
+
+	}
+
 	/**
 	 * Test that an email update works.
 	 */

--- a/tests/testProfileChangeEmail.php
+++ b/tests/testProfileChangeEmail.php
@@ -49,6 +49,9 @@ class TestProfileChangeEmail extends WP_Auth0_Test_Case {
 		$this->assertHookedClass( 'profile_update', 'WP_Auth0_Profile_Change_Email', $expect_hooked );
 	}
 
+	/**
+	 * Test that correct hooks are loaded for buddypress.
+	 */
 	public function testBuddypressInitHooks() {
 
 		$expect_hooked = [

--- a/tests/testProfileChangeEmail.php
+++ b/tests/testProfileChangeEmail.php
@@ -82,6 +82,26 @@ class TestProfileChangeEmail extends WP_Auth0_Test_Case {
 	}
 
 	/**
+	 * Test that an email update works for current user.
+	 */
+	public function testSuccessfulEmailUpdateForCurrentUser() {
+		$user                       = $this->createUser( [], false );
+		$new_email                  = $user->data->user_email;
+		$old_user                   = clone $user;
+		$old_user->data->user_email = 'OLD-' . $new_email;
+		$this->setGlobalUser( $user->ID );
+
+		// API call mocked to succeed.
+		$change_email = $this->getStub( true );
+
+		// Store userinfo for a DB strategy user.
+		$this->storeAuth0Data( $user->ID, 'auth0' );
+
+		$this->assertTrue( $change_email->update_email_for_current_user() );
+		$this->assertEquals( $new_email, get_user_by( 'id', $user->ID )->data->user_email );
+	}
+
+	/**
 	 * Test that a non-Auth0 user will skip the email update.
 	 */
 	public function testThatNonAuth0UserSkipsUpdate() {

--- a/tests/testProfileChangePassword.php
+++ b/tests/testProfileChangePassword.php
@@ -166,14 +166,14 @@ class TestProfileChangePassword extends WP_Auth0_Test_Case {
 	 * Test that password update succeeds when run in the bp_core_general_settings_after_save hook.
 	 */
 	public function testSuccessfulPasswordChangeDuringBuddypressProfileEdit() {
-		$user   = $this->createUser();
+		$user = $this->createUser();
 		$this->setGlobalUser( $user->ID );
 
 		// API call mocked to succeed.
 		$change_password = $this->getStub( true );
 
 		// Buddypress form fields sent for password update.
-		$password = uniqid();
+		$password       = uniqid();
 		$_POST['pass1'] = $password;
 		$_POST['pass2'] = $password;
 

--- a/tests/testProfileChangePassword.php
+++ b/tests/testProfileChangePassword.php
@@ -161,6 +161,30 @@ class TestProfileChangePassword extends WP_Auth0_Test_Case {
 		$this->assertEmpty( $errors->get_error_messages() );
 	}
 
+
+	/**
+	 * Test that password update succeeds when run in the bp_core_general_settings_after_save hook.
+	 */
+	public function testSuccessfulPasswordChangeDuringBuddypressProfileEdit() {
+		$user   = $this->createUser();
+		$this->setGlobalUser( $user->ID );
+
+		// API call mocked to succeed.
+		$change_password = $this->getStub( true );
+
+		// Buddypress form fields sent for password update.
+		$password = uniqid();
+		$_POST['pass1'] = $password;
+		$_POST['pass2'] = $password;
+
+		// Store userinfo for a DB strategy user.
+		$this->storeAuth0Data( $user->ID, 'auth0' );
+
+		$this->assertTrue( $change_password->validate_new_password_for_current_user() );
+		$this->assertEquals( $password, $_POST['pass1'] );
+		$this->assertEquals( $password, $_POST['pass2'] );
+	}
+
 	/**
 	 * Test that the change password process handles escaped data.
 	 */

--- a/tests/testProfileChangePassword.php
+++ b/tests/testProfileChangePassword.php
@@ -79,6 +79,9 @@ class TestProfileChangePassword extends WP_Auth0_Test_Case {
 		$this->assertHookedClass( 'woocommerce_save_account_details_errors', $class_name, $expect_hooked );
 	}
 
+	/**
+	 * Test that correct hooks are loaded for buddypress.
+	 */
 	public function testBuddypressInitHooks() {
 
 		$expect_hooked = [

--- a/tests/testProfileChangePassword.php
+++ b/tests/testProfileChangePassword.php
@@ -79,6 +79,19 @@ class TestProfileChangePassword extends WP_Auth0_Test_Case {
 		$this->assertHookedClass( 'woocommerce_save_account_details_errors', $class_name, $expect_hooked );
 	}
 
+	public function testBuddypressInitHooks() {
+
+		$expect_hooked = [
+			'validate_new_password_for_current_user' => [
+				'priority'      => 10,
+				'accepted_args' => 0,
+			],
+		];
+		// Same method hooked to all 3 actions.
+		$this->assertHooked( 'bp_core_general_settings_after_save', 'WP_Auth0_Profile_Change_Password', $expect_hooked );
+
+	}
+
 	/**
 	 * Test that password update succeeds when run in the user_profile_update_errors hook.
 	 */


### PR DESCRIPTION
### Changes

This change adds support for Buddypress password changes, which don't fire any of the existing hooked actions. Instead, we hook onto `bp_core_general_settings_after_save`.

I'm still testing it here to make sure it works, but I'm opening this PR early for suggestions and feedback. Error handling, for instance, is certainly a problem, as Buddypress doesn't seem to have a hook that allows errors to feed back.

### Testing

Testing needs a WordPress instance with Buddypress installed. When saving email or password from buddypress account settings, the Auth0 equivalents should also be updated. I don't know if there is a way I should be installing Buddypress to test it; there doesn't seem to be anything that does that for Woocommerce that I can see.

* [x] I included manual testing steps above, if applicable
* [x] This change adds unit test coverage
* [x] This change has been tested on the latest version of the platform/language or why not

### Checklist

* [x] I read [Auth0's general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)?
* [x] I read [Auth0's code of conduct guidelines](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
* [ ] All existing and new tests complete without errors
* [ ] All code quality tools/guidelines in the [Contribution guide](CONTRIBUTION.md) have been run/followed
* [ ] All relevant assets have been compiled as directed in the [Contribution guide](CONTRIBUTION.md), if applicable
* [ ] All active GitHub CI checks have passed
