### PR TITLE
Remove implicit login flow

### DIFF
--- a/lib/WP_Auth0_Api_Client.php
+++ b/lib/WP_Auth0_Api_Client.php
@@ -173,7 +173,7 @@ class WP_Auth0_Api_Client {
 			'name'                => $name,
 			'app_type'            => 'regular_web',
 
-			// Callback URLs for Auth Code and Hybrid/Implicit
+			// Callback URL to process login
 			'callbacks'           => [
 				$options->get_wp_auth0_url(),
 			],
@@ -455,7 +455,6 @@ class WP_Auth0_Api_Client {
 
 		return [
 			'authorization_code',
-			'implicit',
 			'refresh_token',
 			'client_credentials',
 		];

--- a/lib/WP_Auth0_DBManager.php
+++ b/lib/WP_Auth0_DBManager.php
@@ -196,6 +196,7 @@ class WP_Auth0_DBManager {
 			$options->remove( 'link_auth0_users' );
 			$options->remove( 'custom_css' );
 			$options->remove( 'custom_js' );
+			$options->remove( 'auth0_implicit_workflow' );
 		}
 
 		$options->update_all();

--- a/lib/WP_Auth0_Lock10_Options.php
+++ b/lib/WP_Auth0_Lock10_Options.php
@@ -19,13 +19,6 @@ class WP_Auth0_Lock10_Options {
 		$this->extended_settings = $extended_settings;
 	}
 
-	public function get_code_callback_url() {
-		return $this->wp_options->get_wp_auth0_url( $this->get_callback_protocol() );
-	}
-
-	public function get_implicit_callback_url() {
-		return $this->wp_options->get_wp_auth0_url( $this->get_callback_protocol(), true );
-	}
 	/**
 	 * @deprecated - 3.10.0, not used.
 	 *
@@ -39,10 +32,6 @@ class WP_Auth0_Lock10_Options {
 
 	public function get_domain() {
 		return $this->wp_options->get_auth_domain();
-	}
-
-	public function get_auth0_implicit_workflow() {
-		return $this->_get_boolean( $this->wp_options->get( 'auth0_implicit_workflow' ) );
 	}
 
 	public function is_registration_enabled() {
@@ -151,16 +140,9 @@ class WP_Auth0_Lock10_Options {
 			],
 		];
 
-		if ( $this->get_auth0_implicit_workflow() ) {
-			$extraOptions['auth']['responseType']    = 'id_token';
-			$extraOptions['auth']['responseMode']    = 'form_post';
-			$extraOptions['auth']['redirectUrl']     = $this->get_implicit_callback_url();
-			$extraOptions['autoParseHash']           = false;
-			$extraOptions['auth']['params']['nonce'] = WP_Auth0_Nonce_Handler::get_instance()->get_unique();
-		} else {
-			$extraOptions['auth']['responseType'] = 'code';
-			$extraOptions['auth']['redirectUrl']  = $this->get_code_callback_url();
-		}
+		$extraOptions['auth']['params']['nonce'] = WP_Auth0_Nonce_Handler::get_instance()->get_unique();
+		$extraOptions['auth']['responseType']    = 'code';
+		$extraOptions['auth']['redirectUrl']     = $this->wp_options->get_wp_auth0_url( $this->get_callback_protocol() );
 
 		if ( $this->wp_options->get( 'custom_domain' ) ) {
 			$tenant_region                        = WP_Auth0::get_tenant_region( $this->wp_options->get( 'domain' ) );

--- a/lib/WP_Auth0_Options.php
+++ b/lib/WP_Auth0_Options.php
@@ -89,13 +89,12 @@ class WP_Auth0_Options extends WP_Auth0_Options_Generic {
 	 * Get the main site URL for Auth0 processing
 	 *
 	 * @param string|null $protocol - forced URL protocol, use default if empty
-	 * @param bool        $implicit - use the implicit flow in the callback
 	 *
 	 * @return string
 	 */
-	public function get_wp_auth0_url( $protocol = null, $implicit = false ) {
+	public function get_wp_auth0_url( $protocol = null ) {
 		$site_url = site_url( 'index.php', $protocol );
-		return add_query_arg( 'auth0', ( $implicit ? 'implicit' : '1' ), $site_url );
+		return add_query_arg( 'auth0', 1, $site_url );
 	}
 
 	/**
@@ -254,7 +253,6 @@ class WP_Auth0_Options extends WP_Auth0_Options_Generic {
 			'migration_token'           => null,
 			'migration_ips_filter'      => false,
 			'migration_ips'             => null,
-			'auth0_implicit_workflow'   => false,
 			'valid_proxy_ip'            => null,
 			'auth0_server_domain'       => 'auth0.auth0.com',
 		];

--- a/lib/admin/WP_Auth0_Admin_Advanced.php
+++ b/lib/admin/WP_Auth0_Admin_Advanced.php
@@ -111,12 +111,6 @@ class WP_Auth0_Admin_Advanced extends WP_Auth0_Admin_Generic {
 				'function' => 'render_auto_login',
 			],
 			[
-				'name'     => __( 'Implicit Login Flow', 'wp-auth0' ),
-				'opt'      => 'auth0_implicit_workflow',
-				'id'       => 'wpa0_auth0_implicit_workflow',
-				'function' => 'render_auth0_implicit_workflow',
-			],
-			[
 				'name'     => __( 'Valid Proxy IP', 'wp-auth0' ),
 				'opt'      => 'valid_proxy_ip',
 				'id'       => 'wpa0_valid_proxy_ip',
@@ -336,24 +330,6 @@ class WP_Auth0_Admin_Advanced extends WP_Auth0_Admin_Generic {
 	}
 
 	/**
-	 * Render form field and description for the `auth0_implicit_workflow` option.
-	 * IMPORTANT: Internal callback use only, do not call this function directly!
-	 *
-	 * @param array $args - callback args passed in from add_settings_field().
-	 *
-	 * @see WP_Auth0_Admin_Generic::init_option_section()
-	 * @see add_settings_field()
-	 */
-	public function render_auth0_implicit_workflow( $args = [] ) {
-		$this->render_switch( $args['label_for'], $args['opt_name'] );
-		$this->render_field_description(
-			__( 'Turns on implicit login flow, which most sites will not need. ', 'wp-auth0' ) .
-			__( 'Only enable this if outbound connections to auth0.com are disabled on your server. ', 'wp-auth0' ) .
-			__( 'This will limit profile changes and other functionality in the plugin', 'wp-auth0' )
-		);
-	}
-
-	/**
 	 * Render form field and description for the `valid_proxy_ip` option.
 	 * IMPORTANT: Internal callback use only, do not call this function directly!
 	 *
@@ -399,11 +375,10 @@ class WP_Auth0_Admin_Advanced extends WP_Auth0_Admin_Generic {
 		$input['skip_strategies'] = isset( $input['skip_strategies'] ) ?
 			sanitize_text_field( trim( $input['skip_strategies'] ) ) : '';
 
-		$input['auto_provisioning']       = ( isset( $input['auto_provisioning'] ) ? $input['auto_provisioning'] : 0 );
-		$input['remember_users_session']  = ( isset( $input['remember_users_session'] ) ? $input['remember_users_session'] : 0 ) == 1;
-		$input['passwordless_enabled']    = ( isset( $input['passwordless_enabled'] ) ? $input['passwordless_enabled'] : 0 ) == 1;
-		$input['auth0_implicit_workflow'] = ( isset( $input['auth0_implicit_workflow'] ) ? $input['auth0_implicit_workflow'] : 0 );
-		$input['force_https_callback']    = ( isset( $input['force_https_callback'] ) ? $input['force_https_callback'] : 0 );
+		$input['auto_provisioning']      = ( isset( $input['auto_provisioning'] ) ? $input['auto_provisioning'] : 0 );
+		$input['remember_users_session'] = ( isset( $input['remember_users_session'] ) ? $input['remember_users_session'] : 0 ) == 1;
+		$input['passwordless_enabled']   = ( isset( $input['passwordless_enabled'] ) ? $input['passwordless_enabled'] : 0 ) == 1;
+		$input['force_https_callback']   = ( isset( $input['force_https_callback'] ) ? $input['force_https_callback'] : 0 );
 
 		$input['migration_ips_filter'] = ( ! empty( $input['migration_ips_filter'] ) ? 1 : 0 );
 

--- a/tests/testApiClient.php
+++ b/tests/testApiClient.php
@@ -20,9 +20,8 @@ class TestApiClient extends WP_Auth0_Test_Case {
 	 */
 	public function testThatGrantTypesAreCorrect() {
 		$grant_types = WP_Auth0_Api_Client::get_client_grant_types();
-		$this->assertCount( 4, $grant_types );
+		$this->assertCount( 3, $grant_types );
 		$this->assertContains( 'authorization_code', $grant_types );
-		$this->assertContains( 'implicit', $grant_types );
 		$this->assertContains( 'refresh_token', $grant_types );
 		$this->assertContains( 'client_credentials', $grant_types );
 	}

--- a/tests/testLockOptions.php
+++ b/tests/testLockOptions.php
@@ -38,22 +38,6 @@ class TestLockOptions extends WP_Auth0_Test_Case {
 	}
 
 	/**
-	 * Test that callback URLs are built properly
-	 */
-	public function testThatAuthCallbacksAreCorrect() {
-		$lock_options = new WP_Auth0_Lock10_Options( [], self::$opts );
-
-		$this->assertEquals( 'http://example.org/index.php?auth0=implicit', $lock_options->get_implicit_callback_url() );
-		$this->assertEquals( 'http://example.org/index.php?auth0=1', $lock_options->get_code_callback_url() );
-
-		self::$opts->set( 'force_https_callback', 1 );
-		$lock_options = new WP_Auth0_Lock10_Options( [], self::$opts );
-
-		$this->assertEquals( 'https://example.org/index.php?auth0=implicit', $lock_options->get_implicit_callback_url() );
-		$this->assertEquals( 'https://example.org/index.php?auth0=1', $lock_options->get_code_callback_url() );
-	}
-
-	/**
 	 * Test that the social_big_buttons option is not used.
 	 */
 	public function testThatSocialButtonStyleStaysBig() {

--- a/tests/testLoginManagerAuthParams.php
+++ b/tests/testLoginManagerAuthParams.php
@@ -32,26 +32,6 @@ class TestLoginManagerAuthParams extends WP_Auth0_Test_Case {
 		$this->assertEquals( 'http://example.org', $decoded_state->redirect_to );
 	}
 
-	public function testThatImplicitAuthParamsAreCorrect() {
-		self::$opts->set( 'client_id', '__test_client_id_2__' );
-		self::$opts->set( 'auth0_implicit_workflow', 1 );
-		$auth_params = WP_Auth0_LoginManager::get_authorize_params();
-
-		$this->assertEquals( '__test_client_id_2__', $auth_params['client_id'] );
-		$this->assertEquals( 'openid email profile', $auth_params['scope'] );
-		$this->assertEquals( 'id_token', $auth_params['response_type'] );
-		$this->assertEquals( 'form_post', $auth_params['response_mode'] );
-		$this->assertEquals( site_url( 'index.php?auth0=implicit' ), $auth_params['redirect_uri'] );
-		$this->assertEquals( WP_Auth0_Nonce_Handler::get_instance()->get_unique(), $auth_params['nonce'] );
-		$this->assertArrayNotHasKey( 'auth0Client', $auth_params );
-
-		$decoded_state = json_decode( base64_decode( $auth_params['state'] ) );
-
-		$this->assertFalse( $decoded_state->interim );
-		$this->assertEquals( WP_Auth0_State_Handler::get_instance()->get_unique(), $decoded_state->nonce );
-		$this->assertEquals( 'http://example.org', $decoded_state->redirect_to );
-	}
-
 	public function testThatRedirectInGetAppearsInState() {
 		$_GET['redirect_to'] = 'http://example.org/get-redirect';
 		$auth_params         = WP_Auth0_LoginManager::get_authorize_params();

--- a/tests/testWPAuth0DbMigrations.php
+++ b/tests/testWPAuth0DbMigrations.php
@@ -173,11 +173,13 @@ class TestWPAuth0DbMigrations extends WP_Auth0_Test_Case {
 		self::$opts->set( 'link_auth0_users', 1 );
 		self::$opts->set( 'custom_css', '__test_css__' );
 		self::$opts->set( 'custom_js', '__test_js__' );
+		self::$opts->set( 'auth0_implicit_workflow', 1 );
 		$db_manager->install_db( $test_version );
 		$this->assertNull( self::$opts->get( 'jwt_auth_integration' ) );
 		$this->assertNull( self::$opts->get( 'link_auth0_users' ) );
 		$this->assertNull( self::$opts->get( 'custom_css' ) );
 		$this->assertNull( self::$opts->get( 'custom_js' ) );
+		$this->assertNull( self::$opts->get( 'auth0_implicit_workflow' ) );
 	}
 
 	/**

--- a/tests/testWPAuth0Options.php
+++ b/tests/testWPAuth0Options.php
@@ -20,7 +20,7 @@ class TestWPAuth0Options extends WP_Auth0_Test_Case {
 	/**
 	 * Total number of options.
 	 */
-	const DEFAULT_OPTIONS_COUNT = 40;
+	const DEFAULT_OPTIONS_COUNT = 39;
 
 	/**
 	 * Test the basic options functionality.


### PR DESCRIPTION
### Changes

Remove the Implicit Login Flow option. The plugin will switch to asking for a user-scoped Management API token in a future PR. 

**Removed the following public methods:**

- `WP_Auth0_Lock10_Options::get_code_callback_url()`
- `WP_Auth0_Lock10_Options::get_implicit_callback_url()`
- `WP_Auth0_Lock10_Options::get_auth0_implicit_workflow()`
- `WP_Auth0_Lock10_Options::get_auth0_implicit_workflow()`
- `WP_Auth0_LoginManager::implicit_login()`
- `WP_Auth0_Admin_Advanced::render_auth0_implicit_workflow()`

### Testing

* [x] This change adds unit test coverage
* [x] This change has been tested on WP 5.3

### Checklist

* [x] All existing and new tests complete without errors
* [x] All code quality tools/guidelines in the [Contribution guide](CONTRIBUTION.md) have been run/followed
* [x] All active GitHub CI checks have passed
