### PR TITLE
Change CDN URL field type

### DIFF
--- a/lib/admin/WP_Auth0_Admin_Advanced.php
+++ b/lib/admin/WP_Auth0_Admin_Advanced.php
@@ -579,16 +579,6 @@ class WP_Auth0_Admin_Advanced extends WP_Auth0_Admin_Generic {
 		$input['auth0_implicit_workflow'] = ( isset( $input['auth0_implicit_workflow'] ) ? $input['auth0_implicit_workflow'] : 0 );
 		$input['force_https_callback']    = ( isset( $input['force_https_callback'] ) ? $input['force_https_callback'] : 0 );
 
-		$input['custom_cdn_url'] = empty( $input['custom_cdn_url'] ) ? 0 : 1;
-
-		$input['cdn_url'] = empty( $input['cdn_url'] ) ? WPA0_LOCK_CDN_URL : sanitize_text_field( $input['cdn_url'] );
-
-		// If an invalid URL is used, default to previously saved (if there is one) or default URL.
-		if ( ! filter_var( $input['cdn_url'], FILTER_VALIDATE_URL ) ) {
-			$input['cdn_url'] = isset( $old_options['cdn_url'] ) ? $old_options['cdn_url'] : WPA0_LOCK_CDN_URL;
-			self::add_validation_error( __( 'The Lock JS CDN URL used is not a valid URL.', 'wp-auth0' ) );
-		}
-
 		$input['migration_ips_filter'] = ( ! empty( $input['migration_ips_filter'] ) ? 1 : 0 );
 
 		$input['valid_proxy_ip'] = ( isset( $input['valid_proxy_ip'] ) ? $input['valid_proxy_ip'] : null );

--- a/lib/admin/WP_Auth0_Admin_Appearance.php
+++ b/lib/admin/WP_Auth0_Admin_Appearance.php
@@ -165,7 +165,7 @@ class WP_Auth0_Admin_Appearance extends WP_Auth0_Admin_Generic {
 	 * @see add_settings_field()
 	 */
 	public function render_cdn_url( $args = array() ) {
-		$this->render_text_field( $args['label_for'], $args['opt_name'], 'url' );
+		$this->render_text_field( $args['label_for'], $args['opt_name'] );
 		$this->render_field_description(
 			__( 'This should point to the latest Lock JS available in the CDN and rarely needs to change', 'wp-auth0' )
 		);
@@ -482,6 +482,17 @@ class WP_Auth0_Admin_Appearance extends WP_Auth0_Admin_Generic {
 				$input['language_dictionary'] = isset( $old_options['language_dictionary'] ) ? $old_options['language_dictionary'] : '';
 			}
 		}
+
+		$input['custom_cdn_url'] = empty( $input['custom_cdn_url'] ) ? 0 : 1;
+
+		$input['cdn_url'] = empty( $input['cdn_url'] ) ? WPA0_LOCK_CDN_URL : sanitize_text_field( $input['cdn_url'] );
+
+		// If an invalid URL is used, default to previously saved (if there is one) or default URL.
+		if ( ! filter_var( $input['cdn_url'], FILTER_VALIDATE_URL ) ) {
+			$input['cdn_url'] = isset( $old_options['cdn_url'] ) ? $old_options['cdn_url'] : WPA0_LOCK_CDN_URL;
+			self::add_validation_error( __( 'The Lock JS CDN URL used is not a valid URL.', 'wp-auth0' ) );
+		}
+
 		return $input;
 	}
 

--- a/tests/testOptionLockCdn.php
+++ b/tests/testOptionLockCdn.php
@@ -27,7 +27,7 @@ class TestOptionLockCdn extends WP_Auth0_Test_Case {
 	 */
 	public static function setUpBeforeClass() {
 		parent::setUpBeforeClass();
-		self::$admin = new WP_Auth0_Admin_Advanced( self::$opts, new WP_Auth0_Routes( self::$opts ) );
+		self::$admin = new WP_Auth0_Admin_Appearance( self::$opts, new WP_Auth0_Routes( self::$opts ) );
 	}
 
 	/**
@@ -122,7 +122,7 @@ class TestOptionLockCdn extends WP_Auth0_Test_Case {
 		);
 
 		// Input should be a checkbox.
-		$this->assertEquals( 'url', $input->item( 0 )->getAttribute( 'type' ) );
+		$this->assertEquals( 'text', $input->item( 0 )->getAttribute( 'type' ) );
 
 		// Check that saving a custom domain appears in the field value.
 		self::$opts->set( $field_args['opt_name'], 'https://auth0.com' );


### PR DESCRIPTION
### Changes

Fixed an issue where the CDN URL is validated while being hidden, causing the settings page to fail while saving silently.

### References

Internal support request.

### Testing

* [x] This change adds unit test coverage
* [x] This change has been tested on WP 5.2.2

### Checklist

* [x] All existing and new tests complete without errors
* [x] All code quality tools/guidelines in the [Contribution guide](CONTRIBUTION.md) have been run/followed
* [x] All active GitHub CI checks have passed
