### PR TITLE
Remove client_secret_b64_encoded setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,9 @@
 
 **Notes on this release**
 
-- The minimum PHP version has been updated from 5.3 to 5.6. All long arrays have been converted to short arrays with a PHPCS check. 
+- The minimum PHP version has been updated from 5.3 to 7.0. All long arrays have been converted to short arrays with a PHPCS check. 
 - The site will no longer auto-redirect paths with `auth0` in them to the callback URL. Use `/index.php?auth0=1` to use the callback URL directly. Your site may require permalinks to be refreshed manually by going to **wp-admin > Settings > Permalinks** and clicking **Save Changes**.
+- The Client Secret Encoded option has been removed. If your WordPress site was using an encoded Client Secret, you'll need to regenerate one in the Auth0 dashboard and save it in wp-admin > Auth0 > Settings > Basic > Client Secret.
 
 **Closed issues**
 - Using the auth0 word in the URL path triggers an authorization code exchange [\#351](https://github.com/auth0/wp-auth0/issues/351)

--- a/lib/WP_Auth0_Api_Client.php
+++ b/lib/WP_Auth0_Api_Client.php
@@ -63,7 +63,6 @@ class WP_Auth0_Api_Client {
 				'domain'                => $a0_options->get( 'domain' ),
 				'client_id'             => $a0_options->get( 'client_id' ),
 				'client_secret'         => $a0_options->get( 'client_secret' ),
-				'client_secret_encoded' => $a0_options->get( 'client_secret_b64_encoded' ),
 				'connection'            => $a0_options->get( 'db_connection_name' ),
 				'app_token'             => null,
 				'audience'              => self::get_endpoint( 'api/v2/' ),

--- a/lib/WP_Auth0_DBManager.php
+++ b/lib/WP_Auth0_DBManager.php
@@ -40,15 +40,6 @@ class WP_Auth0_DBManager {
 			$this->migrate_users_data();
 		}
 
-		// Plugin version < 3.2.22
-		if ( $this->current_db_version < 14 && is_null( $options->get( 'client_secret_b64_encoded' ) ) ) {
-			if ( $options->get( 'client_id' ) ) {
-				$options->set( 'client_secret_b64_encoded', true, false );
-			} else {
-				$options->set( 'client_secret_b64_encoded', false, false );
-			}
-		}
-
 		// Plugin version < 3.4.0
 		if ( $this->current_db_version < 15 || 15 === $version_to_install ) {
 			$options->set( 'cdn_url', WPA0_LOCK_CDN_URL, false );
@@ -197,6 +188,7 @@ class WP_Auth0_DBManager {
 			$options->remove( 'custom_css' );
 			$options->remove( 'custom_js' );
 			$options->remove( 'auth0_implicit_workflow' );
+			$options->remove( 'client_secret_b64_encoded' );
 		}
 
 		$options->update_all();

--- a/lib/WP_Auth0_Options.php
+++ b/lib/WP_Auth0_Options.php
@@ -374,7 +374,6 @@ class WP_Auth0_Options {
 			'custom_domain'             => '',
 			'client_id'                 => '',
 			'client_secret'             => '',
-			'client_secret_b64_encoded' => null,
 			'client_signing_algorithm'  => WP_Auth0_Api_Client::DEFAULT_CLIENT_ALG,
 			'cache_expiration'          => 1440,
 			'wordpress_login_enabled'   => 'link',

--- a/lib/admin/WP_Auth0_Admin_Advanced.php
+++ b/lib/admin/WP_Auth0_Admin_Advanced.php
@@ -431,9 +431,6 @@ class WP_Auth0_Admin_Advanced extends WP_Auth0_Admin_Generic {
 
 		// If we do have a token, try to decode and store the JTI.
 		$secret = $input['client_secret'];
-		if ( ! empty( $input['client_secret_b64_encoded'] ) ) {
-			$secret = base64_decode( $input['client_secret'] );
-		}
 
 		try {
 			$signature_verifier          = new WP_Auth0_SymmetricVerifier( $secret );

--- a/lib/admin/WP_Auth0_Admin_Basic.php
+++ b/lib/admin/WP_Auth0_Admin_Basic.php
@@ -57,12 +57,6 @@ class WP_Auth0_Admin_Basic extends WP_Auth0_Admin_Generic {
 				'function' => 'render_client_secret',
 			],
 			[
-				'name'     => __( 'Client Secret Base64 Encoded', 'wp-auth0' ),
-				'opt'      => 'client_secret_b64_encoded',
-				'id'       => 'wpa0_client_secret_b64_encoded',
-				'function' => 'render_client_secret_b64_encoded',
-			],
-			[
 				'name'     => __( 'JWT Signature Algorithm', 'wp-auth0' ),
 				'opt'      => 'client_signing_algorithm',
 				'id'       => 'wpa0_client_signing_algorithm',
@@ -158,24 +152,6 @@ class WP_Auth0_Admin_Basic extends WP_Auth0_Admin_Generic {
 		$this->render_text_field( $args['label_for'], $args['opt_name'], 'password', '', $style );
 		$this->render_field_description(
 			__( 'Client Secret, found in your Application settings in the ', 'wp-auth0' ) .
-			$this->get_dashboard_link( 'applications' )
-		);
-	}
-
-	/**
-	 * Render form field and description for the `client_secret_b64_encoded` option.
-	 * IMPORTANT: Internal callback use only, do not call this function directly!
-	 *
-	 * @param array $args - callback args passed in from add_settings_field().
-	 *
-	 * @see WP_Auth0_Admin_Generic::init_option_section()
-	 * @see add_settings_field()
-	 */
-	public function render_client_secret_b64_encoded( $args = [] ) {
-		$this->render_switch( $args['label_for'], $args['opt_name'] );
-		$this->render_field_description(
-			__( 'Enable this if your Client Secret is base64 encoded. ', 'wp-auth0' ) .
-			__( 'This information is found below the Client Secret field in the ', 'wp-auth0' ) .
 			$this->get_dashboard_link( 'applications' )
 		);
 	}
@@ -339,8 +315,6 @@ class WP_Auth0_Admin_Basic extends WP_Auth0_Admin_Generic {
 		if ( __( '[REDACTED]', 'wp-auth0' ) === $input['client_secret'] ) {
 			$input['client_secret'] = $old_options['client_secret'];
 		}
-
-		$input['client_secret_b64_encoded'] = empty( $input['client_secret_b64_encoded'] ) ? 0 : 1;
 
 		if ( ! in_array( $input['client_signing_algorithm'], [ 'HS256', 'RS256' ] ) ) {
 			$input['client_signing_algorithm'] = WP_Auth0_Api_Client::DEFAULT_CLIENT_ALG;

--- a/tests/testAdminBasicValidation.php
+++ b/tests/testAdminBasicValidation.php
@@ -39,8 +39,7 @@ class TestAdminBasicValidation extends WP_Auth0_Test_Case {
 			'custom_domain'             => '',
 			'client_id'                 => '__test_client_id__',
 			'client_secret'             => '__test_client_secret__',
-			'client_secret_b64_encoded' => WP_Auth0_Api_Client::DEFAULT_CLIENT_ALG,
-			'client_signing_algorithm'  => '',
+			'client_signing_algorithm'  => WP_Auth0_Api_Client::DEFAULT_CLIENT_ALG,
 			'cache_expiration'          => '',
 		];
 	}
@@ -107,35 +106,6 @@ class TestAdminBasicValidation extends WP_Auth0_Test_Case {
 		$validated                             = self::$admin->basic_validation( $old_input, $new_input );
 
 		$this->assertEquals( 'RS256', $validated['client_signing_algorithm'] );
-	}
-
-	public function testThatSecretEncodedIsValidatedAsOffProperly() {
-		$new_input = array_merge( self::$fields, [ 'client_secret_b64_encoded' => 0 ] );
-		$validated = self::$admin->basic_validation( self::$fields, $new_input );
-
-		$this->assertEquals( 0, $validated['client_secret_b64_encoded'] );
-
-		$new_input = array_merge( self::$fields, [ 'client_secret_b64_encoded' => null ] );
-		$validated = self::$admin->basic_validation( self::$fields, $new_input );
-
-		$this->assertEquals( 0, $validated['client_secret_b64_encoded'] );
-
-		$new_input = array_merge( self::$fields, [ 'client_secret_b64_encoded' => false ] );
-		$validated = self::$admin->basic_validation( self::$fields, $new_input );
-
-		$this->assertEquals( 0, $validated['client_secret_b64_encoded'] );
-	}
-
-	public function testThatSecretEncodedIsValidatedAsOnProperly() {
-		$new_input = array_merge( self::$fields, [ 'client_secret_b64_encoded' => 1 ] );
-		$validated = self::$admin->basic_validation( self::$fields, $new_input );
-
-		$this->assertEquals( 1, $validated['client_secret_b64_encoded'] );
-
-		$new_input = array_merge( self::$fields, [ 'client_secret_b64_encoded' => uniqid() ] );
-		$validated = self::$admin->basic_validation( self::$fields, $new_input );
-
-		$this->assertEquals( 1, $validated['client_secret_b64_encoded'] );
 	}
 
 	public function testThatEmptyAlgorithmIsResetToDefault() {

--- a/tests/testOptionMigrationWs.php
+++ b/tests/testOptionMigrationWs.php
@@ -173,23 +173,6 @@ class TestOptionMigrationWs extends WP_Auth0_Test_Case {
 	}
 
 	/**
-	 * Test that turning on migration keeps the existing token and sets an admin notification.
-	 */
-	public function testThatChangingMigrationToOnKeepsWithBase64JwtSetsId() {
-		$client_secret = '__test_client_secret__';
-		self::$opts->set( 'migration_token', self::makeToken( [ 'jti' => '__test_token_id__' ], $client_secret ) );
-		$input = [
-			'migration_ws'              => 1,
-			'client_secret'             => wp_auth0_url_base64_encode( $client_secret ),
-			'client_secret_b64_encoded' => 1,
-		];
-
-		$validated = self::$admin->migration_ws_validation( [], $input );
-
-		$this->assertEquals( '__test_token_id__', $validated['migration_token_id'] );
-	}
-
-	/**
 	 * Test that turning on migration endpoints without a stored token will generate one.
 	 */
 	public function testThatChangingMigrationToOnGeneratesNewToken() {

--- a/tests/testWPAuth0DbMigrations.php
+++ b/tests/testWPAuth0DbMigrations.php
@@ -174,12 +174,14 @@ class TestWPAuth0DbMigrations extends WP_Auth0_Test_Case {
 		self::$opts->set( 'custom_css', '__test_css__' );
 		self::$opts->set( 'custom_js', '__test_js__' );
 		self::$opts->set( 'auth0_implicit_workflow', 1 );
+		self::$opts->set( 'client_secret_b64_encoded', 1 );
 		$db_manager->install_db( $test_version );
 		$this->assertNull( self::$opts->get( 'jwt_auth_integration' ) );
 		$this->assertNull( self::$opts->get( 'link_auth0_users' ) );
 		$this->assertNull( self::$opts->get( 'custom_css' ) );
 		$this->assertNull( self::$opts->get( 'custom_js' ) );
 		$this->assertNull( self::$opts->get( 'auth0_implicit_workflow' ) );
+		$this->assertNull( self::$opts->get( 'client_secret_b64_encoded' ) );
 	}
 
 	/**

--- a/tests/testWPAuth0Options.php
+++ b/tests/testWPAuth0Options.php
@@ -20,7 +20,7 @@ class TestWPAuth0Options extends WP_Auth0_Test_Case {
 	/**
 	 * Total number of options.
 	 */
-	const DEFAULT_OPTIONS_COUNT = 39;
+	const DEFAULT_OPTIONS_COUNT = 38;
 
 	/**
 	 * Test the basic options functionality.


### PR DESCRIPTION
### Changes

This removed the Client Secret Encoded option. If your WordPress site was using an encoded Client Secret (unlikely but it will say on the Application settings page in Auth0), you'll need to regenerate one in the Auth0 dashboard and save it in wp-admin > Auth0 > Settings > Basic > Client Secret.

Removes `WP_Auth0_Admin_Basic::render_client_secret_b64_encoded()`.
