### PR TITLE
Fix post passwords getting redirected

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,9 +49,6 @@ commands:
             dockerize -wait tcp://127.0.0.1:3306 -timeout 120s
             bash bin/install-wp-tests.sh wordpress_test root '' 127.0.0.1 latest
       - run: composer test-ci
-      - run:
-          command: bash <(curl -s https://codecov.io/bash)
-          when: on_success
 
 jobs:
   php_5:
@@ -74,6 +71,9 @@ jobs:
       - prepare
       - run-tests
       - run-formatting
+      - run:
+          command: bash <(curl -s https://codecov.io/bash)
+          when: on_success
   snyk:
     docker:
       - image: snyk/snyk-cli:composer

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ commands:
             sudo docker-php-ext-install mysqli
             sudo apt-get update
             sudo composer self-update
-            sudo apt-get install -y subversion mysql-client
+            sudo apt-get install -y subversion default-mysql-client
       - restore_cache:
           keys:
             - composer-v1-{{ .Environment.CIRCLE_JOB }}-{{ checksum "composer.json" }}

--- a/functions.php
+++ b/functions.php
@@ -74,7 +74,7 @@ function wp_auth0_can_show_wp_login_form() {
 		return true;
 	}
 
-	if ( wp_auth0_is_current_login_action( array( 'resetpass', 'rp', 'validate_2fa' ) ) ) {
+	if ( wp_auth0_is_current_login_action( array( 'resetpass', 'rp', 'validate_2fa', 'postpass' ) ) ) {
 		return true;
 	}
 

--- a/tests/testFunctionCanShowWpLoginForm.php
+++ b/tests/testFunctionCanShowWpLoginForm.php
@@ -40,6 +40,14 @@ class TestFunctionCanShowWpLoginForm extends WP_Auth0_Test_Case {
 		$this->assertTrue( wp_auth0_can_show_wp_login_form() );
 	}
 
+	public function testThatWpLoginCanBeShownIfProcessingPostPassword() {
+		self::auth0Ready();
+		$GLOBALS['pagenow'] = 'wp-login.php';
+		$_REQUEST['action'] = 'postpass';
+		self::$opts->set( 'wordpress_login_enabled', 'link' );
+		$this->assertTrue( wp_auth0_can_show_wp_login_form() );
+	}
+
 	public function testThatWpLoginCannotBeShownIfNotWle() {
 		self::auth0Ready();
 		self::$opts->set( 'wordpress_login_enabled', 'link' );


### PR DESCRIPTION
### Changes

Content with a password is getting redirected to the ULP. 

### Testing

To manually test before the fix:

1. Turn on **Auth0 > Settings > Features > Universal Login Page**
2. Create a new post or page
3. Set Visibility to Password Protected

![Screenshot 2019-07-16 09 39 41](https://user-images.githubusercontent.com/855223/61312632-ac18d480-a7ad-11e9-8d79-1aa4d5a2ce70.png)

4. View the post or page
5. Enter the password and submit
6. Redirected to the ULP (bad)
7. Apply the fix
8. Try steps 4 and 5 above
9. See the password-protected content 

* [x] I included manual testing steps above, if applicable
* [x] This change adds unit test coverage
* [x] This change has been tested in WP 5.2.2

### Checklist

* [x] All existing and new tests complete without errors
* [x] All code quality tools/guidelines in the [Contribution guide](CONTRIBUTION.md) have been run/followed
* [x] All active GitHub CI checks have passed
