### PR TITLE
Move WooCommerce hooks to global functions and remove init method

### DIFF
--- a/WP_Auth0.php
+++ b/WP_Auth0.php
@@ -144,9 +144,6 @@ class WP_Auth0 {
 		$configure_jwt_auth = new WP_Auth0_Configure_JWTAUTH( $this->a0_options );
 		$configure_jwt_auth->init();
 
-		$woocommerce_override = new WP_Auth0_WooCommerceOverrides( $this, $this->a0_options );
-		$woocommerce_override->init();
-
 		$users_exporter = new WP_Auth0_Export_Users( $this->db_manager );
 		$users_exporter->init();
 
@@ -657,6 +654,23 @@ function wp_auth0_filter_body_class( array $classes ) {
 }
 add_filter( 'body_class', 'wp_auth0_filter_body_class' );
 add_filter( 'login_body_class', 'wp_auth0_filter_body_class' );
+
+/*
+ * WooCommerce hooks
+ */
+function wp_auth0_filter_woocommerce_checkout_login_message( $html ) {
+	$wp_auth0_opts        = WP_Auth0_Options::Instance();
+	$wp_auth0_woocommerce = new WP_Auth0_WooCommerceOverrides( new WP_Auth0( $wp_auth0_opts ), $wp_auth0_opts );
+	$wp_auth0_woocommerce->override_woocommerce_checkout_login_form( $html );
+}
+add_filter( 'woocommerce_checkout_login_message', 'wp_auth0_filter_woocommerce_checkout_login_message' );
+
+function wp_auth0_filter_woocommerce_before_customer_login_form( $html ) {
+	$wp_auth0_opts        = WP_Auth0_Options::Instance();
+	$wp_auth0_woocommerce = new WP_Auth0_WooCommerceOverrides( new WP_Auth0( $wp_auth0_opts ), $wp_auth0_opts );
+	$wp_auth0_woocommerce->override_woocommerce_login_form( $html );
+}
+add_filter( 'woocommerce_before_customer_login_form', 'wp_auth0_filter_woocommerce_before_customer_login_form' );
 
 /*
  * Beta plugin deactivation

--- a/WP_Auth0.php
+++ b/WP_Auth0.php
@@ -658,17 +658,32 @@ add_filter( 'login_body_class', 'wp_auth0_filter_body_class' );
 /*
  * WooCommerce hooks
  */
+
+/**
+ * Add the Auth0 login form to the checkout page.
+ *
+ * @param string $html - Original HTML passed to this hook.
+ *
+ * @return mixed
+ */
 function wp_auth0_filter_woocommerce_checkout_login_message( $html ) {
 	$wp_auth0_opts        = WP_Auth0_Options::Instance();
 	$wp_auth0_woocommerce = new WP_Auth0_WooCommerceOverrides( new WP_Auth0( $wp_auth0_opts ), $wp_auth0_opts );
-	$wp_auth0_woocommerce->override_woocommerce_checkout_login_form( $html );
+	return $wp_auth0_woocommerce->override_woocommerce_checkout_login_form( $html );
 }
 add_filter( 'woocommerce_checkout_login_message', 'wp_auth0_filter_woocommerce_checkout_login_message' );
 
+/**
+ * Add the Auth0 login form to the account page.
+ *
+ * @param string $html - Original HTML passed to this hook.
+ *
+ * @return mixed
+ */
 function wp_auth0_filter_woocommerce_before_customer_login_form( $html ) {
 	$wp_auth0_opts        = WP_Auth0_Options::Instance();
 	$wp_auth0_woocommerce = new WP_Auth0_WooCommerceOverrides( new WP_Auth0( $wp_auth0_opts ), $wp_auth0_opts );
-	$wp_auth0_woocommerce->override_woocommerce_login_form( $html );
+	return $wp_auth0_woocommerce->override_woocommerce_login_form( $html );
 }
 add_filter( 'woocommerce_before_customer_login_form', 'wp_auth0_filter_woocommerce_before_customer_login_form' );
 

--- a/lib/WP_Auth0_WooCommerceOverrides.php
+++ b/lib/WP_Auth0_WooCommerceOverrides.php
@@ -1,48 +1,73 @@
 <?php
+/**
+ * Contains Class WP_Auth0_WooCommerceOverrides class.
+ *
+ * @package WP-Auth0
+ *
+ * @since 2.0.0
+ */
 
+/**
+ * Class WP_Auth0_WooCommerceOverrides.
+ */
 class WP_Auth0_WooCommerceOverrides {
+
+	/**
+	 * Injected WP_Auth0 instance.
+	 *
+	 * @var WP_Auth0
+	 */
 	protected $plugin;
+
+	/**
+	 * Injected WP_Auth0_Options instance.
+	 *
+	 * @var WP_Auth0_Options
+	 */
 	protected $options;
 
 	/**
 	 * WP_Auth0_WooCommerceOverrides constructor.
 	 *
-	 * @param WP_Auth0              $plugin
-	 * @param null|WP_Auth0_Options $options
+	 * @param WP_Auth0         $plugin - WP_Auth0 instance.
+	 * @param WP_Auth0_Options $options - WP_Auth0_Options instance.
 	 */
-	public function __construct( WP_Auth0 $plugin, $options = null ) {
-		$this->plugin = $plugin;
-		if ( $options == null ) {
-			$this->options = \WP_Auth0_Options::Instance();
-		} else {
-			$this->options = $options;
-		}
+	public function __construct( WP_Auth0 $plugin, WP_Auth0_Options $options ) {
+		$this->plugin  = $plugin;
+		$this->options = $options;
 	}
 
 	/**
-	 * @deprecated - 3.10.0, will move add_action calls out of this class in the next major.
+	 * Render the login form or link to ULP.
 	 *
-	 * @codeCoverageIgnore - Deprecated.
+	 * @param string $redirect_page - Page slug to redirect to after logging in.
 	 */
-	public function init() {
-		add_filter( 'woocommerce_checkout_login_message', [ $this, 'override_woocommerce_checkout_login_form' ] );
-		add_filter( 'woocommerce_before_customer_login_form', [ $this, 'override_woocommerce_login_form' ] );
-	}
-
-	private function render_login_form( $redirectPage ) {
+	private function render_login_form( $redirect_page ) {
 		$this->plugin->render_auth0_login_css();
 		if ( $this->options->get( 'auto_login', false ) ) {
-			// Redirecting to WordPress login area
-			$redirectUrl = get_permalink( wc_get_page_id( $redirectPage ) );
-			$loginUrl    = wp_login_url( $redirectUrl );
+			// Redirecting to WordPress login page.
+			$redirect_url = get_permalink( wc_get_page_id( $redirect_page ) );
+			$login_url    = wp_login_url( $redirect_url );
 
-			printf( "<a class='button' href='%s'>%s</a>", $loginUrl, __( 'Login', 'wp-auth0' ) );
+			printf( "<a class='button' href='%s'>%s</a>", $login_url, __( 'Login', 'wp-auth0' ) );
 		} else {
 			echo $this->plugin->render_form( '' );
 		}
 	}
 
+	/**
+	 * Handle Auth0 login on the checkout form if the plugin is ready.
+	 *
+	 * @param string $html - Original HTML passed to filter.
+	 *
+	 * @return mixed
+	 */
 	public function override_woocommerce_checkout_login_form( $html ) {
+
+		if ( ! WP_Auth0::ready() ) {
+			return $html;
+		}
+
 		$this->render_login_form( 'checkout' );
 
 		if ( wp_auth0_can_show_wp_login_form() ) {
@@ -50,7 +75,19 @@ class WP_Auth0_WooCommerceOverrides {
 		}
 	}
 
+	/**
+	 * Handle Auth0 login on the account form if the plugin is ready.
+	 *
+	 * @param $html string $html - Original HTML passed to filter.
+	 *
+	 * @return mixed
+	 */
 	public function override_woocommerce_login_form( $html ) {
+
+		if ( ! WP_Auth0::ready() ) {
+			return $html;
+		}
+
 		$this->render_login_form( 'myaccount' );
 	}
 }

--- a/tests/testWoocommerceOverrides.php
+++ b/tests/testWoocommerceOverrides.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * Contains Class TestWoocommerceOverrides.
+ *
+ * @package WP-Auth0
+ *
+ * @since 4.0.0
+ */
+
+/**
+ * Class TestWoocommerceOverrides.
+ * Tests the WP_Auth0_WooCommerceOverrides class.
+ */
+class TestWoocommerceOverrides extends WP_Auth0_Test_Case {
+
+	use HookHelpers;
+
+	public function testThatWooCheckoutHookIsSet() {
+		$expect_hooked = [
+			'wp_auth0_filter_woocommerce_checkout_login_message' => [
+				'priority'      => 10,
+				'accepted_args' => 1,
+			],
+		];
+		$this->assertHookedFunction( 'woocommerce_checkout_login_message', $expect_hooked );
+	}
+
+	public function testThatWooAccountHookIsSet() {
+		$expect_hooked = [
+			'wp_auth0_filter_woocommerce_before_customer_login_form' => [
+				'priority'      => 10,
+				'accepted_args' => 1,
+			],
+		];
+		$this->assertHookedFunction( 'woocommerce_before_customer_login_form', $expect_hooked );
+	}
+
+	public function testThatUnchangedHtmlIsReturnedFromCheckoutHookIfPluginNotReady() {
+		$returned = wp_auth0_filter_woocommerce_checkout_login_message( '__original_text__' );
+		$this->assertEquals( '__original_text__', $returned );
+	}
+
+	public function testThatUnchangedHtmlIsReturnedFromAccountHookIfPluginNotReady() {
+		$returned = wp_auth0_filter_woocommerce_before_customer_login_form( '__original_text__' );
+		$this->assertEquals( '__original_text__', $returned );
+	}
+}


### PR DESCRIPTION
### Changes

**This is a potential (though unlikely) breaking change for developers!** 

- **BREAKING:** Remove deprecated `\WP_Auth0_WooCommerceOverrides:: init()` method
- **BREAKING:** Enforce `WP_Auth0_WooCommerceOverrides` constructor accepts a `WP_Auth0_Options` instance
- Switch `woocommerce_checkout_login_message` hooked function from `\WP_Auth0_WooCommerceOverrides::override_woocommerce_checkout_login_form()` to new `wp_auth0_filter_woocommerce_checkout_login_message()`
- Switch `woocommerce_before_customer_login_form ` hooked function from `\WP_Auth0_WooCommerceOverrides::override_woocommerce_login_form()` to new `wp_auth0_filter_woocommerce_before_customer_login_form()`
- Add a check for plugin readiness

### Checklist

* [x] All existing and new tests complete without errors
* [x] All code quality tools/guidelines in the [Contribution guide](CONTRIBUTION.md) have been run/followed
* [x] All active GitHub CI checks have passed
