### PR TITLE
Change JWT leeway filter name and add tests

### DIFF
--- a/lib/WP_Auth0_Id_Token_Validator.php
+++ b/lib/WP_Auth0_Id_Token_Validator.php
@@ -62,7 +62,7 @@ class WP_Auth0_Id_Token_Validator {
 		$this->issuer    = 'https://' . $opts->get_auth_domain() . '/';
 		$this->audience  = $opts->get( 'client_id' );
 
-		JWT::$leeway = apply_filters( 'wp_auth0_jwt_leeway', \JWT::$leeway );
+		JWT::$leeway = absint( apply_filters( 'auth0_jwt_leeway', \JWT::$leeway ) );
 	}
 
 	/**

--- a/tests/testFunctionCanShowWpLoginForm.php
+++ b/tests/testFunctionCanShowWpLoginForm.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Contains Class TestOptionCanShowWpLogin.
+ * Contains Class TestFunctionCanShowWpLoginForm.
  *
  * @package WP-Auth0
  *
@@ -8,9 +8,9 @@
  */
 
 /**
- * Class TestOptionCanShowWpLogin.
+ * Class TestFunctionCanShowWpLoginForm.
  */
-class TestOptionCanShowWpLogin extends WP_Auth0_Test_Case {
+class TestFunctionCanShowWpLoginForm extends WP_Auth0_Test_Case {
 
 	public function testThatWpLoginCanBeShownIfPluginNotReady() {
 		$this->assertTrue( wp_auth0_can_show_wp_login_form() );

--- a/tests/testIdTokenValidator.php
+++ b/tests/testIdTokenValidator.php
@@ -244,4 +244,24 @@ class TestIdTokenValidator extends WP_Auth0_Test_Case {
 		$decoded_token = @$decoder->decode( true );
 		$this->assertEquals( '__test_data__', $decoded_token->data );
 	}
+
+	/**
+	 * Test that the JWT leeway filter works.
+	 */
+	public function testThatJwtFilterChangesLeewayTimeUsed() {
+		add_filter( 'auth0_jwt_leeway', [ self::class, 'jwtLeewayFilter' ], 10 );
+		new WP_Auth0_Id_Token_Validator( uniqid(), self::$opts );
+		remove_filter( 'auth0_jwt_leeway', [ self::class, 'jwtLeewayFilter' ], 10 );
+
+		$this->assertEquals( 1234, JWT::$leeway );
+	}
+
+	/**
+	 * Use this function to filter the JWT leeway.
+	 *
+	 * @return int
+	 */
+	public static function jwtLeewayFilter() {
+		return 1234;
+	}
 }


### PR DESCRIPTION
### Changes

Change the not-yet-released JWT filter name from `wp_auth0_jwt_leeway` to `auth0_jwt_leeway`

### Testing

* [x] This change adds unit test coverage
* [x] This change has been tested on WP 5.2.1

### Checklist

* [x] All existing and new tests complete without errors
* [x] All code quality tools/guidelines in the [Contribution guide](CONTRIBUTION.md) have been run/followed
* [x] All active GitHub CI checks have passed
