### PR TITLE
Add auth0_lock_options filter

### DIFF
--- a/lib/WP_Auth0_Lock10_Options.php
+++ b/lib/WP_Auth0_Lock10_Options.php
@@ -219,7 +219,7 @@ class WP_Auth0_Lock10_Options {
 			$options_obj['initialScreen'] = 'signUp';
 		}
 
-		return $options_obj;
+		return apply_filters( 'auth0_lock_options', $options_obj );
 	}
 
 	/**

--- a/lib/WP_Auth0_LoginManager.php
+++ b/lib/WP_Auth0_LoginManager.php
@@ -234,7 +234,7 @@ class WP_Auth0_LoginManager {
 
 		// Attempt to authenticate with the Management API, if allowed.
 		$userinfo = null;
-		if ( apply_filters( 'wp_auth0_use_management_api_for_userinfo', true ) ) {
+		if ( apply_filters( 'auth0_use_management_api_for_userinfo', true ) ) {
 			$cc_api        = new WP_Auth0_Api_Client_Credentials( $this->a0_options );
 			$get_user_api  = new WP_Auth0_Api_Get_User( $this->a0_options, $cc_api );
 			$get_user_resp = $get_user_api->call( $decoded_token->sub );

--- a/tests/testLockOptions.php
+++ b/tests/testLockOptions.php
@@ -13,6 +13,11 @@
  */
 class TestLockOptions extends WP_Auth0_Test_Case {
 
+	public function tearDown() {
+		remove_filter( 'auth0_lock_options', [ __CLASS__, 'setLockLanguage' ] );
+		parent::tearDown();
+	}
+
 	/**
 	 * Test that a custom domain adds a correct key for CDN configuration to Lock options.
 	 */
@@ -82,5 +87,21 @@ class TestLockOptions extends WP_Auth0_Test_Case {
 
 		$lock_opts = $lock_options->get_lock_options();
 		$this->assertEquals( 'big', $lock_opts['socialButtonStyle'] );
+	}
+
+	public function testThatLockOptionsFilterWorks() {
+		$lock_options = new WP_Auth0_Lock10_Options( [ 'language' => '__test_language__' ], self::$opts );
+
+		$lock_opts = $lock_options->get_lock_options();
+		$this->assertEquals( '__test_language__', $lock_opts['language'] );
+
+		add_filter( 'auth0_lock_options', [ __CLASS__, 'setLockLanguage' ] );
+		$lock_opts = $lock_options->get_lock_options();
+		$this->assertEquals( '__test_filtered_language__', $lock_opts['language'] );
+	}
+
+	public static function setLockLanguage( $options ) {
+		$options['language'] = '__test_filtered_language__';
+		return $options;
 	}
 }

--- a/tests/testLoginManagerRedirectLogin.php
+++ b/tests/testLoginManagerRedirectLogin.php
@@ -57,7 +57,7 @@ class TestLoginManagerRedirectLogin extends WP_Auth0_Test_Case {
 		delete_transient( WP_Auth0_Api_Client_Credentials::TOKEN_TRANSIENT_KEY );
 		delete_transient( WP_Auth0_Api_Client_Credentials::SCOPE_TRANSIENT_KEY );
 
-		remove_filter( 'wp_auth0_use_management_api_for_userinfo', '__return_false', 10 );
+		remove_filter( 'auth0_use_management_api_for_userinfo', '__return_false', 10 );
 	}
 
 	/**
@@ -392,7 +392,7 @@ class TestLoginManagerRedirectLogin extends WP_Auth0_Test_Case {
 		self::$opts->set( 'client_id', '__test_client_id__' );
 		self::$opts->set( 'client_secret', '__test_client_secret__' );
 		self::$opts->set( 'client_signing_algorithm', 'HS256' );
-		add_filter( 'wp_auth0_use_management_api_for_userinfo', '__return_false', 10 );
+		add_filter( 'auth0_use_management_api_for_userinfo', '__return_false', 10 );
 		$_REQUEST['code'] = uniqid();
 
 		try {


### PR DESCRIPTION
### Changes

- Adds `auth0_lock_options` filter to modify Lock options before using
- Renames unreleased `wp_auth0_use_management_api_for_userinfo` to `auth0_use_management_api_for_userinfo` for consistency.

### References

[Docs PR to add new filter, change previous](https://github.com/auth0/docs/pull/7594/commits/07a2f5f52f34ae6f5e4873bd683f8d762adb0cab)

### Testing

* [x] This change adds unit test coverage
* [x] This change has been tested on WP 5.2.1

### Checklist

* [x] All existing and new tests complete without errors
* [x] All code quality tools/guidelines in the [Contribution guide](CONTRIBUTION.md) have been run/followed
* [x] All active GitHub CI checks have passed
