### PR TITLE
Deprecate WP_Auth0_Options::can_show_wp_login_form()

### DIFF
--- a/lib/WP_Auth0_Options.php
+++ b/lib/WP_Auth0_Options.php
@@ -190,9 +190,11 @@ class WP_Auth0_Options extends WP_Auth0_Options_Generic {
 	}
 
 	/**
-	 * TODO: Deprecate
+	 * @deprecated - 3.11.0, use wp_auth0_can_show_wp_login_form() instead.
 	 *
 	 * @return bool
+	 *
+	 * @codeCoverageIgnore
 	 */
 	public function can_show_wp_login_form() {
 		return wp_auth0_can_show_wp_login_form();


### PR DESCRIPTION
### Changes

Deprecates `WP_Auth0_Options::can_show_wp_login_form()`

### Checklist

* [x] All existing and new tests complete without errors
* [x] All code quality tools/guidelines in the [Contribution guide](CONTRIBUTION.md) have been run/followed
* [x] All active GitHub CI checks have passed
