### PR TITLE
Fix migration namespace and callback

### DIFF
--- a/lib/WP_Auth0_Api_Operations.php
+++ b/lib/WP_Auth0_Api_Operations.php
@@ -84,7 +84,7 @@ class WP_Auth0_Api_Operations {
 				'bareConfiguration'            => array(
 					'endpointUrl'    => site_url( 'index.php?a0_action=' ),
 					'migrationToken' => $migration_token,
-					'userNamespace'  => get_auth0_curatedBlogName(),
+					'userNamespace'  => 'DB-' . get_auth0_curatedBlogName(),
 				),
 			);
 

--- a/lib/WP_Auth0_Routes.php
+++ b/lib/WP_Auth0_Routes.php
@@ -217,9 +217,6 @@ class WP_Auth0_Routes {
 			$username = $_POST['username'];
 
 			$user = get_user_by( 'email', $username );
-			if ( ! $user ) {
-				$user = get_user_by( 'slug', $username );
-			}
 
 			if ( ! $user ) {
 				throw new Exception( __( 'User not found', 'wp-auth0' ), 401 );

--- a/lib/api/WP_Auth0_Api_Change_Email.php
+++ b/lib/api/WP_Auth0_Api_Change_Email.php
@@ -66,6 +66,7 @@ class WP_Auth0_Api_Change_Email extends WP_Auth0_Api_Abstract {
 			->add_body( 'email', $email )
 			// Email is either changed by an admin or verified by WP.
 			->add_body( 'email_verified', true )
+			->add_body( 'client_id', $this->options->get( 'client_id' ) )
 			->patch()
 			->handle_response( __METHOD__ );
 	}

--- a/lib/scripts-js/db-get-user.js
+++ b/lib/scripts-js/db-get-user.js
@@ -31,9 +31,9 @@ function getByEmail (email, callback) {
 
       var wpUser = JSON.parse(body);
 
-      // Error returned from WordPress, exit.
-      if (wpUser.error) {
-        callback(null);
+      // Error returned from WordPress or no data, exit.
+      if (wpUser.error || ! wpUser.data) {
+        return callback(null);
       }
 
       // Use WordPress profile data to populate Auth0 account.

--- a/lib/scripts-js/db-login.js
+++ b/lib/scripts-js/db-login.js
@@ -33,9 +33,9 @@ function login (email, password, callback) {
 
       var wpUser = JSON.parse(body);
 
-      // Error returned from WordPress, exit.
-      if (wpUser.error) {
-        callback(null);
+      // Error returned from WordPress or no data, exit.
+      if (wpUser.error || ! wpUser.data) {
+        return callback(null);
       }
 
       // Use WordPress profile data to populate Auth0 account.

--- a/tests/testApiChangeEmail.php
+++ b/tests/testApiChangeEmail.php
@@ -68,6 +68,7 @@ class TestApiChangeEmail extends WP_Auth0_Test_Case {
 	public function testThatApiCallIsFormedCorrectly() {
 		$this->startHttpHalting();
 		self::$opts->set( 'domain', self::TEST_DOMAIN );
+		self::$opts->set( 'client_id', '__test_client_id__' );
 
 		// Should succeed with a user_id + provider and set_bearer returning true.
 		$change_email = $this->getStub( true );
@@ -86,7 +87,10 @@ class TestApiChangeEmail extends WP_Auth0_Test_Case {
 		$this->assertEquals( 'PATCH', $decoded_res['method'] );
 		$this->assertArrayHasKey( 'email', $decoded_res['body'] );
 		$this->assertEquals( 'email@address.com', $decoded_res['body']['email'] );
+		$this->assertArrayHasKey( 'email_verified', $decoded_res['body'] );
 		$this->assertTrue( $decoded_res['body']['email_verified'] );
+		$this->assertArrayHasKey( 'client_id', $decoded_res['body'] );
+		$this->assertEquals( '__test_client_id__', $decoded_res['body']['client_id'] );
 	}
 
 	/**

--- a/tests/testApiOperations.php
+++ b/tests/testApiOperations.php
@@ -111,7 +111,7 @@ class TestApiOperations extends WP_Auth0_Test_Case {
 		);
 
 		$this->assertEquals(
-			get_auth0_curatedBlogName(),
+			'DB-' . get_auth0_curatedBlogName(),
 			$caught_http['body']['options']['bareConfiguration']['userNamespace']
 		);
 	}

--- a/tests/testRoutesGetUser.php
+++ b/tests/testRoutesGetUser.php
@@ -200,12 +200,5 @@ class TestRoutesGetUser extends WP_Auth0_Test_Case {
 		$this->assertEquals( $user->display_name, $output_em->data->display_name );
 		$this->assertObjectNotHasAttribute( 'user_pass', $output_em->data );
 		$this->assertEmpty( self::$error_log->get() );
-
-		// Test username lookup.
-		$_POST['username'] = $user->user_login;
-		$output_un         = json_decode( self::$routes->custom_requests( self::$wp, true ) );
-
-		$this->assertEquals( $output_em, $output_un );
-		$this->assertEmpty( self::$error_log->get() );
 	}
 }


### PR DESCRIPTION
### Changes

- Change the namespace used when creating a new custom DB connection
- Remove the check for username on the get user endpoint
- Add `client_id` to the update user API call

### Testing

* [x] This change adds unit test coverage
* [x] This change has been tested on WP 5.2.1

### Checklist

* [x] All existing and new tests complete without errors
* [x] All code quality tools/guidelines in the [Contribution guide](CONTRIBUTION.md) have been run/followed
* [x] All active GitHub CI checks have passed
