### PR TITLE
Remove deprecated from User and Change Password

### DIFF
--- a/WP_Auth0.php
+++ b/WP_Auth0.php
@@ -138,10 +138,6 @@ class WP_Auth0 {
 
 		$api_client_creds = new WP_Auth0_Api_Client_Credentials( $this->a0_options );
 
-		$api_change_password = new WP_Auth0_Api_Change_Password( $this->a0_options, $api_client_creds );
-		$profile_change_pwd  = new WP_Auth0_Profile_Change_Password( $api_change_password );
-		$profile_change_pwd->init();
-
 		$api_change_email     = new WP_Auth0_Api_Change_Email( $this->a0_options, $api_client_creds );
 		$profile_change_email = new WP_Auth0_Profile_Change_Email( $api_change_email );
 		$profile_change_email->init();
@@ -497,6 +493,23 @@ $a0_plugin->init();
 /*
  * Core WP hooks
  */
+
+function wp_auth0_validate_new_password( $errors, $user ) {
+	$options             = WP_Auth0_Options::Instance();
+	$api_client_creds    = new WP_Auth0_Api_Client_Credentials( $options );
+	$api_change_password = new WP_Auth0_Api_Change_Password( $options, $api_client_creds );
+	$profile_change_pwd  = new WP_Auth0_Profile_Change_Password( $api_change_password );
+	return $profile_change_pwd->validate_new_password( $errors, $user );
+}
+
+// Used during profile update in wp-admin.
+add_action( 'user_profile_update_errors', 'wp_auth0_validate_new_password', 10, 2 );
+
+// Used during password reset on wp-login.php.
+add_action( 'validate_password_reset', 'wp_auth0_validate_new_password', 10, 2 );
+
+// Used during WooCommerce edit account save.
+add_action( 'woocommerce_save_account_details_errors', 'wp_auth0_validate_new_password', 10, 2 );
 
 function wp_auth0_init_admin_menu() {
 

--- a/lib/WP_Auth0_Users.php
+++ b/lib/WP_Auth0_Users.php
@@ -5,11 +5,10 @@ class WP_Auth0_Users {
 	 * Create a WordPress user with Auth0 data.
 	 *
 	 * @param object       $userinfo - User profile data from Auth0.
-	 * @param null|boolean $role - Set the role as administrator - @deprecated - 3.8.0.
 	 *
 	 * @return int|WP_Error
 	 */
-	public static function create_user( $userinfo, $role = null ) {
+	public static function create_user( $userinfo ) {
 		$email = null;
 		if ( isset( $userinfo->email ) ) {
 			$email = $userinfo->email;
@@ -85,12 +84,6 @@ class WP_Auth0_Users {
 		];
 
 		$user_data = apply_filters( 'auth0_create_user_data', $user_data, $userinfo );
-
-		if ( $role ) {
-			// phpcs:ignore
-			@trigger_error( sprintf( __( '$role parameter is deprecated.', 'wp-auth0' ), __METHOD__ ), E_USER_DEPRECATED );
-			$user_data['role'] = 'administrator';
-		}
 
 		// Update the user
 		$user_id = wp_insert_user( $user_data );

--- a/lib/WP_Auth0_Users.php
+++ b/lib/WP_Auth0_Users.php
@@ -4,7 +4,7 @@ class WP_Auth0_Users {
 	/**
 	 * Create a WordPress user with Auth0 data.
 	 *
-	 * @param object       $userinfo - User profile data from Auth0.
+	 * @param object $userinfo - User profile data from Auth0.
 	 *
 	 * @return int|WP_Error
 	 */

--- a/lib/profile/WP_Auth0_Profile_Change_Password.php
+++ b/lib/profile/WP_Auth0_Profile_Change_Password.php
@@ -29,25 +29,6 @@ class WP_Auth0_Profile_Change_Password {
 	}
 
 	/**
-	 * Add actions and filters for the profile page.
-	 *
-	 * @deprecated - 3.10.0, will move add_action calls out of this class in the next major.
-	 *
-	 * @codeCoverageIgnore - Deprecated.
-	 */
-	public function init() {
-
-		// Used during profile update in wp-admin.
-		add_action( 'user_profile_update_errors', [ $this, 'validate_new_password' ], 10, 2 );
-
-		// Used during password reset on wp-login.php.
-		add_action( 'validate_password_reset', [ $this, 'validate_new_password' ], 10, 2 );
-
-		// Used during WooCommerce edit account save.
-		add_action( 'woocommerce_save_account_details_errors', [ $this, 'validate_new_password' ], 10, 2 );
-	}
-
-	/**
 	 * Update the user's password at Auth0
 	 * Hooked to: user_profile_update_errors, validate_password_reset, woocommerce_save_account_details_errors
 	 * IMPORTANT: Internal callback use only, do not call this function directly!

--- a/tests/classes/WP_Auth0_Test_Case.php
+++ b/tests/classes/WP_Auth0_Test_Case.php
@@ -102,6 +102,9 @@ abstract class WP_Auth0_Test_Case extends \PHPUnit\Framework\TestCase {
 		delete_user_meta( 1, $wpdb->prefix . 'auth0_id' );
 		delete_user_meta( 1, $wpdb->prefix . 'auth0_obj' );
 		delete_user_meta( 1, $wpdb->prefix . 'last_update' );
+
+		delete_transient( WP_Auth0_Api_Client_Credentials::TOKEN_TRANSIENT_KEY );
+		delete_transient( WP_Auth0_Api_Client_Credentials::SCOPE_TRANSIENT_KEY );
 	}
 
 	/**
@@ -114,5 +117,15 @@ abstract class WP_Auth0_Test_Case extends \PHPUnit\Framework\TestCase {
 		self::$opts->set( 'domain', $value );
 		self::$opts->set( 'client_id', $value );
 		self::$opts->set( 'client_secret', $value );
+	}
+
+	/**
+	 * Set or delete the stored API token.
+	 *
+	 * @param string $scope - Scope string to use.
+	 */
+	public static function setApiToken( $scope ) {
+		set_transient( WP_Auth0_Api_Client_Credentials::TOKEN_TRANSIENT_KEY, '__test_access_token__', 9999 );
+		set_transient( WP_Auth0_Api_Client_Credentials::SCOPE_TRANSIENT_KEY, $scope, 9999 );
 	}
 }

--- a/tests/testApiGetUser.php
+++ b/tests/testApiGetUser.php
@@ -48,9 +48,7 @@ class TestApiGetUser extends WP_Auth0_Test_Case {
 	 */
 	public function testThatApiRequestIsCorrect() {
 		$this->startHttpHalting();
-
-		set_transient( WP_Auth0_Api_Client_Credentials::TOKEN_TRANSIENT_KEY, '__test_access_token__', 9999 );
-		set_transient( WP_Auth0_Api_Client_Credentials::SCOPE_TRANSIENT_KEY, 'read:users', 9990 );
+		$this->setApiToken( 'read:users' );
 
 		self::$opts->set( 'domain', 'test.auth0.com' );
 		$get_user_api = new WP_Auth0_Api_Get_User( self::$opts, self::$api_client_creds );
@@ -77,9 +75,7 @@ class TestApiGetUser extends WP_Auth0_Test_Case {
 	public function testThatNetworkErrorIsHandled() {
 		$this->startHttpMocking();
 		$this->http_request_type = 'wp_error';
-
-		set_transient( WP_Auth0_Api_Client_Credentials::TOKEN_TRANSIENT_KEY, '__test_access_token__', 9999 );
-		set_transient( WP_Auth0_Api_Client_Credentials::SCOPE_TRANSIENT_KEY, 'read:users', 9990 );
+		$this->setApiToken( 'read:users' );
 
 		self::$opts->set( 'domain', 'test.auth0.com' );
 		$get_user_api = new WP_Auth0_Api_Get_User( self::$opts, self::$api_client_creds );

--- a/tests/testEmailVerification.php
+++ b/tests/testEmailVerification.php
@@ -161,13 +161,11 @@ class TestEmailVerification extends WP_Auth0_Test_Case {
 	public function testResendVerificationEmail() {
 		$this->startHttpMocking();
 		$this->startAjaxHalting();
+		$this->setApiToken( 'update:users' );
 
 		$_REQUEST['_ajax_nonce'] = wp_create_nonce( WP_Auth0_Email_Verification::RESEND_NONCE_ACTION );
 		$_POST['sub']            = $this->getUserinfo()->sub;
 		$this->http_request_type = 'success_create_empty_body';
-
-		set_transient( WP_Auth0_Api_Client_Credentials::TOKEN_TRANSIENT_KEY, uniqid(), 9999999 );
-		set_transient( WP_Auth0_Api_Client_Credentials::SCOPE_TRANSIENT_KEY, 'update:users', 9999999 );
 
 		ob_start();
 		try {

--- a/tests/testLoginManagerRedirectLogin.php
+++ b/tests/testLoginManagerRedirectLogin.php
@@ -46,8 +46,7 @@ class TestLoginManagerRedirectLogin extends WP_Auth0_Test_Case {
 
 		add_filter( 'auth0_get_wp_user', [ $this, 'auth0_get_wp_user_handler' ], 1, 2 );
 
-		set_transient( WP_Auth0_Api_Client_Credentials::TOKEN_TRANSIENT_KEY, '__test_access_token__', 9999 );
-		set_transient( WP_Auth0_Api_Client_Credentials::SCOPE_TRANSIENT_KEY, 'read:users', 9990 );
+		$this->setApiToken( 'read:users' );
 	}
 
 	/**
@@ -56,10 +55,6 @@ class TestLoginManagerRedirectLogin extends WP_Auth0_Test_Case {
 	public function tearDown() {
 		parent::tearDown();
 		remove_filter( 'auth0_get_wp_user', [ $this, 'auth0_get_wp_user_handler' ], 1 );
-
-		delete_transient( WP_Auth0_Api_Client_Credentials::TOKEN_TRANSIENT_KEY );
-		delete_transient( WP_Auth0_Api_Client_Credentials::SCOPE_TRANSIENT_KEY );
-
 		remove_filter( 'auth0_use_management_api_for_userinfo', '__return_false', 10 );
 	}
 


### PR DESCRIPTION
### Changes

- Remove `$role` parameter from `WP_Auth0_Users::create_user()`
- Remove `WP_Auth0_Profile_Change_Password::init()`

### Testing

* [x] This change adds unit test coverage
* [x] This change has been tested on WP 5.3

### Checklist

* [x] All existing and new tests complete without errors
* [x] All code quality tools/guidelines in the [Contribution guide](CONTRIBUTION.md) have been run/followed
* [x] All active GitHub CI checks have passed
