### PR TITLE
Fix sensitive field handling; add Basic settings tab validations

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
         "php": "^5.3 || ^7.0"
     },
     "require-dev": {
-        "dealerdirect/phpcodesniffer-composer-installer": "^0.4.3",
+        "dealerdirect/phpcodesniffer-composer-installer": "^0.5",
         "wp-coding-standards/wpcs": "^1",
         "phpcompatibility/phpcompatibility-wp": "*",
         "phpunit/phpunit": "^5.0 || ^6.0"

--- a/lib/admin/WP_Auth0_Admin_Basic.php
+++ b/lib/admin/WP_Auth0_Admin_Basic.php
@@ -103,7 +103,8 @@ class WP_Auth0_Admin_Basic extends WP_Auth0_Admin_Generic {
 	 * @see add_settings_field()
 	 */
 	public function render_domain( $args = array() ) {
-		$this->render_text_field( $args['label_for'], $args['opt_name'], 'text', 'your-tenant.auth0.com' );
+		$style = $this->options->get( $args['opt_name'] ) ? '' : self::ERROR_FIELD_STYLE;
+		$this->render_text_field( $args['label_for'], $args['opt_name'], 'text', 'your-tenant.auth0.com', $style );
 		$this->render_field_description(
 			__( 'Auth0 Domain, found in your Application settings in the ', 'wp-auth0' ) .
 			$this->get_dashboard_link( 'applications' )
@@ -139,7 +140,8 @@ class WP_Auth0_Admin_Basic extends WP_Auth0_Admin_Generic {
 	 * @see add_settings_field()
 	 */
 	public function render_client_id( $args = array() ) {
-		$this->render_text_field( $args['label_for'], $args['opt_name'] );
+		$style = $this->options->get( $args['opt_name'] ) ? '' : self::ERROR_FIELD_STYLE;
+		$this->render_text_field( $args['label_for'], $args['opt_name'], 'text', '', $style );
 		$this->render_field_description(
 			__( 'Client ID, found in your Application settings in the ', 'wp-auth0' ) .
 			$this->get_dashboard_link( 'applications' )
@@ -156,7 +158,8 @@ class WP_Auth0_Admin_Basic extends WP_Auth0_Admin_Generic {
 	 * @see add_settings_field()
 	 */
 	public function render_client_secret( $args = array() ) {
-		$this->render_text_field( $args['label_for'], $args['opt_name'], 'password' );
+		$style = $this->options->get( $args['opt_name'] ) ? '' : self::ERROR_FIELD_STYLE;
+		$this->render_text_field( $args['label_for'], $args['opt_name'], 'password', '', $style );
 		$this->render_field_description(
 			__( 'Client Secret, found in your Application settings in the ', 'wp-auth0' ) .
 			$this->get_dashboard_link( 'applications' )
@@ -354,19 +357,21 @@ class WP_Auth0_Admin_Basic extends WP_Auth0_Admin_Generic {
 			return $input;
 		}
 
+		$input['domain']           = sanitize_text_field( $input['domain'] );
+		$input['custom_domain']    = sanitize_text_field( $input['custom_domain'] );
 		$input['client_id']        = sanitize_text_field( $input['client_id'] );
 		$input['cache_expiration'] = absint( $input['cache_expiration'] );
 
-		$input['allow_signup'] = ( isset( $input['allow_signup'] ) ? $input['allow_signup'] : 0 );
+		$input['client_secret'] = sanitize_text_field( $input['client_secret'] );
+		if ( __( '[REDACTED]', 'wp-auth0' ) === $input['client_secret'] ) {
+			$input['client_secret'] = $old_options['client_secret'];
+		}
 
-		// Only replace the secret or token if a new value was set. If not, we will keep the last one entered.
-		$input['client_secret'] = ( ! empty( $input['client_secret'] )
-			? $input['client_secret']
-			: $old_options['client_secret'] );
+		$input['client_secret_b64_encoded'] = empty( $input['client_secret_b64_encoded'] ) ? 0 : 1;
 
-		$input['client_secret_b64_encoded'] = ( isset( $input['client_secret_b64_encoded'] )
-			? $input['client_secret_b64_encoded'] == 1
-			: false );
+		if ( ! in_array( $input['client_signing_algorithm'], array( 'HS256', 'RS256' ) ) ) {
+			$input['client_signing_algorithm'] = WP_Auth0_Api_Client::DEFAULT_CLIENT_ALG;
+		}
 
 		if ( empty( $input['domain'] ) ) {
 			$this->add_validation_error( __( 'You need to specify a domain', 'wp-auth0' ) );

--- a/lib/admin/WP_Auth0_Admin_Generic.php
+++ b/lib/admin/WP_Auth0_Admin_Generic.php
@@ -2,6 +2,8 @@
 
 class WP_Auth0_Admin_Generic {
 
+	const ERROR_FIELD_STYLE = 'border: 1px solid red;';
+
 	protected $options;
 
 	protected $_option_name;
@@ -167,8 +169,8 @@ class WP_Auth0_Admin_Generic {
 
 		// Secure fields are not output by default; validation keeps last value if a new one is not entered
 		if ( 'password' === $type ) {
-			$placeholder = ! empty( $value ) ? 'Not visible' : '';
-			$value       = '';
+			$value = empty( $value ) ? '' : __( '[REDACTED]', 'wp-auth0' );
+			$type  = 'text';
 		}
 		if ( $field_is_const = $this->options->has_constant_val( $input_name ) ) {
 			$this->render_const_notice( $input_name );

--- a/templates/initial-setup/connection_profile.php
+++ b/templates/initial-setup/connection_profile.php
@@ -177,7 +177,7 @@
 					<?php _e( ' and paste it below:', 'wp-auth0' ); ?>
 				</p>
 
-				<input type="password" name="apitoken" class="js-a0-setup-input" autocomplete="off" required>
+				<input type="text" name="apitoken" class="js-a0-setup-input" autocomplete="off" required>
 				  <p>
 					  <small>
 				<?php _e( 'Scopes required', 'wp-auth0' ); ?>:

--- a/tests/testAdminBasicValidation.php
+++ b/tests/testAdminBasicValidation.php
@@ -1,0 +1,156 @@
+<?php
+/**
+ * Contains Class TestAdminBasicValidation.
+ *
+ * @package WP-Auth0
+ *
+ * @since 3.11.1
+ */
+
+/**
+ * Class TestAdminBasicValidation.
+ */
+class TestAdminBasicValidation extends WP_Auth0_Test_Case {
+
+	use DomDocumentHelpers;
+
+	/**
+	 * WP_Auth0_Admin_Basic instance.
+	 *
+	 * @var WP_Auth0_Admin_Basic
+	 */
+	public static $admin;
+
+	/**
+	 * All required basic settings fields.
+	 *
+	 * @var array
+	 */
+	public static $fields;
+
+	/**
+	 * Run before the test suite starts.
+	 */
+	public static function setUpBeforeClass() {
+		parent::setUpBeforeClass();
+		self::$admin  = new WP_Auth0_Admin_Basic( self::$opts );
+		self::$fields = [
+			'domain'                    => 'test.auth0.com',
+			'custom_domain'             => '',
+			'client_id'                 => '__test_client_id__',
+			'client_secret'             => '__test_client_secret__',
+			'client_secret_b64_encoded' => WP_Auth0_Api_Client::DEFAULT_CLIENT_ALG,
+			'client_signing_algorithm'  => '',
+			'cache_expiration'          => '',
+		];
+	}
+
+	public function testThatDomainIsValidatedProperly() {
+		$old_input = array_merge( self::$fields, [ 'domain' => uniqid() ] );
+		$validated = self::$admin->basic_validation( $old_input, self::$fields );
+
+		$this->assertEquals( 'test.auth0.com', $validated['domain'] );
+	}
+
+	public function testThatEmptyDomainIsAllowed() {
+		$old_input = array_merge( self::$fields, [ 'domain' => uniqid() ] );
+		$new_input = array_merge( self::$fields, [ 'domain' => '' ] );
+		$validated = self::$admin->basic_validation( $old_input, $new_input );
+
+		$this->assertEmpty( $validated['domain'] );
+	}
+
+	public function testThatHtmlIsRemovedFromDomain() {
+		$new_input = array_merge( self::$fields, [ 'domain' => '<script>alert("hi")</script>test1.auth0.com' ] );
+		$validated = self::$admin->basic_validation( self::$fields, $new_input );
+
+		$this->assertEquals( 'test1.auth0.com', $validated['domain'] );
+	}
+
+	public function testThatClientSecretIsValidatedProperly() {
+		$old_input = array_merge( self::$fields, [ 'client_secret' => uniqid() ] );
+		$validated = self::$admin->basic_validation( $old_input, self::$fields );
+
+		$this->assertEquals( '__test_client_secret__', $validated['client_secret'] );
+	}
+
+	public function testThatEmptyClientSecretIsAllowed() {
+		$old_input = array_merge( self::$fields, [ 'client_secret' => uniqid() ] );
+		$new_input = array_merge( self::$fields, [ 'client_secret' => '' ] );
+		$validated = self::$admin->basic_validation( $old_input, $new_input );
+
+		$this->assertEmpty( $validated['client_secret'] );
+	}
+
+	public function testThatHtmlIsRemovedFromClientSecret() {
+		$new_input = array_merge( self::$fields, [ 'client_secret' => '<script>alert("hi")</script>__secret__' ] );
+		$validated = self::$admin->basic_validation( self::$fields, $new_input );
+
+		$this->assertEquals( '__secret__', $validated['client_secret'] );
+	}
+
+	public function testThatUnchangedClientSecretIsKept() {
+		$new_input = array_merge( self::$fields, [ 'client_secret' => '[REDACTED]' ] );
+		$validated = self::$admin->basic_validation( self::$fields, $new_input );
+
+		$this->assertEquals( '__test_client_secret__', $validated['client_secret'] );
+	}
+
+	public function testThatValidAlgorithmIsValidatedProperly() {
+		$old_input = array_merge( self::$fields, [ 'client_signing_algorithm' => uniqid() ] );
+		$new_input = array_merge( self::$fields, [ 'client_signing_algorithm' => 'HS256' ] );
+		$validated = self::$admin->basic_validation( $old_input, $new_input );
+
+		$this->assertEquals( 'HS256', $validated['client_signing_algorithm'] );
+
+		$new_input['client_signing_algorithm'] = 'RS256';
+		$validated                             = self::$admin->basic_validation( $old_input, $new_input );
+
+		$this->assertEquals( 'RS256', $validated['client_signing_algorithm'] );
+	}
+
+	public function testThatSecretEncodedIsValidatedAsOffProperly() {
+		$new_input = array_merge( self::$fields, [ 'client_secret_b64_encoded' => 0 ] );
+		$validated = self::$admin->basic_validation( self::$fields, $new_input );
+
+		$this->assertEquals( 0, $validated['client_secret_b64_encoded'] );
+
+		$new_input = array_merge( self::$fields, [ 'client_secret_b64_encoded' => null ] );
+		$validated = self::$admin->basic_validation( self::$fields, $new_input );
+
+		$this->assertEquals( 0, $validated['client_secret_b64_encoded'] );
+
+		$new_input = array_merge( self::$fields, [ 'client_secret_b64_encoded' => false ] );
+		$validated = self::$admin->basic_validation( self::$fields, $new_input );
+
+		$this->assertEquals( 0, $validated['client_secret_b64_encoded'] );
+	}
+
+	public function testThatSecretEncodedIsValidatedAsOnProperly() {
+		$new_input = array_merge( self::$fields, [ 'client_secret_b64_encoded' => 1 ] );
+		$validated = self::$admin->basic_validation( self::$fields, $new_input );
+
+		$this->assertEquals( 1, $validated['client_secret_b64_encoded'] );
+
+		$new_input = array_merge( self::$fields, [ 'client_secret_b64_encoded' => uniqid() ] );
+		$validated = self::$admin->basic_validation( self::$fields, $new_input );
+
+		$this->assertEquals( 1, $validated['client_secret_b64_encoded'] );
+	}
+
+	public function testThatEmptyAlgorithmIsResetToDefault() {
+		$old_input = array_merge( self::$fields, [ 'client_signing_algorithm' => 'HS256' ] );
+		$new_input = array_merge( self::$fields, [ 'client_signing_algorithm' => '' ] );
+		$validated = self::$admin->basic_validation( $old_input, $new_input );
+
+		$this->assertEquals( 'RS256', $validated['client_signing_algorithm'] );
+	}
+
+	public function testThatInvalidAlgorithmIsResetToDefault() {
+		$old_input = array_merge( self::$fields, [ 'client_signing_algorithm' => 'HS256' ] );
+		$new_input = array_merge( self::$fields, [ 'client_signing_algorithm' => uniqid() ] );
+		$validated = self::$admin->basic_validation( $old_input, $new_input );
+
+		$this->assertEquals( 'RS256', $validated['client_signing_algorithm'] );
+	}
+}

--- a/tests/testConstantSettings.php
+++ b/tests/testConstantSettings.php
@@ -155,8 +155,8 @@ class TestConstantSettings extends WP_Auth0_Test_Case {
 			$this->assertContains( $constant_name, $field_html );
 
 			// Sensitive fields will not output the current value.
-			$is_sensitive = in_array( $field['opt_name'], [ 'client_secret' ] );
-			$this->assertContains( 'value="' . ( $is_sensitive ? '' : $field['value'] ) . '"', $field_html );
+			$expected_value = 'client_secret' === $field['opt_name'] ? '[REDACTED]' : $field['value'];
+			$this->assertContains( 'value="' . $expected_value . '"', $field_html );
 		}
 	}
 }

--- a/tests/testOptionClientId.php
+++ b/tests/testOptionClientId.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * Contains Class TestOptionClientId.
+ *
+ * @package WP-Auth0
+ *
+ * @since 3.11.1
+ */
+
+/**
+ * Class TestOptionClientId.
+ * Tests that Basic > Client ID functions properly.
+ */
+class TestOptionClientId extends WP_Auth0_Test_Case {
+
+	use DomDocumentHelpers;
+
+	/**
+	 * WP_Auth0_Admin_Basic instance.
+	 *
+	 * @var WP_Auth0_Admin_Basic
+	 */
+	public static $admin;
+
+	/**
+	 * Domain settings field args
+	 *
+	 * @var array
+	 */
+	public static $field_args;
+
+	/**
+	 * Run before the test suite starts.
+	 */
+	public static function setUpBeforeClass() {
+		parent::setUpBeforeClass();
+		self::$admin      = new WP_Auth0_Admin_Basic( self::$opts );
+		self::$field_args = [
+			'label_for' => 'wpa0_client_id',
+			'opt_name'  => 'client_id',
+		];
+	}
+
+	public function testThatClientIdFieldRendersProperly() {
+		ob_start();
+		self::$admin->render_client_id( self::$field_args );
+		$field_html = ob_get_clean();
+
+		$input = $this->getDomListFromTagName( $field_html, 'input' );
+
+		$this->assertEquals( 1, $input->length );
+		$this->assertEquals( 'wpa0_client_id', $input->item( 0 )->getAttribute( 'id' ) );
+		$this->assertEquals( 'text', $input->item( 0 )->getAttribute( 'type' ) );
+		$this->assertEquals( self::OPTIONS_NAME . '[client_id]', $input->item( 0 )->getAttribute( 'name' ) );
+		$this->assertEquals( 'border: 1px solid red;', $input->item( 0 )->getAttribute( 'style' ) );
+		$this->assertEmpty( $input->item( 0 )->getAttribute( 'value' ) );
+	}
+
+	public function testThatClientIdFieldDoesNotShowErrorStylesIfValueIsPresent() {
+		self::$opts->set( 'client_id', '__test_client_id__' );
+
+		ob_start();
+		self::$admin->render_client_id( self::$field_args );
+		$field_html = ob_get_clean();
+
+		$input = $this->getDomListFromTagName( $field_html, 'input' );
+		$this->assertEmpty( $input->item( 0 )->getAttribute( 'style' ) );
+		$this->assertEquals( '__test_client_id__', $input->item( 0 )->getAttribute( 'value' ) );
+	}
+}

--- a/tests/testOptionClientSecret.php
+++ b/tests/testOptionClientSecret.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * Contains Class TestOptionClientSecret.
+ *
+ * @package WP-Auth0
+ *
+ * @since 3.11.1
+ */
+
+/**
+ * Class TestOptionClientSecret.
+ * Tests that Basic > Client Secret functions properly.
+ */
+class TestOptionClientSecret extends WP_Auth0_Test_Case {
+
+	use DomDocumentHelpers;
+
+	/**
+	 * WP_Auth0_Admin_Basic instance.
+	 *
+	 * @var WP_Auth0_Admin_Basic
+	 */
+	public static $admin;
+
+	/**
+	 * Domain settings field args
+	 *
+	 * @var array
+	 */
+	public static $field_args;
+
+	/**
+	 * Run before the test suite starts.
+	 */
+	public static function setUpBeforeClass() {
+		parent::setUpBeforeClass();
+		self::$admin      = new WP_Auth0_Admin_Basic( self::$opts );
+		self::$field_args = [
+			'label_for' => 'wpa0_client_secret',
+			'opt_name'  => 'client_secret',
+		];
+	}
+
+	public function testThatClientSecretFieldRendersProperly() {
+		ob_start();
+		self::$admin->render_client_secret( self::$field_args );
+		$field_html = ob_get_clean();
+
+		$input = $this->getDomListFromTagName( $field_html, 'input' );
+
+		$this->assertEquals( 1, $input->length );
+		$this->assertEquals( 'wpa0_client_secret', $input->item( 0 )->getAttribute( 'id' ) );
+		$this->assertEquals( 'text', $input->item( 0 )->getAttribute( 'type' ) );
+		$this->assertEquals( self::OPTIONS_NAME . '[client_secret]', $input->item( 0 )->getAttribute( 'name' ) );
+		$this->assertEquals( 'border: 1px solid red;', $input->item( 0 )->getAttribute( 'style' ) );
+		$this->assertEmpty( $input->item( 0 )->getAttribute( 'value' ) );
+	}
+
+	public function testThatClientSecretFieldDoesNotShowErrorStylesIfValueIsPresent() {
+		self::$opts->set( 'client_secret', '__test_client_secret__' );
+
+		ob_start();
+		self::$admin->render_client_secret( self::$field_args );
+		$field_html = ob_get_clean();
+
+		$input = $this->getDomListFromTagName( $field_html, 'input' );
+		$this->assertEmpty( $input->item( 0 )->getAttribute( 'style' ) );
+		$this->assertEquals( '[REDACTED]', $input->item( 0 )->getAttribute( 'value' ) );
+	}
+}

--- a/tests/testOptionDomain.php
+++ b/tests/testOptionDomain.php
@@ -1,0 +1,71 @@
+<?php
+/**
+ * Contains Class TestOptionDomain.
+ *
+ * @package WP-Auth0
+ *
+ * @since 3.11.1
+ */
+
+/**
+ * Class TestOptionDomain.
+ * Tests that Basic > Domain functions properly.
+ */
+class TestOptionDomain extends WP_Auth0_Test_Case {
+
+	use DomDocumentHelpers;
+
+	/**
+	 * WP_Auth0_Admin_Basic instance.
+	 *
+	 * @var WP_Auth0_Admin_Basic
+	 */
+	public static $admin;
+
+	/**
+	 * Domain settings field args
+	 *
+	 * @var array
+	 */
+	public static $field_args;
+
+	/**
+	 * Run before the test suite starts.
+	 */
+	public static function setUpBeforeClass() {
+		parent::setUpBeforeClass();
+		self::$admin      = new WP_Auth0_Admin_Basic( self::$opts );
+		self::$field_args = [
+			'label_for' => 'wpa0_domain',
+			'opt_name'  => 'domain',
+		];
+	}
+
+	public function testThatDomainFieldRendersProperly() {
+		ob_start();
+		self::$admin->render_domain( self::$field_args );
+		$field_html = ob_get_clean();
+
+		$input = $this->getDomListFromTagName( $field_html, 'input' );
+
+		$this->assertEquals( 1, $input->length );
+		$this->assertEquals( 'wpa0_domain', $input->item( 0 )->getAttribute( 'id' ) );
+		$this->assertEquals( 'text', $input->item( 0 )->getAttribute( 'type' ) );
+		$this->assertEquals( 'your-tenant.auth0.com', $input->item( 0 )->getAttribute( 'placeholder' ) );
+		$this->assertEquals( self::OPTIONS_NAME . '[domain]', $input->item( 0 )->getAttribute( 'name' ) );
+		$this->assertEquals( 'border: 1px solid red;', $input->item( 0 )->getAttribute( 'style' ) );
+		$this->assertEmpty( $input->item( 0 )->getAttribute( 'value' ) );
+	}
+
+	public function testThatDomainFieldDoesNotShowErrorStylesIfValueIsPresent() {
+		self::$opts->set( 'domain', '__test_domain__' );
+
+		ob_start();
+		self::$admin->render_domain( self::$field_args );
+		$field_html = ob_get_clean();
+
+		$input = $this->getDomListFromTagName( $field_html, 'input' );
+		$this->assertEmpty( $input->item( 0 )->getAttribute( 'style' ) );
+		$this->assertEquals( '__test_domain__', $input->item( 0 )->getAttribute( 'value' ) );
+	}
+}


### PR DESCRIPTION
### Changes

- Fix `password` field types (client secret and API token) triggering password managers
- Add empty required field error styles
- Add validation/sanitization for domain, custom domain, client secret, and token algorithm fields

**Note to reviewers:** bulk of the additions here are missing tests

### References

Internal support request. 

### Testing

Please describe how this can be tested by reviewers. Tests must be added for new functionality and existing tests should complete without errors. 

* [x] This change adds unit test coverage
* [x] This change has been tested on WP 5.2.2

### Checklist

* [x] All existing and new tests complete without errors
* [x] All code quality tools/guidelines in the [Contribution guide](CONTRIBUTION.md) have been run/followed
* [x] All active GitHub CI checks have passed
