### PR TITLE
Add wpa0_user_data filter before creating WP_User

### DIFF
--- a/lib/WP_Auth0_Users.php
+++ b/lib/WP_Auth0_Users.php
@@ -84,7 +84,7 @@ class WP_Auth0_Users {
 			'description'  => $description,
 		];
 
-		$user_data = apply_filters( 'wpa0_user_data', $user_data, $userinfo, $firstname, $lastname );
+		$user_data = apply_filters( 'auth0_create_user_data', $user_data, $userinfo );
 
 		if ( $role ) {
 			// phpcs:ignore

--- a/lib/WP_Auth0_Users.php
+++ b/lib/WP_Auth0_Users.php
@@ -84,6 +84,8 @@ class WP_Auth0_Users {
 			'description'  => $description,
 		];
 
+		$user_data = apply_filters( 'wpa0_user_data', $user_data, $userinfo, $firstname, $lastname );
+
 		if ( $role ) {
 			// phpcs:ignore
 			@trigger_error( sprintf( __( '$role parameter is deprecated.', 'wp-auth0' ), __METHOD__ ), E_USER_DEPRECATED );


### PR DESCRIPTION
### Changes

Add filter `wpa0_user_data`  to allow customizing user data before creating WP_User because I would like to separate `display_name` from `username`. The current implementation hardcodes the WordPress `user_login` and `display_name` to come from the Auth0 `username`. However, in many cases, those are separated based on naming style in Japan.

### References

There is no reference. only this PR.

### Testing

* [x] I included manual testing steps above, if applicable
* [x] This change adds unit test coverage
* [x] This change has been tested on the latest version of the platform/language or why not

### Checklist

* [x] I read [Auth0's general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)?
* [x] I read [Auth0's code of conduct guidelines](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
* [x] All existing and new tests complete without errors
* [x] All code quality tools/guidelines in the [Contribution guide](CONTRIBUTION.md) have been run/followed
* [x] All relevant assets have been compiled as directed in the [Contribution guide](CONTRIBUTION.md), if applicable
* [ ] All active GitHub CI checks have passed
