### PR TITLE
Add check for GET and POST globals for state validation

### DIFF
--- a/lib/WP_Auth0_LoginManager.php
+++ b/lib/WP_Auth0_LoginManager.php
@@ -625,7 +625,7 @@ class WP_Auth0_LoginManager {
 	}
 
 	/**
-	 * Get a value from query_vars or $_REQUEST global.
+	 * Get a value from query_vars or request global.
 	 *
 	 * @param string $key - query var key to return.
 	 *

--- a/lib/WP_Auth0_LoginManager.php
+++ b/lib/WP_Auth0_LoginManager.php
@@ -175,7 +175,7 @@ class WP_Auth0_LoginManager {
 
 		// Check for valid state nonce, set in WP_Auth0_Lock10_Options::get_state_obj().
 		// See https://auth0.com/docs/protocols/oauth2/oauth-state for more info.
-		$state_returned = isset( $_REQUEST['state'] ) ? rawurldecode( $_REQUEST['state'] ) : null;
+		$state_returned = $this->query_vars( 'state' );
 		if ( ! $state_returned || ! WP_Auth0_State_Handler::get_instance()->validate( $state_returned ) ) {
 			$this->die_on_login( __( 'Invalid state', 'wp-auth0' ) );
 		}
@@ -638,6 +638,12 @@ class WP_Auth0_LoginManager {
 		}
 		if ( isset( $_REQUEST[ $key ] ) ) {
 			return $_REQUEST[ $key ];
+		}
+		if ( isset( $_GET[ $key ] ) ) {
+			return $_GET[ $key ];
+		}
+		if ( isset( $_POST[ $key ] ) ) {
+			return $_POST[ $key ];
 		}
 		return null;
 	}

--- a/tests/testLoginManagerInitAuth0.php
+++ b/tests/testLoginManagerInitAuth0.php
@@ -110,6 +110,51 @@ class TestLoginManagerInitAuth0 extends WP_Auth0_Test_Case {
 		$this->assertContains( '<a href="https://test.auth0.com/v2/logout?client_id=__test_client_id__', $output );
 	}
 
+	public function testThatQueryVarIsFound() {
+		self::auth0Ready();
+		set_query_var( 'auth0', 1 );
+
+		$output = '';
+		try {
+			$this->login->init_auth0();
+		} catch ( Exception $e ) {
+			$output = $e->getMessage();
+		}
+
+		// This error means that the callback was triggered, which is what we are testing for.
+		$this->assertContains( 'There was a problem with your log in: Invalid state', $output );
+	}
+
+	public function testThatGetVarIsFound() {
+		self::auth0Ready();
+		$_GET['auth0'] = 1;
+
+		$output = '';
+		try {
+			$this->login->init_auth0();
+		} catch ( Exception $e ) {
+			$output = $e->getMessage();
+		}
+
+		// This error means that the callback was triggered, which is what we are testing for.
+		$this->assertContains( 'There was a problem with your log in: Invalid state', $output );
+	}
+
+	public function testThatPostVarIsFound() {
+		self::auth0Ready();
+		$_POST['auth0'] = 1;
+
+		$output = '';
+		try {
+			$this->login->init_auth0();
+		} catch ( Exception $e ) {
+			$output = $e->getMessage();
+		}
+
+		// This error means that the callback was triggered, which is what we are testing for.
+		$this->assertContains( 'There was a problem with your log in: Invalid state', $output );
+	}
+
 	/**
 	 * Test that an error in the URL parameter logs the current user out.
 	 */


### PR DESCRIPTION
### Changes

Add checking for state in other PHP globals in case `$_REQUEST` is not set.

### Testing

* [ ] This change adds unit test coverage
* [x] This change has been tested on WP 5.2.2

### Checklist

* [x] All existing and new tests complete without errors
* [x] All code quality tools/guidelines in the [Contribution guide](CONTRIBUTION.md) have been run/followed
* [x] All active GitHub CI checks have passed
