### PR TITLE
Move WP_Auth0_Routes initialize method to function

### DIFF
--- a/WP_Auth0.php
+++ b/WP_Auth0.php
@@ -130,7 +130,6 @@ class WP_Auth0 {
 		$users_repo = new WP_Auth0_UsersRepo( $this->a0_options );
 
 		$this->router = new WP_Auth0_Routes( $this->a0_options );
-		$this->router->init();
 
 		$auth0_admin = new WP_Auth0_Admin( $this->a0_options, $this->router );
 		$auth0_admin->init();
@@ -500,6 +499,12 @@ $a0_plugin->init();
 /*
  * Core WP hooks
  */
+
+function wp_auth0_custom_requests( $wp, $return = false ) {
+	$routes = new WP_Auth0_Routes( WP_Auth0_Options::Instance() );
+	return $routes->custom_requests( $wp, $return );
+}
+add_action( 'parse_request', 'wp_auth0_custom_requests' );
 
 function wp_auth0_profile_enqueue_scripts() {
 	global $pagenow;

--- a/lib/WP_Auth0_Routes.php
+++ b/lib/WP_Auth0_Routes.php
@@ -14,11 +14,15 @@
 class WP_Auth0_Routes {
 
 	/**
+	 * WP_Auth0_Options instance for this class.
+	 *
 	 * @var WP_Auth0_Options
 	 */
 	protected $a0_options;
 
 	/**
+	 * WP_Auth0_Ip_Check instance for this class.
+	 *
 	 * @var WP_Auth0_Ip_Check
 	 */
 	protected $ip_check;
@@ -35,14 +39,8 @@ class WP_Auth0_Routes {
 	}
 
 	/**
-	 * @deprecated - 3.10.0, will move add_action calls out of this class in the next major.
-	 *
-	 * @codeCoverageIgnore - Deprecated.
+	 * Add rewrite tags and rules.
 	 */
-	public function init() {
-		add_action( 'parse_request', [ $this, 'custom_requests' ] );
-	}
-
 	public function setup_rewrites() {
 		add_rewrite_tag( '%auth0%', '([^&]+)' );
 		add_rewrite_tag( '%auth0fallback%', '([^&]+)' );

--- a/tests/testRoutes.php
+++ b/tests/testRoutes.php
@@ -33,14 +33,6 @@ class TestRoutes extends WP_Auth0_Test_Case {
 	protected static $wp;
 
 	/**
-	 * Run before test suite.
-	 */
-	public static function setUpBeforeClass() {
-		parent::setUpBeforeClass();
-		self::$routes = new WP_Auth0_Routes( self::$opts );
-	}
-
-	/**
 	 * Runs before each test method.
 	 */
 	public function setUp() {
@@ -52,7 +44,7 @@ class TestRoutes extends WP_Auth0_Test_Case {
 	 * If we have no query vars, the route should do nothing.
 	 */
 	public function testThatEmptyQueryVarsDoesNothing() {
-		$this->assertFalse( self::$routes->custom_requests( self::$wp, true ) );
+		$this->assertFalse( wp_auth0_custom_requests( self::$wp, true ) );
 	}
 
 	/**
@@ -60,11 +52,11 @@ class TestRoutes extends WP_Auth0_Test_Case {
 	 */
 	public function testThatUnknownRouteDoesNothing() {
 		self::$wp->query_vars['a0_action'] = uniqid();
-		$this->assertFalse( self::$routes->custom_requests( self::$wp, true ) );
+		$this->assertFalse( wp_auth0_custom_requests( self::$wp, true ) );
 
 		unset( self::$wp->query_vars['a0_action'] );
 		self::$wp->query_vars['pagename'] = uniqid();
-		$this->assertFalse( self::$routes->custom_requests( self::$wp, true ) );
+		$this->assertFalse( wp_auth0_custom_requests( self::$wp, true ) );
 
 		$this->assertEmpty( self::$error_log->get() );
 	}
@@ -75,7 +67,7 @@ class TestRoutes extends WP_Auth0_Test_Case {
 	public function testThatOauthConfigIsCorrect() {
 		self::$wp->set_query_var( 'a0_action', 'oauth2-config' );
 
-		$output = json_decode( self::$routes->custom_requests( self::$wp, true ), true );
+		$output = json_decode( wp_auth0_custom_requests( self::$wp, true ), true );
 
 		$this->assertEquals( 'Test Blog', $output['client_name'] );
 		$this->assertCount( 1, $output['redirect_uris'] );
@@ -86,7 +78,7 @@ class TestRoutes extends WP_Auth0_Test_Case {
 
 		self::$wp->set_query_var( 'a0_action', null );
 		self::$wp->set_query_var( 'pagename', 'oauth2-config' );
-		$output_2 = json_decode( self::$routes->custom_requests( self::$wp, true ), true );
+		$output_2 = json_decode( wp_auth0_custom_requests( self::$wp, true ), true );
 		$this->assertEquals( $output, $output_2 );
 	}
 
@@ -97,7 +89,7 @@ class TestRoutes extends WP_Auth0_Test_Case {
 		self::auth0Ready( true );
 		self::$wp->set_query_var( 'a0_action', 'coo-fallback' );
 
-		$output = self::$routes->custom_requests( self::$wp, true );
+		$output = wp_auth0_custom_requests( self::$wp, true );
 
 		$this->assertContains( '<script src="' . WPA0_AUTH0_JS_CDN_URL . '"></script>', $output );
 		$this->assertContains( 'var auth0 = new auth0.WebAuth({', $output );
@@ -108,7 +100,7 @@ class TestRoutes extends WP_Auth0_Test_Case {
 
 		self::$wp->set_query_var( 'a0_action', null );
 		self::$wp->set_query_var( 'auth0fallback', 1 );
-		$output_2 = self::$routes->custom_requests( self::$wp, true );
+		$output_2 = wp_auth0_custom_requests( self::$wp, true );
 		$this->assertEquals( $output, $output_2 );
 	}
 }

--- a/tests/testRoutesGetUser.php
+++ b/tests/testRoutesGetUser.php
@@ -17,6 +17,7 @@ class TestRoutesGetUser extends WP_Auth0_Test_Case {
 	use HookHelpers;
 
 	use TokenHelper;
+
 	use UsersHelper;
 
 	/**
@@ -32,14 +33,6 @@ class TestRoutesGetUser extends WP_Auth0_Test_Case {
 	 * @var WP
 	 */
 	protected static $wp;
-
-	/**
-	 * Run before test suite.
-	 */
-	public static function setUpBeforeClass() {
-		parent::setUpBeforeClass();
-		self::$routes = new WP_Auth0_Routes( self::$opts );
-	}
 
 	/**
 	 * Runs before each test method.
@@ -58,7 +51,7 @@ class TestRoutesGetUser extends WP_Auth0_Test_Case {
 	 * If migration services are off, the route should fail with an error.
 	 */
 	public function testThatGetUserRouteIsForbiddenByDefault() {
-		$output = json_decode( self::$routes->custom_requests( self::$wp, true ) );
+		$output = json_decode( wp_auth0_custom_requests( self::$wp, true ) );
 
 		$this->assertEquals( 403, $output->status );
 		$this->assertEquals( 'Forbidden', $output->error );
@@ -73,7 +66,7 @@ class TestRoutesGetUser extends WP_Auth0_Test_Case {
 		self::$opts->set( 'migration_ws', 1 );
 		self::$opts->set( 'migration_ips_filter', 1 );
 
-		$output = json_decode( self::$routes->custom_requests( self::$wp, true ) );
+		$output = json_decode( wp_auth0_custom_requests( self::$wp, true ) );
 
 		$this->assertEquals( 401, $output->status );
 		$this->assertEquals( 'Unauthorized', $output->error );
@@ -86,7 +79,7 @@ class TestRoutesGetUser extends WP_Auth0_Test_Case {
 	public function testThatGetUserRouteIsUnauthorizedIfNoToken() {
 		self::$opts->set( 'migration_ws', 1 );
 
-		$output = json_decode( self::$routes->custom_requests( self::$wp, true ) );
+		$output = json_decode( wp_auth0_custom_requests( self::$wp, true ) );
 
 		$this->assertEquals( 401, $output->status );
 		$this->assertEquals( 'Unauthorized: missing authorization header', $output->error );
@@ -107,7 +100,7 @@ class TestRoutesGetUser extends WP_Auth0_Test_Case {
 
 		$_POST['access_token'] = self::makeToken( [ 'jti' => uniqid() ], $client_secret );
 
-		$output = json_decode( self::$routes->custom_requests( self::$wp, true ) );
+		$output = json_decode( wp_auth0_custom_requests( self::$wp, true ) );
 
 		$this->assertEquals( 401, $output->status );
 		$this->assertEquals( 'Invalid token', $output->error );
@@ -127,7 +120,7 @@ class TestRoutesGetUser extends WP_Auth0_Test_Case {
 
 		$_POST['access_token'] = $migration_token;
 
-		$output = json_decode( self::$routes->custom_requests( self::$wp, true ) );
+		$output = json_decode( wp_auth0_custom_requests( self::$wp, true ) );
 
 		$this->assertEquals( 400, $output->status );
 		$this->assertEquals( 'Username is required', $output->error );
@@ -148,7 +141,7 @@ class TestRoutesGetUser extends WP_Auth0_Test_Case {
 		$_POST['access_token'] = $migration_token;
 		$_POST['username']     = uniqid();
 
-		$output = json_decode( self::$routes->custom_requests( self::$wp, true ) );
+		$output = json_decode( wp_auth0_custom_requests( self::$wp, true ) );
 
 		$this->assertEquals( 401, $output->status );
 		$this->assertEquals( 'User not found', $output->error );
@@ -172,7 +165,7 @@ class TestRoutesGetUser extends WP_Auth0_Test_Case {
 		$user = $this->createUser( [ 'user_email' => $_POST['username'] ] );
 		WP_Auth0_UsersRepo::update_meta( $user->ID, 'auth0_transient_email_update', $_POST['username'] );
 
-		$output = json_decode( self::$routes->custom_requests( self::$wp, true ) );
+		$output = json_decode( wp_auth0_custom_requests( self::$wp, true ) );
 
 		$this->assertFalse( isset( $output->ID ) );
 		$this->assertEquals( 200, $output->status );
@@ -193,7 +186,7 @@ class TestRoutesGetUser extends WP_Auth0_Test_Case {
 
 		$_POST['access_token'] = $migration_token;
 
-		$output_em = json_decode( self::$routes->custom_requests( self::$wp, true ) );
+		$output_em = json_decode( wp_auth0_custom_requests( self::$wp, true ) );
 
 		$this->assertEquals( $user->ID, $output_em->data->ID );
 		$this->assertEquals( $user->user_login, $output_em->data->user_login );

--- a/tests/testRoutesLogin.php
+++ b/tests/testRoutesLogin.php
@@ -35,14 +35,6 @@ class TestRoutesLogin extends WP_Auth0_Test_Case {
 	protected static $wp;
 
 	/**
-	 * Run before test suite.
-	 */
-	public static function setUpBeforeClass() {
-		parent::setUpBeforeClass();
-		self::$routes = new WP_Auth0_Routes( self::$opts );
-	}
-
-	/**
 	 * Runs before each test method.
 	 */
 	public function setUp() {
@@ -60,7 +52,7 @@ class TestRoutesLogin extends WP_Auth0_Test_Case {
 	public function testThatLoginRouteIsForbiddenByDefault() {
 		self::$wp->query_vars['a0_action'] = 'migration-ws-login';
 
-		$output = json_decode( self::$routes->custom_requests( self::$wp, true ) );
+		$output = json_decode( wp_auth0_custom_requests( self::$wp, true ) );
 
 		$this->assertEquals( 403, $output->status );
 		$this->assertEquals( 'Forbidden', $output->error );
@@ -76,7 +68,7 @@ class TestRoutesLogin extends WP_Auth0_Test_Case {
 		self::$opts->set( 'migration_ips_filter', 1 );
 		self::$wp->query_vars['a0_action'] = 'migration-ws-login';
 
-		$output = json_decode( self::$routes->custom_requests( self::$wp, true ) );
+		$output = json_decode( wp_auth0_custom_requests( self::$wp, true ) );
 
 		$this->assertEquals( 401, $output->status );
 		$this->assertEquals( 'Unauthorized', $output->error );
@@ -91,7 +83,7 @@ class TestRoutesLogin extends WP_Auth0_Test_Case {
 		self::$opts->set( 'migration_ws', 1 );
 		self::$wp->query_vars['a0_action'] = 'migration-ws-login';
 
-		$output = json_decode( self::$routes->custom_requests( self::$wp, true ) );
+		$output = json_decode( wp_auth0_custom_requests( self::$wp, true ) );
 
 		$this->assertEquals( 401, $output->status );
 		$this->assertEquals( 'Unauthorized: missing authorization header', $output->error );
@@ -113,7 +105,7 @@ class TestRoutesLogin extends WP_Auth0_Test_Case {
 		self::$wp->query_vars['a0_action'] = 'migration-ws-login';
 		$_POST['access_token']             = self::makeToken( [ 'jti' => uniqid() ], $client_secret );
 
-		$output = json_decode( self::$routes->custom_requests( self::$wp, true ) );
+		$output = json_decode( wp_auth0_custom_requests( self::$wp, true ) );
 
 		$this->assertEquals( 401, $output->status );
 		$this->assertEquals( 'Invalid token', $output->error );
@@ -135,7 +127,7 @@ class TestRoutesLogin extends WP_Auth0_Test_Case {
 		self::$wp->query_vars['a0_action'] = 'migration-ws-login';
 		$_POST['access_token']             = self::makeToken( [ 'iss' => uniqid() ], $client_secret );
 
-		$output = json_decode( self::$routes->custom_requests( self::$wp, true ) );
+		$output = json_decode( wp_auth0_custom_requests( self::$wp, true ) );
 
 		$this->assertEquals( 401, $output->status );
 		$this->assertEquals( 'Invalid token', $output->error );
@@ -159,7 +151,7 @@ class TestRoutesLogin extends WP_Auth0_Test_Case {
 		self::$wp->query_vars['a0_action'] = 'migration-ws-login';
 		$_POST['access_token']             = $migration_token;
 
-		$output = json_decode( self::$routes->custom_requests( self::$wp, true ) );
+		$output = json_decode( wp_auth0_custom_requests( self::$wp, true ) );
 
 		$this->assertEquals( 400, $output->status );
 		$this->assertEquals( 'Username is required', $output->error );
@@ -184,7 +176,7 @@ class TestRoutesLogin extends WP_Auth0_Test_Case {
 		$_POST['access_token']             = $migration_token;
 		$_POST['username']                 = uniqid();
 
-		$output = json_decode( self::$routes->custom_requests( self::$wp, true ) );
+		$output = json_decode( wp_auth0_custom_requests( self::$wp, true ) );
 
 		$this->assertEquals( 400, $output->status );
 		$this->assertEquals( 'Password is required', $output->error );
@@ -211,7 +203,7 @@ class TestRoutesLogin extends WP_Auth0_Test_Case {
 		$_POST['username']     = uniqid();
 		$_POST['password']     = uniqid();
 
-		$output = json_decode( self::$routes->custom_requests( self::$wp, true ) );
+		$output = json_decode( wp_auth0_custom_requests( self::$wp, true ) );
 
 		$this->assertEquals( 401, $output->status );
 		$this->assertEquals( 'Invalid credentials', $output->error );
@@ -243,7 +235,7 @@ class TestRoutesLogin extends WP_Auth0_Test_Case {
 		self::$wp->query_vars['a0_action'] = 'migration-ws-login';
 		$_POST['access_token']             = $migration_token;
 
-		$output = json_decode( self::$routes->custom_requests( self::$wp, true ) );
+		$output = json_decode( wp_auth0_custom_requests( self::$wp, true ) );
 
 		$this->assertEquals( $user->ID, $output->data->ID );
 		$this->assertEquals( $user->user_login, $output->data->user_login );


### PR DESCRIPTION
### Changes

Move `WP_Auth0_Routes::init()` method to `wp_auth0_custom_requests()`

### Checklist

* [x] All existing and new tests complete without errors
* [x] All code quality tools/guidelines in the [Contribution guide](CONTRIBUTION.md) have been run/followed
* [x] All active GitHub CI checks have passed
