### PR TITLE
Fix auth0 in paths triggering callback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 **Notes on this release**
 
 - The minimum PHP version has been updated from 5.3 to 5.6. All long arrays have been converted to short arrays with a PHPCS check. 
+- The site will no longer auto-redirect paths with `auth0` in them to the callback URL. Use `/index.php?auth0=1` to use the callback URL directly. Your site may require permalinks to be refreshed manually by going to **wp-admin > Settings > Permalinks** and clicking **Save Changes**.
 
 ## [3.11.0](https://github.com/auth0/wp-auth0/tree/3.11.0) (2019-05-30)
 [Full Changelog](https://github.com/auth0/wp-auth0/compare/3.10.0...3.11.0)

--- a/lib/WP_Auth0_Routes.php
+++ b/lib/WP_Auth0_Routes.php
@@ -51,7 +51,6 @@ class WP_Auth0_Routes {
 		add_rewrite_tag( '%auth0_error%', '([^&]+)' );
 		add_rewrite_tag( '%a0_action%', '([^&]+)' );
 
-		add_rewrite_rule( '^auth0', 'index.php?auth0=1', 'top' );
 		add_rewrite_rule( '^\.well-known/oauth2-client-configuration', 'index.php?a0_action=oauth2-config', 'top' );
 	}
 


### PR DESCRIPTION
### Changes

Fixes an issue were accessing a page with `auth0` in the path triggered a redirect to the callback URL, which causes an Invalid State error.

### References

Fixes #351 