### PR TITLE
Update minimum PHP to 7.0 and WP to 4.9

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,6 +42,7 @@ commands:
             composer phpcbf-tests
             composer phpcs-tests
             composer phpcs-i18n
+            composer compat
   run-tests:
     steps:
       - run:
@@ -52,17 +53,6 @@ commands:
       - run: composer test-ci
 
 jobs:
-  php_5:
-    docker:
-      - image: circleci/php:5.6
-      - image: circleci/mysql:5.6
-        environment:
-          MYSQL_ALLOW_EMPTY_PASSWORD: true
-    steps:
-      - prepare
-      - run-tests
-      - run:
-          command: composer compat
   php_7:
     docker:
       - image: circleci/php:7.1
@@ -93,9 +83,6 @@ jobs:
 
 #Each workflow represents a Github check
 workflows:
-  build_php_5:
-    jobs:
-      - php_5
   build_php_7:
     jobs:
       - php_7

--- a/bin/install-wp-tests.sh
+++ b/bin/install-wp-tests.sh
@@ -15,7 +15,7 @@ SKIP_DB_CREATE=${6-false}
 TMPDIR=${TMPDIR-/tmp}
 TMPDIR=$(echo $TMPDIR | sed -e "s/\/$//")
 WP_TESTS_DIR=${WP_TESTS_DIR-$TMPDIR/wordpress-tests-lib}
-WP_CORE_DIR=${WP_CORE_DIR-$TMPDIR/wordpress}
+WP_CORE_DIR=${WP_CORE_DIR-$TMPDIR/wordpress/}
 
 download() {
     if [ `which curl` ]; then
@@ -104,12 +104,18 @@ install_test_suite() {
 	if [ ! -d $WP_TESTS_DIR ]; then
 		# set up testing suite
 		mkdir -p $WP_TESTS_DIR
-		svn co --quiet https://develop.svn.wordpress.org/${WP_TESTS_TAG}/tests/phpunit/includes/ $WP_TESTS_DIR/includes
-		svn co --quiet https://develop.svn.wordpress.org/${WP_TESTS_TAG}/tests/phpunit/data/ $WP_TESTS_DIR/data
+		echo "Starting svn for tests/phpunit/includes"
+		svn co --quiet https://develop.svn.wordpress.org/${WP_TESTS_TAG}/tests/phpunit/includes/ $WP_TESTS_DIR/includes --ignore-externals
+		echo "Finished svn for tests/phpunit/includes"
+		echo "Starting svn for tests/phpunit/data"
+		svn co --quiet https://develop.svn.wordpress.org/${WP_TESTS_TAG}/tests/phpunit/data/ $WP_TESTS_DIR/data --ignore-externals
+		echo "Finished svn for tests/phpunit/data"
 	fi
 
 	if [ ! -f wp-tests-config.php ]; then
+	    echo "Starting download for wp-tests-config-sample.php"
 		download https://develop.svn.wordpress.org/${WP_TESTS_TAG}/wp-tests-config-sample.php "$WP_TESTS_DIR"/wp-tests-config.php
+		echo "Finished download for wp-tests-config-sample.php"
 		# remove all forward slashes in the end
 		WP_CORE_DIR=$(echo $WP_CORE_DIR | sed "s:/\+$::")
 		sed $ioption "s:dirname( __FILE__ ) . '/src/':'$WP_CORE_DIR/':" "$WP_TESTS_DIR"/wp-tests-config.php

--- a/composer.json
+++ b/composer.json
@@ -4,13 +4,13 @@
     "homepage": "https://auth0.com/wordpress",
     "license": "GPLv2",
     "require": {
-        "php": "^5.6 || ^7.0"
+        "php": "^7.0"
     },
     "require-dev": {
         "dealerdirect/phpcodesniffer-composer-installer": "^0.5",
         "wp-coding-standards/wpcs": "^1",
         "phpcompatibility/phpcompatibility-wp": "*",
-        "phpunit/phpunit": "^5.0 || ^6.0"
+        "phpunit/phpunit": "^6.0"
     },
     "authors": [
         {

--- a/lib/WP_Auth0_Nonce_Handler.php
+++ b/lib/WP_Auth0_Nonce_Handler.php
@@ -139,8 +139,7 @@ class WP_Auth0_Nonce_Handler {
 	}
 
 	/**
-	 * Generate a unique value to use.
-	 * If using on PHP 7, it will be cryptographically secure.
+	 * Generate a cryptographically secure unique value to use.
 	 *
 	 * @see https://secure.php.net/manual/en/function.random-bytes.php
 	 *
@@ -149,11 +148,7 @@ class WP_Auth0_Nonce_Handler {
 	 * @return string
 	 */
 	public function generate_unique( $bytes = 32 ) {
-		$nonce_bytes = function_exists( 'random_bytes' )
-			// phpcs:ignore
-			? random_bytes( $bytes )
-			: openssl_random_pseudo_bytes( $bytes );
-		return bin2hex( $nonce_bytes );
+		return bin2hex( random_bytes( $bytes ) );
 	}
 
 	/**

--- a/lib/api/WP_Auth0_Api_Refresh_Access_Token.php
+++ b/lib/api/WP_Auth0_Api_Refresh_Access_Token.php
@@ -31,7 +31,7 @@ class WP_Auth0_Api_Refresh_Access_Token extends WP_Auth0_Api_Abstract {
 	 * @return null|string
 	 */
 	public function call( $client_id = null, $client_secret = null, $refresh_token = null ) {
-		
+
 		if ( empty( $refresh_token ) ) {
 			return self::RETURN_ON_FAILURE;
 		}

--- a/phpcs-compat-ruleset.xml
+++ b/phpcs-compat-ruleset.xml
@@ -20,8 +20,8 @@
     <!-- Show coloured output, if available. -->
     <arg name="colors"/>
 
-    <config name="testVersion" value="5.6-"/>
-    <config name="minimum_supported_wp_version" value="3.8"/>
+    <config name="testVersion" value="7.0-"/>
+    <config name="minimum_supported_wp_version" value="4.9"/>
 
     <rule ref="PHPCompatibility"/>
 </ruleset>

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -29,8 +29,8 @@
     PHPCompatibility sniffs to check for PHP cross-version incompatible code.
     https://github.com/PHPCompatibility/PHPCompatibility
     -->
-    <config name="testVersion" value="5.6-"/>
-    <config name="minimum_supported_wp_version" value="3.8"/>
+    <config name="testVersion" value="7.0-"/>
+    <config name="minimum_supported_wp_version" value="4.9"/>
     <rule ref="PHPCompatibilityWP"/>
 
     <rule ref="Generic.CodeAnalysis">

--- a/readme.txt
+++ b/readme.txt
@@ -1,8 +1,8 @@
 === Login by Auth0 ===
 Tags: login, oauth, authentication, single sign on, ldap, active directory, saml, windows azure ad, google apps, two factor, two-factor, facebook, google, twitter, baidu, renren, linkedin, github, paypal, yahoo, amazon, vkontakte, salesforce, box, dwolla, yammer, passwordless, sms, magiclink, totp, social
 Tested up to: 5.2.2
-Requires at least: 3.8
-Requires PHP: 5.6
+Requires at least: 4.9
+Requires PHP: 7.0
 License: GPLv2
 License URI: https://github.com/auth0/wp-auth0/blob/master/LICENSE
 Stable tag: trunk


### PR DESCRIPTION
### Changes

Update minimum PHP version to 7.0

### Testing

* [x] This change has been tested on WP version 5.2.2

### Checklist

* [x] All existing and new tests complete without errors
* [x] All code quality tools/guidelines in the [Contribution guide](CONTRIBUTION.md) have been run/followed
* [x] All active GitHub CI checks have passed
