### PR TITLE
Move actions from methods to functions for profile delete and change email

### DIFF
--- a/WP_Auth0.php
+++ b/WP_Auth0.php
@@ -141,9 +141,6 @@ class WP_Auth0 {
 		$api_change_email     = new WP_Auth0_Api_Change_Email( $this->a0_options, $api_client_creds );
 		$profile_change_email = new WP_Auth0_Profile_Change_Email( $api_change_email );
 		$profile_change_email->init();
-
-		$profile_delete_data = new WP_Auth0_Profile_Delete_Data( $users_repo );
-		$profile_delete_data->init();
 	}
 
 	/**
@@ -510,6 +507,19 @@ add_action( 'validate_password_reset', 'wp_auth0_validate_new_password', 10, 2 )
 
 // Used during WooCommerce edit account save.
 add_action( 'woocommerce_save_account_details_errors', 'wp_auth0_validate_new_password', 10, 2 );
+
+function wp_auth0_show_delete_identity() {
+	$profile_delete_data = new WP_Auth0_Profile_Delete_Data();
+	$profile_delete_data->show_delete_identity();
+}
+add_action( 'edit_user_profile', 'wp_auth0_show_delete_identity' );
+add_action( 'show_user_profile', 'wp_auth0_show_delete_identity' );
+
+function wp_auth0_delete_user_data() {
+	$profile_delete_data = new WP_Auth0_Profile_Delete_Data();
+	$profile_delete_data->delete_user_data();
+}
+add_action( 'wp_ajax_auth0_delete_data', 'wp_auth0_delete_user_data' );
 
 function wp_auth0_init_admin_menu() {
 

--- a/WP_Auth0.php
+++ b/WP_Auth0.php
@@ -126,8 +126,6 @@ class WP_Auth0 {
 		$initial_setup = new WP_Auth0_InitialSetup( $this->a0_options );
 		$initial_setup->init();
 
-		$users_repo = new WP_Auth0_UsersRepo( $this->a0_options );
-
 		$this->router = new WP_Auth0_Routes( $this->a0_options );
 
 		$error_log = new WP_Auth0_ErrorLog();
@@ -135,12 +133,6 @@ class WP_Auth0 {
 
 		$import_settings = new WP_Auth0_Import_Settings( $this->a0_options );
 		$import_settings->init();
-
-		$api_client_creds = new WP_Auth0_Api_Client_Credentials( $this->a0_options );
-
-		$api_change_email     = new WP_Auth0_Api_Change_Email( $this->a0_options, $api_client_creds );
-		$profile_change_email = new WP_Auth0_Profile_Change_Email( $api_change_email );
-		$profile_change_email->init();
 	}
 
 	/**
@@ -490,6 +482,15 @@ $a0_plugin->init();
 /*
  * Core WP hooks
  */
+
+function wp_auth0_profile_change_email( $wp_user_id, $old_user_data ) {
+	$options              = WP_Auth0_Options::Instance();
+	$api_client_creds     = new WP_Auth0_Api_Client_Credentials( $options );
+	$api_change_email     = new WP_Auth0_Api_Change_Email( $options, $api_client_creds );
+	$profile_change_email = new WP_Auth0_Profile_Change_Email( $api_change_email );
+	return $profile_change_email->update_email( $wp_user_id, $old_user_data );
+}
+add_action( 'profile_update', 'wp_auth0_profile_change_email', 100, 2 );
 
 function wp_auth0_validate_new_password( $errors, $user ) {
 	$options             = WP_Auth0_Options::Instance();

--- a/functions.php
+++ b/functions.php
@@ -144,6 +144,16 @@ function wp_auth0_url_base64_decode( $input ) {
 	return base64_decode( strtr( $input, '-_', '+/' ) );
 }
 
+/**
+ * @param $user_id
+ */
+function wp_auth0_delete_auth0_object( $user_id ) {
+	WP_Auth0_UsersRepo::delete_meta( $user_id, 'auth0_id' );
+	WP_Auth0_UsersRepo::delete_meta( $user_id, 'auth0_obj' );
+	WP_Auth0_UsersRepo::delete_meta( $user_id, 'last_update' );
+	WP_Auth0_UsersRepo::delete_meta( $user_id, 'auth0_transient_email_update' );
+}
+
 if ( ! function_exists( 'get_auth0userinfo' ) ) {
 	/**
 	 * Get the Auth0 profile from the database, if one exists.

--- a/lib/WP_Auth0_UsersRepo.php
+++ b/lib/WP_Auth0_UsersRepo.php
@@ -155,18 +155,6 @@ class WP_Auth0_UsersRepo {
 	}
 
 	/**
-	 * Delete all Auth0 meta fields for a WordPress user.
-	 *
-	 * @param int $user_id - WordPress user ID.
-	 */
-	public function delete_auth0_object( $user_id ) {
-		self::delete_meta( $user_id, 'auth0_id' );
-		self::delete_meta( $user_id, 'auth0_obj' );
-		self::delete_meta( $user_id, 'last_update' );
-		self::delete_meta( $user_id, 'auth0_transient_email_update' );
-	}
-
-	/**
 	 * Get a user's Auth0 meta data.
 	 *
 	 * @param integer  $user_id - WordPress user ID.

--- a/lib/profile/WP_Auth0_Profile_Change_Email.php
+++ b/lib/profile/WP_Auth0_Profile_Change_Email.php
@@ -34,19 +34,6 @@ class WP_Auth0_Profile_Change_Email {
 	}
 
 	/**
-	 * Add actions for the update user process.
-	 *
-	 * @deprecated - 3.10.0, will move add_action calls out of this class in the next major.
-	 *
-	 * @codeCoverageIgnore - Deprecated.
-	 */
-	public function init() {
-
-		// Used during profile update in wp-admin or email verification link.
-		add_action( 'profile_update', [ $this, 'update_email' ], 100, 2 );
-	}
-
-	/**
 	 * Update the user's email at Auth0 when changing email for a database connection user.
 	 * This runs AFTER a successful email change is saved in WP.
 	 * Hooked to: profile_update

--- a/lib/profile/WP_Auth0_Profile_Delete_Data.php
+++ b/lib/profile/WP_Auth0_Profile_Delete_Data.php
@@ -14,35 +14,6 @@
 class WP_Auth0_Profile_Delete_Data {
 
 	/**
-	 * WP_Auth0_UsersRepo instance.
-	 *
-	 * @var WP_Auth0_UsersRepo
-	 */
-	protected $users_repo;
-
-	/**
-	 * WP_Auth0_Profile_Delete_Data constructor.
-	 *
-	 * @param WP_Auth0_UsersRepo $users_repo - WP_Auth0_UsersRepo instance.
-	 */
-	public function __construct( WP_Auth0_UsersRepo $users_repo ) {
-		$this->users_repo = $users_repo;
-	}
-
-	/**
-	 * Add actions and filters for the profile page.
-	 *
-	 * @deprecated - 3.10.0, will move add_action calls out of this class in the next major.
-	 *
-	 * @codeCoverageIgnore - Deprecated.
-	 */
-	public function init() {
-		add_action( 'edit_user_profile', [ $this, 'show_delete_identity' ] );
-		add_action( 'show_user_profile', [ $this, 'show_delete_identity' ] );
-		add_action( 'wp_ajax_auth0_delete_data', [ $this, 'delete_user_data' ] );
-	}
-
-	/**
 	 * Show the delete Auth0 user data button.
 	 * Hooked to: edit_user_profile, show_user_profile
 	 * IMPORTANT: Internal callback use only, do not call this function directly!
@@ -95,7 +66,7 @@ class WP_Auth0_Profile_Delete_Data {
 			wp_send_json_error( [ 'error' => __( 'Forbidden', 'wp-auth0' ) ] );
 		}
 
-		$this->users_repo->delete_auth0_object( $user_id );
+		wp_auth0_delete_auth0_object( $user_id );
 		wp_send_json_success();
 	}
 }

--- a/tests/testUserMeta.php
+++ b/tests/testUserMeta.php
@@ -97,7 +97,7 @@ class TestUserMeta extends WP_Auth0_Test_Case {
 		$this->assertNotEmpty( get_user_meta( $uid, $wpdb->prefix . 'auth0_id', true ) );
 		$this->assertNotEmpty( get_user_meta( $uid, $wpdb->prefix . 'auth0_obj', true ) );
 
-		$user_repo->delete_auth0_object( $uid );
+		wp_auth0_delete_auth0_object( $uid );
 
 		$this->assertEmpty( get_user_meta( $uid, $wpdb->prefix . 'last_update', true ) );
 		$this->assertEmpty( get_user_meta( $uid, $wpdb->prefix . 'auth0_id', true ) );

--- a/tests/testUserRepoMeta.php
+++ b/tests/testUserRepoMeta.php
@@ -102,7 +102,7 @@ class TestUserRepoMeta extends WP_Auth0_Test_Case {
 		$this->assertNotEmpty( $users_repo::get_meta( 1, 'last_update' ) );
 		$this->assertNotEmpty( $users_repo::get_meta( 1, 'auth0_transient_email_update' ) );
 
-		$users_repo->delete_auth0_object( 1 );
+		wp_auth0_delete_auth0_object( 1 );
 
 		$this->assertEmpty( $users_repo::get_meta( 1, 'auth0_id' ) );
 		$this->assertEmpty( $users_repo::get_meta( 1, 'auth0_obj' ) );


### PR DESCRIPTION
### Changes

- Change `WP_Auth0_UsersRepo::delete_auth0_object()` to `wp_auth0_delete_auth0_object()`
- Remove `WP_Auth0_Profile_Change_Email::init()` 
- Remove `WP_Auth0_UsersRepo` dependency from `WP_Auth0_Profile_Delete_Data` constructor 
- Remove `WP_Auth0_Profile_Delete_Data::init()` 

### Testing

* [x] This change adds unit test coverage
* [x] This change has been tested on WP 5.3

### Checklist

* [x] All existing and new tests complete without errors
* [x] All code quality tools/guidelines in the [Contribution guide](CONTRIBUTION.md) have been run/followed
* [x] All active GitHub CI checks have passed
