### PR TITLE
Fix VIP Go MFA screen

### DIFF
--- a/WP_Auth0.php
+++ b/WP_Auth0.php
@@ -616,7 +616,7 @@ add_filter( 'wp_redirect', 'wp_auth0_filter_wp_redirect_lostpassword', 100 );
  * @return string
  */
 function wp_auth0_filter_login_override_url( $wp_login_url ) {
-	if ( WP_Auth0_Options::Instance()->can_show_wp_login_form() && isset( $_REQUEST['wle'] ) ) {
+	if ( wp_auth0_can_show_wp_login_form() && isset( $_REQUEST['wle'] ) ) {
 		// We are on an override page.
 		$wp_login_url = add_query_arg( 'wle', $_REQUEST['wle'], $wp_login_url );
 	} elseif ( wp_auth0_is_current_login_action( array( 'resetpass' ) ) ) {
@@ -634,7 +634,7 @@ add_filter( 'login_url', 'wp_auth0_filter_login_override_url', 100 );
  * Add the core WP form override to the lost password and login forms.
  */
 function wp_auth0_filter_login_override_form() {
-	if ( WP_Auth0_Options::Instance()->can_show_wp_login_form() && isset( $_REQUEST['wle'] ) ) {
+	if ( wp_auth0_can_show_wp_login_form() && isset( $_REQUEST['wle'] ) ) {
 		printf( '<input type="hidden" name="wle" value="%s" />', $_REQUEST['wle'] );
 	}
 }
@@ -650,7 +650,7 @@ add_action( 'lostpassword_form', 'wp_auth0_filter_login_override_form', 100 );
  * @return array
  */
 function wp_auth0_filter_body_class( array $classes ) {
-	if ( WP_Auth0_Options::Instance()->can_show_wp_login_form() ) {
+	if ( wp_auth0_can_show_wp_login_form() ) {
 		$classes[] = 'a0-show-core-login';
 	}
 	return $classes;

--- a/functions.php
+++ b/functions.php
@@ -31,7 +31,10 @@ function wp_auth0_get_option( $key, $default = null ) {
 function wp_auth0_is_current_login_action( array $actions ) {
 
 	// Not on wp-login.php.
-	if ( ! isset( $GLOBALS['pagenow'] ) || 'wp-login.php' !== $GLOBALS['pagenow'] ) {
+	if (
+		( isset( $GLOBALS['pagenow'] ) && 'wp-login.php' !== $GLOBALS['pagenow'] ) &&
+		! function_exists( 'login_header' )
+	) {
 		return false;
 	}
 
@@ -71,8 +74,11 @@ function wp_auth0_can_show_wp_login_form() {
 		return true;
 	}
 
-	$current_login_action = isset( $_REQUEST['action'] ) ? $_REQUEST['action'] : null;
-	if ( in_array( $current_login_action, array( 'resetpass', 'rp' ) ) ) {
+	if ( wp_auth0_is_current_login_action( array( 'resetpass', 'rp', 'validate_2fa' ) ) ) {
+		return true;
+	}
+
+	if ( get_query_var( 'auth0_login_successful' ) ) {
 		return true;
 	}
 

--- a/lib/WP_Auth0_LoginManager.php
+++ b/lib/WP_Auth0_LoginManager.php
@@ -110,7 +110,7 @@ class WP_Auth0_LoginManager {
 		}
 
 		// Do not redirect login page override.
-		if ( $this->a0_options->can_show_wp_login_form() ) {
+		if ( wp_auth0_can_show_wp_login_form() ) {
 			return false;
 		}
 
@@ -151,6 +151,8 @@ class WP_Auth0_LoginManager {
 	 * Handles errors and state validation
 	 */
 	public function init_auth0() {
+
+		set_query_var( 'auth0_login_successful', false );
 
 		// Not an Auth0 login process or settings are not configured to allow logins.
 		if ( ! $this->query_vars( 'auth0' ) || ! WP_Auth0::ready() ) {
@@ -446,6 +448,8 @@ class WP_Auth0_LoginManager {
 		} catch ( Exception $e ) {
 			throw new WP_Auth0_BeforeLoginException( $e->getMessage() );
 		}
+
+		set_query_var( 'auth0_login_successful', true );
 
 		$secure_cookie = is_ssl();
 

--- a/lib/WP_Auth0_WooCommerceOverrides.php
+++ b/lib/WP_Auth0_WooCommerceOverrides.php
@@ -45,7 +45,7 @@ class WP_Auth0_WooCommerceOverrides {
 	public function override_woocommerce_checkout_login_form( $html ) {
 		$this->render_login_form( 'checkout' );
 
-		if ( $this->options->can_show_wp_login_form() ) {
+		if ( wp_auth0_can_show_wp_login_form() ) {
 			echo '<style>.woocommerce-checkout .woocommerce-info{display:block;}</style>';
 		}
 	}

--- a/phpcs-test-ruleset.xml
+++ b/phpcs-test-ruleset.xml
@@ -41,5 +41,8 @@
     <rule ref="Squiz.Commenting.FunctionComment">
         <exclude name="Squiz.Commenting.FunctionComment.Missing"/>
     </rule>
+    <rule ref="Generic.Commenting">
+        <exclude name="Generic.Commenting.DocComment.MissingShort"/>
+    </rule>
 
 </ruleset>

--- a/templates/login-form.php
+++ b/templates/login-form.php
@@ -5,7 +5,7 @@ function renderAuth0Form( $canShowLegacyLogin = true, $specialSettings = array()
 	}
 
 	$options = WP_Auth0_Options::Instance();
-	if ( ! $canShowLegacyLogin || ! $options->can_show_wp_login_form() ) {
+	if ( ! $canShowLegacyLogin || ! wp_auth0_can_show_wp_login_form() ) {
 		$lock_options = new WP_Auth0_Lock10_Options( $specialSettings );
 		$use_sso      = ! isset( $_GET['skip_sso'] ) && $options->get( 'sso', false );
 

--- a/tests/testFunctionCanShowWpLoginForm.php
+++ b/tests/testFunctionCanShowWpLoginForm.php
@@ -32,6 +32,14 @@ class TestOptionCanShowWpLogin extends WP_Auth0_Test_Case {
 		$this->assertTrue( wp_auth0_can_show_wp_login_form() );
 	}
 
+	public function testThatWpLoginCanBeShownIfOn2faPage() {
+		self::auth0Ready();
+		$GLOBALS['pagenow'] = 'wp-login.php';
+		$_REQUEST['action'] = 'validate_2fa';
+		self::$opts->set( 'wordpress_login_enabled', 'link' );
+		$this->assertTrue( wp_auth0_can_show_wp_login_form() );
+	}
+
 	public function testThatWpLoginCannotBeShownIfNotWle() {
 		self::auth0Ready();
 		self::$opts->set( 'wordpress_login_enabled', 'link' );
@@ -69,6 +77,20 @@ class TestOptionCanShowWpLogin extends WP_Auth0_Test_Case {
 		$_REQUEST['wle'] = '__invalid_wle_code__';
 		self::$opts->set( 'wordpress_login_enabled', 'code' );
 		self::$opts->set( 'wle_code', '__test_wle_code__' );
+		$this->assertFalse( wp_auth0_can_show_wp_login_form() );
+	}
+
+	public function testThatWpLoginCanBeShownIfLoginSuccessful() {
+		self::auth0Ready();
+		self::$opts->set( 'wordpress_login_enabled', 'link' );
+		set_query_var( 'auth0_login_successful', true );
+		$this->assertTrue( wp_auth0_can_show_wp_login_form() );
+	}
+
+	public function testThatWpLoginCannotBeShownIfLoginNotSuccessful() {
+		self::auth0Ready();
+		self::$opts->set( 'wordpress_login_enabled', 'link' );
+		set_query_var( 'auth0_login_successful', false );
 		$this->assertFalse( wp_auth0_can_show_wp_login_form() );
 	}
 }

--- a/tests/testFunctionIsCurrentLoginAction.php
+++ b/tests/testFunctionIsCurrentLoginAction.php
@@ -37,4 +37,13 @@ class TestFunctionIsCurrentLoginAction extends WP_Auth0_Test_Case {
 		$_REQUEST['action'] = '__valid_action__';
 		$this->assertTrue( wp_auth0_is_current_login_action( [ '__valid_action__' ] ) );
 	}
+
+	/**
+	 * @runInSeparateProcess
+	 */
+	public function testThatCurrentActionIsTrueIfActionDoesMatchAndLoginHeaderExists() {
+		function login_header() {}
+		$_REQUEST['action'] = '__valid_action__';
+		$this->assertTrue( wp_auth0_is_current_login_action( [ '__valid_action__' ] ) );
+	}
 }


### PR DESCRIPTION
### Changes

Add a query var during Auth0 login to indicate the status of the process globally. This allows for the VIP MFA form to show instead of a redirect (ULP) or Auth0 form showing (embedded). Also switches all uses of `WP_Auth0_Options::Instance()->can_show_wp_login_form()` to `wp_auth0_can_show_wp_login_form()`.

### References

Closes #687 

### Testing

* [x] This change adds unit test coverage
* [x] This change has been tested on WP 5.2.1

### Checklist

* [ ] All existing and new tests complete without errors
* [x] All code quality tools/guidelines in the [Contribution guide](CONTRIBUTION.md) have been run/followed
* [ ] All active GitHub CI checks have passed
