### PR TITLE
Update auth params method to add filters

### DIFF
--- a/tests/testLoginManager.php
+++ b/tests/testLoginManager.php
@@ -47,49 +47,6 @@ class TestLoginManager extends WP_Auth0_Test_Case {
 	}
 
 	/**
-	 * Test that authorize URL params are built and filtered properly.
-	 */
-	public function testAuthorizeParams() {
-		$test_client_id  = uniqid();
-		$test_connection = uniqid();
-		$auth_params     = WP_Auth0_LoginManager::get_authorize_params();
-
-		$this->assertEquals( 'openid email profile', $auth_params['scope'] );
-		$this->assertEquals( 'code', $auth_params['response_type'] );
-		$this->assertEquals( site_url( 'index.php?auth0=1' ), $auth_params['redirect_uri'] );
-		$this->assertArrayNotHasKey( 'auth0Client', $auth_params );
-		$this->assertNotEmpty( $auth_params['state'] );
-
-		$auth_params = WP_Auth0_LoginManager::get_authorize_params( $test_connection );
-		$this->assertEquals( $test_connection, $auth_params['connection'] );
-
-		self::$opts->set( 'client_id', $test_client_id );
-
-		$auth_params = WP_Auth0_LoginManager::get_authorize_params();
-		$this->assertEquals( $test_client_id, $auth_params['client_id'] );
-
-		self::$opts->set( 'auth0_implicit_workflow', 1 );
-		$auth_params = WP_Auth0_LoginManager::get_authorize_params();
-		$this->assertEquals( add_query_arg( 'auth0', 'implicit', site_url( 'index.php' ) ), $auth_params['redirect_uri'] );
-		$this->assertEquals( 'id_token', $auth_params['response_type'] );
-		$this->assertNotEmpty( $auth_params['nonce'] );
-		$this->assertEquals( 'form_post', $auth_params['response_mode'] );
-
-		add_filter(
-			'auth0_authorize_url_params',
-			function( $params, $connection, $redirect_to ) {
-				$params[ $connection ] = $redirect_to;
-				return $params;
-			},
-			10,
-			3
-		);
-
-		$auth_params = WP_Auth0_LoginManager::get_authorize_params( 'auth0', 'https://auth0.com' );
-		$this->assertEquals( 'https://auth0.com', $auth_params['auth0'] );
-	}
-
-	/**
 	 * Test that the authorize URL is built properly.
 	 */
 	public function testBuildAuthorizeUrl() {

--- a/tests/testLoginManagerAuthParams.php
+++ b/tests/testLoginManagerAuthParams.php
@@ -1,0 +1,123 @@
+<?php
+/**
+ * Contains Class TestLoginManagerAuthParams.
+ *
+ * @package WP-Auth0
+ *
+ * @since 4.0.0
+ */
+
+/**
+ * Class TestLoginManagerAuthParams.
+ * Tests that the WP_Auth0_LoginManager:get_authorize_params() method functions as expected.
+ */
+class TestLoginManagerAuthParams extends WP_Auth0_Test_Case {
+
+	public function testThatDefaultAuthParamsAreCorrect() {
+		self::$opts->set( 'client_id', '__test_client_id_1__' );
+		$auth_params = WP_Auth0_LoginManager::get_authorize_params();
+
+		$this->assertEquals( '__test_client_id_1__', $auth_params['client_id'] );
+		$this->assertEquals( 'openid email profile', $auth_params['scope'] );
+		$this->assertEquals( 'code', $auth_params['response_type'] );
+		$this->assertEquals( 'query', $auth_params['response_mode'] );
+		$this->assertEquals( site_url( 'index.php?auth0=1' ), $auth_params['redirect_uri'] );
+		$this->assertArrayNotHasKey( 'auth0Client', $auth_params );
+
+		$decoded_state = json_decode( base64_decode( $auth_params['state'] ) );
+
+		$this->assertFalse( $decoded_state->interim );
+		$this->assertEquals( WP_Auth0_State_Handler::get_instance()->get_unique(), $decoded_state->nonce );
+		$this->assertEquals( 'http://example.org', $decoded_state->redirect_to );
+	}
+
+	public function testThatImplicitAuthParamsAreCorrect() {
+		self::$opts->set( 'client_id', '__test_client_id_2__' );
+		self::$opts->set( 'auth0_implicit_workflow', 1 );
+		$auth_params = WP_Auth0_LoginManager::get_authorize_params();
+
+		$this->assertEquals( '__test_client_id_2__', $auth_params['client_id'] );
+		$this->assertEquals( 'openid email profile', $auth_params['scope'] );
+		$this->assertEquals( 'id_token', $auth_params['response_type'] );
+		$this->assertEquals( 'form_post', $auth_params['response_mode'] );
+		$this->assertEquals( site_url( 'index.php?auth0=implicit' ), $auth_params['redirect_uri'] );
+		$this->assertEquals( WP_Auth0_Nonce_Handler::get_instance()->get_unique(), $auth_params['nonce'] );
+		$this->assertArrayNotHasKey( 'auth0Client', $auth_params );
+
+		$decoded_state = json_decode( base64_decode( $auth_params['state'] ) );
+
+		$this->assertFalse( $decoded_state->interim );
+		$this->assertEquals( WP_Auth0_State_Handler::get_instance()->get_unique(), $decoded_state->nonce );
+		$this->assertEquals( 'http://example.org', $decoded_state->redirect_to );
+	}
+
+	public function testThatRedirectInGetAppearsInState() {
+		$_GET['redirect_to'] = 'http://example.org/get-redirect';
+		$auth_params         = WP_Auth0_LoginManager::get_authorize_params();
+		$decoded_state       = json_decode( base64_decode( $auth_params['state'] ) );
+		$this->assertEquals( 'http://example.org/get-redirect', $decoded_state->redirect_to );
+	}
+
+	public function testThatConnectionPassedAppearsInParams() {
+		$auth_params = WP_Auth0_LoginManager::get_authorize_params( '__test_connection__' );
+		$this->assertEquals( '__test_connection__', $auth_params['connection'] );
+	}
+
+	public function testThatRedirectPassedAppearsInState() {
+		$auth_params   = WP_Auth0_LoginManager::get_authorize_params( null, 'http://example.org/param-redirect' );
+		$decoded_state = json_decode( base64_decode( $auth_params['state'] ) );
+		$this->assertEquals( 'http://example.org/param-redirect', $decoded_state->redirect_to );
+	}
+
+	public function testThatParamFilterIsApplied() {
+		add_filter( 'auth0_authorize_url_params', [ $this, 'filter_auth_parms' ], 10, 3 );
+
+		$auth_params = WP_Auth0_LoginManager::get_authorize_params( 'auth0', 'https://auth0.com' );
+
+		$this->assertEquals( 'https://auth0.com', $auth_params['auth0'] );
+		$this->assertEquals( 'id_token code', $auth_params['response_type'] );
+
+		remove_filter( 'auth0_authorize_url_params', [ $this, 'filter_auth_parms' ], 10 );
+	}
+
+	public function testThatStateFilterIsApplied() {
+		add_filter( 'auth0_authorize_state', [ $this, 'filter_state_parms' ], 10, 2 );
+
+		$auth_params   = WP_Auth0_LoginManager::get_authorize_params();
+		$decoded_state = json_decode( base64_decode( $auth_params['state'] ) );
+
+		$this->assertEquals( '__test_param_value__', $decoded_state->some_state_prop );
+		$this->assertEquals( 'code', $decoded_state->response_type_repeat );
+
+		remove_filter( 'auth0_authorize_state', [ $this, 'filter_state_parms' ], 10 );
+	}
+
+	/**
+	 * Helper method to filter the auth params for testing.
+	 *
+	 * @param array       $params - Existing params.
+	 * @param string|null $connection - Connection param value, if any.
+	 * @param string      $redirect_to - Redirect value added to state.
+	 *
+	 * @return array
+	 */
+	public function filter_auth_parms( $params, $connection, $redirect_to ) {
+		$params[ $connection ]   = $redirect_to;
+		$params['response_type'] = 'id_token code';
+		return $params;
+	}
+
+	/**
+	 * Helper method to filter the state params for testing.
+	 *
+	 * @param array $state - Existing state properties.
+	 * @param array $filtered_params - Existing auth params.
+	 *
+	 * @return array
+	 */
+	public function filter_state_parms( $state, $filtered_params ) {
+		$state['some_state_prop']      = '__test_param_value__';
+		$state['response_type_repeat'] = $filtered_params['response_type'];
+		return $state;
+	}
+}


### PR DESCRIPTION
### Changes

- Move filter `auth0_authorize_url_params` before state is generated and decoded
- Add filter `auth0_authorize_state` to modify state contents before decoding

### Testing

* [x] This change adds unit test coverage
* [x] This change has been tested on WP 5.2.2

### Checklist

* [x] All existing and new tests complete without errors
* [x] All code quality tools/guidelines in the [Contribution guide](CONTRIBUTION.md) have been run/followed
* [x] All active GitHub CI checks have passed
