### PR TITLE
Add new Auth0 IPs; do not save duplicate or whitelisted IPs

### DIFF
--- a/lib/WP_Auth0_Ip_Check.php
+++ b/lib/WP_Auth0_Ip_Check.php
@@ -27,10 +27,13 @@ class WP_Auth0_Ip_Check {
 	 */
 	protected $valid_webtask_ips = array(
 		'us' => array(
+			'3.211.189.167',
+			'18.233.90.226',
 			'34.195.142.251',
 			'35.160.3.103',
 			'35.166.202.113',
 			'35.167.74.121',
+			'35.171.156.124',
 			'52.14.17.114',
 			'52.14.38.78',
 			'52.14.40.253',
@@ -57,10 +60,13 @@ class WP_Auth0_Ip_Check {
 			'52.29.176.99',
 			'52.50.106.250',
 			'52.57.230.214',
+			'52.208.95.174',
+			'52.210.122.50',
 			'52.211.56.181',
 			'52.213.38.246',
 			'52.213.74.69',
 			'52.213.216.142',
+			'54.76.184.103',
 		),
 		'au' => array(
 			'13.54.254.182',
@@ -99,7 +105,7 @@ class WP_Auth0_Ip_Check {
 	 * @param string $domain - Tenant domain.
 	 * @param string $glue   - String used to implode arrays.
 	 *
-	 * @return string
+	 * @return string|array
 	 */
 	public function get_ips_by_domain( $domain = null, $glue = self::IP_STRING_GLUE ) {
 		if ( empty( $domain ) ) {
@@ -115,10 +121,11 @@ class WP_Auth0_Ip_Check {
 	 * @param string $region - Tenant region.
 	 * @param string $glue   - String used to implode arrays.
 	 *
-	 * @return string
+	 * @return string|array
 	 */
 	public function get_ip_by_region( $region, $glue = self::IP_STRING_GLUE ) {
-		return implode( $glue, $this->valid_webtask_ips[ $region ] );
+		$ip_addresses = $this->valid_webtask_ips[ $region ];
+		return is_null( $glue ) ? $ip_addresses : implode( $glue, $ip_addresses );
 	}
 
 	/**

--- a/tests/testIpCheck.php
+++ b/tests/testIpCheck.php
@@ -43,14 +43,14 @@ class TestIpCheck extends WP_Auth0_Test_Case {
 		$ip_check = new WP_Auth0_Ip_Check( self::$opts );
 
 		$us_ips = explode( ',', $ip_check->get_ip_by_region( 'us' ) );
-		$this->assertCount( 16, $us_ips );
+		$this->assertCount( 19, $us_ips );
 		$us_ips = explode( ',', $ip_check->get_ips_by_domain( 'test.auth0.com' ) );
-		$this->assertCount( 16, $us_ips );
+		$this->assertCount( 19, $us_ips );
 
 		$eu_ips = explode( ',', $ip_check->get_ip_by_region( 'eu' ) );
-		$this->assertCount( 16, $eu_ips );
+		$this->assertCount( 19, $eu_ips );
 		$eu_ips = explode( ',', $ip_check->get_ips_by_domain( 'test.eu.auth0.com' ) );
-		$this->assertCount( 16, $eu_ips );
+		$this->assertCount( 19, $eu_ips );
 
 		$au_ips = explode( ',', $ip_check->get_ip_by_region( 'au' ) );
 		$this->assertCount( 11, $au_ips );

--- a/tests/testOptionMigrationIps.php
+++ b/tests/testOptionMigrationIps.php
@@ -1,0 +1,121 @@
+<?php
+/**
+ * Contains Class TestOptionMigrationIps.
+ *
+ * @package WP-Auth0
+ *
+ * @since 3.11.1
+ */
+
+/**
+ * Class TestOptionMigrationIps.
+ */
+class TestOptionMigrationIps extends WP_Auth0_Test_Case {
+
+	use AjaxHelpers;
+
+	use DomDocumentHelpers;
+
+	use UsersHelper;
+
+	/**
+	 * Instance of WP_Auth0_Admin_Advanced.
+	 *
+	 * @var WP_Auth0_Admin_Advanced
+	 */
+	public static $admin;
+
+	/**
+	 * Instance of WP_Auth0_Ip_Check.
+	 *
+	 * @var WP_Auth0_Ip_Check
+	 */
+	public static $ip_check;
+
+	/**
+	 * Runs before each test starts.
+	 */
+	public function setUp() {
+		parent::setUp();
+		$router         = new WP_Auth0_Routes( self::$opts );
+		self::$admin    = new WP_Auth0_Admin_Advanced( self::$opts, $router );
+		self::$ip_check = new WP_Auth0_Ip_Check();
+	}
+
+
+	public function testThatSettingsFieldRendersProperly() {
+		self::$opts->set( 'domain', 'test.eu.auth0.com' );
+		$field_args = [
+			'label_for' => 'wpa0_migration_ws_ips',
+			'opt_name'  => 'migration_ips',
+		];
+
+		// Get the field HTML.
+		ob_start();
+		self::$admin->render_migration_ws_ips( $field_args );
+		$field_html = ob_get_clean();
+
+		$textarea = $this->getDomListFromTagName( $field_html, 'textarea' );
+		$this->assertEquals( 1, $textarea->length );
+		$this->assertEquals( $field_args['label_for'], $textarea->item( 0 )->getAttribute( 'id' ) );
+		$this->assertEquals(
+			self::OPTIONS_NAME . '[' . $field_args['opt_name'] . ']',
+			$textarea->item( 0 )->getAttribute( 'name' )
+		);
+
+		$whitelist_ips = self::$ip_check->get_ips_by_domain( 'test.eu.auth0.com', null );
+
+		$ips = $this->getDomListFromTagName( $field_html, 'code' );
+		$this->assertEquals( count( $whitelist_ips ), $ips->length );
+		for ( $item_index = 0; $item_index < $ips->length; $item_index++ ) {
+			$this->assertContains( $ips->item( $item_index )->nodeValue, $whitelist_ips );
+		}
+	}
+
+	public function testThatEmptyIpsAreValidatedToAnEmptyString() {
+		$input     = [ 'migration_ips' => 0 ];
+		$validated = self::$admin->migration_ips_validation( [], $input );
+		$this->assertEquals( '', $validated['migration_ips'] );
+
+		$input     = [ 'migration_ips' => false ];
+		$validated = self::$admin->migration_ips_validation( [], $input );
+		$this->assertEquals( '', $validated['migration_ips'] );
+
+		$input     = [ 'migration_ips' => null ];
+		$validated = self::$admin->migration_ips_validation( [], $input );
+		$this->assertEquals( '', $validated['migration_ips'] );
+	}
+
+	public function testThatDuplicateIpsAreRemovedDuringValidation() {
+		$input = [ 'migration_ips' => '1.2.3.4, 2.3.4.5,1.2.3.4,3.4.5.6, 2.3.4.5' ];
+
+		$validated = self::$admin->migration_ips_validation( [], $input );
+		$this->assertEquals( '1.2.3.4, 2.3.4.5, 3.4.5.6', $validated['migration_ips'] );
+	}
+
+	public function testThatExistingWhitelistIpsAreRemovedDuringValidation() {
+		$whitelist_ips         = self::$ip_check->get_ip_by_region( 'eu', null );
+		$random_whitelisted_ip = $whitelist_ips[ array_rand( $whitelist_ips ) ];
+		$input                 = [
+			'migration_ips' => '4.5.6.7,' . $random_whitelisted_ip . ',5.6.7.8',
+			'domain'        => 'test.eu.auth0.com',
+		];
+
+		$validated = self::$admin->migration_ips_validation( [], $input );
+		$this->assertEquals( '4.5.6.7, 5.6.7.8', $validated['migration_ips'] );
+	}
+
+	public function testThatUnsafeValuesAreRemovedDuringValidation() {
+		$input = [ 'migration_ips' => '6.7.8.9,<script>alert("Hello")</script>,7.8.9.10' ];
+
+		$validated = self::$admin->migration_ips_validation( [], $input );
+		$this->assertEquals( '6.7.8.9, 7.8.9.10', $validated['migration_ips'] );
+	}
+
+	public function testThatEmptyValuesAreRemovedDuringValidation() {
+		$input = [ 'migration_ips' => '8.9.10.11, , 9.10.11.12, 0' ];
+
+		$validated = self::$admin->migration_ips_validation( [], $input );
+		$this->assertEquals( '8.9.10.11, 9.10.11.12', $validated['migration_ips'] );
+	}
+}


### PR DESCRIPTION
### Changes

- Add new Auth0 incoming IP addresses to fix migration route filters
- Fix IP address validation to exclude duplicate, empty values, and IPs already whitelisted

### References

[Current Auth0 IP address list](https://auth0.com/docs/guides/ip-whitelist)

### Testing

* [x] This change adds unit test coverage
* [x] This change has been tested on WP 5.2.2

### Checklist

* [x] All existing and new tests complete without errors
* [x] All code quality tools/guidelines in the [Contribution guide](CONTRIBUTION.md) have been run/followed
* [x] All active GitHub CI checks have passed
