### PR TITLE
Remove deprecated from import settings

### DIFF
--- a/WP_Auth0.php
+++ b/WP_Auth0.php
@@ -481,9 +481,22 @@ $a0_plugin->init();
  */
 
 function wp_auth0_export_settings_admin_action() {
-	$options         = WP_Auth0_Options::Instance();
-	$import_settings = new WP_Auth0_Import_Settings( $options );
-	$import_settings->export_settings();
+
+	if ( ! current_user_can( 'manage_options' ) ) {
+		wp_die( __( 'Unauthorized.', 'wp-auth0' ) );
+		exit;
+	}
+
+	$options  = WP_Auth0_Options::Instance();
+	$name     = urlencode( get_auth0_curatedBlogName() );
+	$settings = get_option( $options->get_options_name() );
+
+	header( 'Content-Type: application/json' );
+	header( "Content-Disposition: attachment; filename=auth0_for_wordpress_settings-$name.json" );
+	header( 'Pragma: no-cache' );
+
+	echo wp_json_encode( $settings );
+	exit;
 }
 add_action( 'admin_action_wpauth0_export_settings', 'wp_auth0_export_settings_admin_action' );
 

--- a/WP_Auth0.php
+++ b/WP_Auth0.php
@@ -130,9 +130,6 @@ class WP_Auth0 {
 
 		$error_log = new WP_Auth0_ErrorLog();
 		$error_log->init();
-
-		$import_settings = new WP_Auth0_Import_Settings( $this->a0_options );
-		$import_settings->init();
 	}
 
 	/**
@@ -483,6 +480,33 @@ $a0_plugin->init();
  * Core WP hooks
  */
 
+function wp_auth0_export_settings_admin_action() {
+	$options         = WP_Auth0_Options::Instance();
+	$import_settings = new WP_Auth0_Import_Settings( $options );
+	$import_settings->export_settings();
+}
+add_action( 'admin_action_wpauth0_export_settings', 'wp_auth0_export_settings_admin_action' );
+
+function wp_auth0_import_settings_admin_action() {
+	$options         = WP_Auth0_Options::Instance();
+	$import_settings = new WP_Auth0_Import_Settings( $options );
+	$import_settings->import_settings();
+}
+add_action( 'admin_action_wpauth0_import_settings', 'wp_auth0_import_settings_admin_action' );
+
+function wp_auth0_settings_admin_action_error() {
+	if ( ! wp_auth0_is_admin_page( 'wpa0-import-settings' ) || empty( $_REQUEST['error'] ) ) {
+		return false;
+	}
+
+	printf(
+		'<div class="notice notice-error is-dismissible"><p><strong>%s</strong></p></div>',
+		sanitize_text_field( $_REQUEST['error'] )
+	);
+	return true;
+}
+add_action( 'admin_notices', 'wp_auth0_settings_admin_action_error' );
+
 function wp_auth0_profile_change_email( $wp_user_id, $old_user_data ) {
 	$options              = WP_Auth0_Options::Instance();
 	$api_client_creds     = new WP_Auth0_Api_Client_Credentials( $options );
@@ -524,7 +548,7 @@ add_action( 'wp_ajax_auth0_delete_data', 'wp_auth0_delete_user_data' );
 
 function wp_auth0_init_admin_menu() {
 
-	if ( isset( $_REQUEST['page'] ) && $_REQUEST['page'] === 'wpa0-help' ) {
+	if ( wp_auth0_is_admin_page( 'wpa0-help' ) ) {
 		wp_redirect( admin_url( 'admin.php?page=wpa0#help' ), 301 );
 		exit;
 	}

--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -71,10 +71,6 @@ jQuery(document).ready(function($) {
     /*
     Import and Export settings tabs
      */
-    $('.js-a0-upload-toggle').click(function(){
-        $('#js-a0-upload-file').toggle();
-        $('#js-a0-paste-json').toggle();
-    });
 
     $('.js-a0-import-export-tabs').click(function (e) {
         e.preventDefault();

--- a/functions.php
+++ b/functions.php
@@ -145,7 +145,9 @@ function wp_auth0_url_base64_decode( $input ) {
 }
 
 /**
- * @param $user_id
+ * Delete all Auth0 data for a specific user.
+ *
+ * @param int $user_id - WordPress user ID.
  */
 function wp_auth0_delete_auth0_object( $user_id ) {
 	WP_Auth0_UsersRepo::delete_meta( $user_id, 'auth0_id' );
@@ -155,7 +157,9 @@ function wp_auth0_delete_auth0_object( $user_id ) {
 }
 
 /**
- * @param $page
+ * Determine whether a specific admin page is being loaded or not.
+ *
+ * @param string $page - Admin page slug to check.
  *
  * @return bool
  */

--- a/functions.php
+++ b/functions.php
@@ -154,6 +154,19 @@ function wp_auth0_delete_auth0_object( $user_id ) {
 	WP_Auth0_UsersRepo::delete_meta( $user_id, 'auth0_transient_email_update' );
 }
 
+/**
+ * @param $page
+ *
+ * @return bool
+ */
+function wp_auth0_is_admin_page( $page ) {
+	if ( empty( $_REQUEST['page'] ) || ! is_admin() ) {
+		return false;
+	}
+
+	return $page === $_REQUEST['page'];
+}
+
 if ( ! function_exists( 'get_auth0userinfo' ) ) {
 	/**
 	 * Get the Auth0 profile from the database, if one exists.

--- a/lib/WP_Auth0_Import_Settings.php
+++ b/lib/WP_Auth0_Import_Settings.php
@@ -40,23 +40,6 @@ class WP_Auth0_Import_Settings {
 		exit;
 	}
 
-	public function export_settings() {
-
-		if ( ! current_user_can( 'manage_options' ) ) {
-			wp_die( __( 'Unauthorized.', 'wp-auth0' ) );
-			exit;
-		}
-
-		header( 'Content-Type: application/json' );
-		$name = urlencode( get_auth0_curatedBlogName() );
-		header( "Content-Disposition: attachment; filename=auth0_for_wordpress_settings-$name.json" );
-		header( 'Pragma: no-cache' );
-
-		$settings = get_option( $this->a0_options->get_options_name() );
-		echo wp_json_encode( $settings );
-		exit;
-	}
-
 	/**
 	 * @codeCoverageIgnore
 	 */

--- a/lib/WP_Auth0_Import_Settings.php
+++ b/lib/WP_Auth0_Import_Settings.php
@@ -8,151 +8,27 @@ class WP_Auth0_Import_Settings {
 		$this->a0_options = $a0_options;
 	}
 
-	/**
-	 * @deprecated - 3.10.0, will move add_action calls out of this class in the next major.
-	 *
-	 * @codeCoverageIgnore - Deprecated.
-	 */
-	public function init() {
-		add_action( 'admin_action_wpauth0_export_settings', [ $this, 'export_settings' ] );
-		add_action( 'admin_action_wpauth0_import_settings', [ $this, 'import_settings' ] );
-
-		if ( isset( $_REQUEST['error'] ) && isset( $_REQUEST['page'] ) && $_REQUEST['page'] === 'wpa0-import-settings' ) {
-			add_action( 'admin_notices', [ $this, 'show_error' ] );
-		}
-	}
-
-	public function show_error() {
-		printf(
-			'<div class="notice notice-error"><p><strong>%s</strong></p></div>',
-			sanitize_text_field( $_REQUEST['error'] )
-		);
-	}
-
 	public function render_import_settings_page() {
-
 		include WPA0_PLUGIN_DIR . 'templates/import_settings.php';
-
 	}
 
 	public function import_settings() {
 
-		if ( ! function_exists( 'wp_handle_upload' ) ) {
-			require_once ABSPATH . 'wp-admin/includes/file.php';
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_die( __( 'Unauthorized.', 'wp-auth0' ) );
+			exit;
 		}
 
-		if ( isset( $_FILES['settings-file'] ) && $_FILES['settings-file']['error'] !== 4 ) {
+		$settings_json = trim( stripslashes( $_POST['settings-json'] ?? '' ) );
+		if ( empty( $settings_json ) ) {
+			wp_safe_redirect( $this->make_error_url( __( 'No settings JSON entered.', 'wp-auth0' ) ) );
+			exit;
+		}
 
-			if ( $_FILES['settings-file']['error'] === 0 ) {
-				$uploadedfile     = $_FILES['settings-file'];
-				$upload_overrides = [
-					'test_form' => false,
-					'mimes'     => [ 'json' => 'application/json' ],
-				];
-
-				$movefile = wp_handle_upload( $uploadedfile, $upload_overrides );
-
-				if ( $movefile && ! isset( $movefile['error'] ) ) {
-
-					$settings_json = file_get_contents( $movefile['file'] );
-					unlink( $movefile['file'] );
-
-					if ( empty( $settings_json ) ) {
-						exit(
-							wp_redirect(
-								admin_url(
-									'admin.php?page=wpa0-import-settings&error=' .
-									rawurlencode( __( 'The settings file is empty.', 'wp-auth0' ) )
-								)
-							)
-						);
-					}
-
-					$settings = json_decode( $settings_json, true );
-
-					if ( empty( $settings ) ) {
-						exit(
-							wp_redirect(
-								admin_url(
-									'admin.php?page=wpa0-import-settings&error=' .
-									rawurlencode( __( 'The settings file is not valid.', 'wp-auth0' ) )
-								)
-							)
-						);
-					}
-				} else {
-					exit(
-						wp_redirect(
-							admin_url(
-								'admin.php?page=wpa0-import-settings&error=' .
-								rawurlencode( $movefile['error'] )
-							)
-						)
-					);
-				}
-			} else {
-				switch ( $_FILES['settings-file']['error'] ) {
-					case 1:
-					case 2:
-						exit(
-							wp_redirect(
-								admin_url(
-									'admin.php?page=wpa0-import-settings&error=' .
-									rawurlencode( __( 'The file you are uploading is too big.', 'wp-auth0' ) )
-								)
-							)
-						);
-					break;
-					case 3:
-						exit(
-							wp_redirect(
-								admin_url(
-									'admin.php?page=wpa0-import-settings&error=' .
-									rawurlencode( __( 'There was an error uploading the file.', 'wp-auth0' ) )
-								)
-							)
-						);
-					break;
-					case 6:
-					case 7:
-					case 8:
-						exit(
-							wp_redirect(
-								admin_url(
-									'admin.php?page=wpa0-import-settings&error=' .
-									rawurlencode( __( 'There was an error importing your settings, please try again.', 'wp-auth0' ) )
-								)
-							)
-						);
-					break;
-				}
-			}
-		} else {
-			$settings_json = trim( stripslashes( $_POST['settings-json'] ) );
-
-			if ( empty( $settings_json ) ) {
-				exit(
-					wp_redirect(
-						admin_url(
-							'admin.php?page=wpa0-import-settings&error=' .
-							rawurlencode( __( 'Please upload the Auth0 for WordPress setting file or copy the content.', 'wp-auth0' ) )
-						)
-					)
-				);
-			}
-
-			$settings = json_decode( $settings_json, true );
-
-			if ( empty( $settings ) ) {
-				exit(
-					wp_redirect(
-						admin_url(
-							'admin.php?page=wpa0-import-settings&error=' .
-							rawurlencode( __( 'The settings json is not valid.', 'wp-auth0' ) )
-						)
-					)
-				);
-			}
+		$settings = json_decode( $settings_json, true );
+		if ( empty( $settings ) ) {
+			wp_safe_redirect( $this->make_error_url( __( 'Settings JSON entered is not valid.', 'wp-auth0' ) ) );
+			exit;
 		}
 
 		foreach ( $settings as $key => $value ) {
@@ -160,19 +36,31 @@ class WP_Auth0_Import_Settings {
 		}
 
 		$this->a0_options->update_all();
-
-		exit( wp_redirect( admin_url( 'admin.php?page=wpa0' ) ) );
+		wp_safe_redirect( admin_url( 'admin.php?page=wpa0' ) );
+		exit;
 	}
 
 	public function export_settings() {
+
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_die( __( 'Unauthorized.', 'wp-auth0' ) );
+			exit;
+		}
+
 		header( 'Content-Type: application/json' );
 		$name = urlencode( get_auth0_curatedBlogName() );
 		header( "Content-Disposition: attachment; filename=auth0_for_wordpress_settings-$name.json" );
 		header( 'Pragma: no-cache' );
 
 		$settings = get_option( $this->a0_options->get_options_name() );
-		echo json_encode( $settings );
+		echo wp_json_encode( $settings );
 		exit;
 	}
 
+	/**
+	 * @codeCoverageIgnore
+	 */
+	private function make_error_url( $error ) {
+		return admin_url( 'admin.php?page=wpa0-import-settings&error=' . rawurlencode( $error ) );
+	}
 }

--- a/lib/admin/WP_Auth0_Admin.php
+++ b/lib/admin/WP_Auth0_Admin.php
@@ -47,10 +47,8 @@ class WP_Auth0_Admin {
 			return false;
 		}
 
-		if ( in_array( $wpa0_curr_page, [ 'wpa0', 'wpa0-setup', 'wpa0-import-settings', 'wpa0-errors' ] ) ) {
-			wp_enqueue_script( 'wpa0_admin' );
-			wp_enqueue_script( 'wpa0_async' );
-		}
+		wp_enqueue_script( 'wpa0_admin' );
+		wp_enqueue_script( 'wpa0_async' );
 
 		if ( 'wpa0' === $wpa0_curr_page ) {
 			wp_enqueue_media();

--- a/templates/import_settings.php
+++ b/templates/import_settings.php
@@ -34,16 +34,8 @@ $constant_keys = $opts->get_all_constant_keys();
 		  <form action="options.php" method="post" enctype="multipart/form-data">
 			<input type="hidden" name="action" value="wpauth0_import_settings" />
 
-			<div id="js-a0-upload-file">
-			  <p class="a0-step-text top-margin"><?php _e( 'Please upload the exported json file or', 'wp-auth0' ); ?>
-					<span class="link js-a0-upload-toggle"><?php _e( 'paste the entire json', 'wp-auth0' ); ?></span>.</p>
-			  <div class="a0-step-text top-margin"><input type="file" name="settings-file" /></div>
-			</div>
-			<div id="js-a0-paste-json" style="display:none;">
-			  <p class="a0-step-text top-margin"><?php _e( 'Please paste the exported json file or', 'wp-auth0' ); ?>
-					<span class="link js-a0-upload-toggle"><?php _e( 'upload the exported file', 'wp-auth0' ); ?></span>.</p>
-			  <div class="a0-step-text top-margin"><textarea name="settings-json"></textarea></div>
-			</div>
+			  <p class="a0-step-text top-margin"><?php _e( 'Paste the settings JSON in the field below:', 'wp-auth0' ); ?>
+			  <div class="a0-step-text top-margin"><textarea name="settings-json" class="large-text code" rows="6"></textarea></div>
 
 			<div class="a0-buttons">
 			  <input type="submit" name="setup" class="a0-button primary" value="<?php _e( 'Import', 'wp-auth0' ); ?>" />

--- a/tests/testFunctionIsAdminPage.php
+++ b/tests/testFunctionIsAdminPage.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * Contains Class TestFunctionIsAdminPage.
+ *
+ * @package WP-Auth0
+ *
+ * @since 4.0.0
+ */
+
+/**
+ * Class TestFunctionIsAdminPage.
+ */
+class TestFunctionIsAdminPage extends WP_Auth0_Test_Case {
+
+	public function testThatEmptyPageReturnsFalse() {
+		$this->assertFalse( wp_auth0_is_admin_page( null ) );
+		$this->assertFalse( wp_auth0_is_admin_page( false ) );
+		$this->assertFalse( wp_auth0_is_admin_page( '' ) );
+		$this->assertFalse( wp_auth0_is_admin_page( uniqid() ) );
+	}
+
+	public function testThatNotAdminReturnsFalse() {
+		$_REQUEST['page'] = '__test_page__';
+		$this->assertFalse( wp_auth0_is_admin_page( '__test_page__' ) );
+
+		$_REQUEST['page'] = 'wpa0';
+		$this->assertFalse( wp_auth0_is_admin_page( 'wpa0' ) );
+	}
+
+	public function testThatIncorrectPageReturnsFalse() {
+		$GLOBALS['current_screen'] = new class { public function in_admin() {
+				return true;
+		} };
+		$_REQUEST['page']          = '__current_page__';
+		$this->assertFalse( wp_auth0_is_admin_page( '__page_requested__' ) );
+	}
+
+	public function testThatCorrectPageReturnsTrue() {
+		$GLOBALS['current_screen'] = new class { public function in_admin() {
+				return true;
+		} };
+		$_REQUEST['page']          = '__current_page__';
+		$this->assertTrue( wp_auth0_is_admin_page( '__current_page__' ) );
+	}
+}

--- a/tests/testImportExportSettings.php
+++ b/tests/testImportExportSettings.php
@@ -1,0 +1,168 @@
+<?php
+/**
+ * Contains Class TestImportExportSettings.
+ *
+ * @package WP-Auth0
+ *
+ * @since 4.0.0
+ */
+
+/**
+ * Class TestImportExportSettings.
+ */
+class TestImportExportSettings extends WP_Auth0_Test_Case {
+
+	use HookHelpers;
+
+	use RedirectHelpers;
+
+	use UsersHelper;
+
+	use WpDieHelper;
+
+	public function testThatImportExportHooksAreSet() {
+		$expect_hooked = [
+			'wp_auth0_export_settings_admin_action' => [
+				'priority'      => 10,
+				'accepted_args' => 1,
+			],
+		];
+		$this->assertHookedFunction( 'admin_action_wpauth0_export_settings', $expect_hooked );
+
+		$expect_hooked = [
+			'wp_auth0_import_settings_admin_action' => [
+				'priority'      => 10,
+				'accepted_args' => 1,
+			],
+		];
+		$this->assertHookedFunction( 'admin_action_wpauth0_import_settings', $expect_hooked );
+
+		$expect_hooked = [
+			'wp_auth0_settings_admin_action_error' => [
+				'priority'      => 10,
+				'accepted_args' => 1,
+			],
+		];
+		$this->assertHookedFunction( 'admin_notices', $expect_hooked );
+	}
+
+	public function testThatSettingsImportNoticeDoesNotAppearIfNoError() {
+		$GLOBALS['current_screen'] = new class { public function in_admin() {
+				return true;
+		} };
+		$_REQUEST['page']          = 'wpa0-import-settings';
+
+		ob_start();
+		$this->assertFalse( wp_auth0_settings_admin_action_error() );
+		$this->assertEmpty( ob_get_clean() );
+	}
+
+	public function testThatSettingsImportNoticeDoesNotAppearIfWrongPage() {
+		$GLOBALS['current_screen'] = new class { public function in_admin() {
+				return true;
+		} };
+		$_REQUEST['page']          = uniqid();
+		$_REQUEST['error']         = '__test_error_message__';
+
+		ob_start();
+		$this->assertFalse( wp_auth0_settings_admin_action_error() );
+		$this->assertEmpty( ob_get_clean() );
+	}
+
+	public function testThatSettingsImportNoticeAppearsCorrectly() {
+		$GLOBALS['current_screen'] = new class { public function in_admin() {
+				return true;
+		} };
+		$_REQUEST['page']          = 'wpa0-import-settings';
+		$_REQUEST['error']         = '__test_error_message__';
+
+		ob_start();
+		$this->assertTrue( wp_auth0_settings_admin_action_error() );
+
+		$notice_html = ob_get_clean();
+		$this->assertContains( 'class="notice notice-error is-dismissible"', $notice_html );
+		$this->assertContains( '<p><strong>__test_error_message__</strong></p>', $notice_html );
+	}
+
+	public function testThatProcessDiesIfNotAdminForExport() {
+		$this->startWpDieHalting();
+
+		try {
+			wp_auth0_export_settings_admin_action();
+			$output = 'Not caught';
+		} catch ( \Exception $e ) {
+			$output = $e->getMessage();
+		}
+
+		$this->assertEquals( 'Unauthorized.', $output );
+	}
+
+	public function testThatProcessDiesIfNotAdminForImport() {
+		$this->startWpDieHalting();
+
+		try {
+			wp_auth0_import_settings_admin_action();
+			$output = 'Not caught';
+		} catch ( \Exception $e ) {
+			$output = $e->getMessage();
+		}
+
+		$this->assertEquals( 'Unauthorized.', $output );
+	}
+
+	public function testThatErrorRedirectHappensIfJsonEmpty() {
+		$this->startRedirectHalting();
+		$this->setGlobalUser();
+
+		try {
+			wp_auth0_import_settings_admin_action();
+			$redirect_data = [ 'location' => 'No redirect caught' ];
+		} catch ( Exception $e ) {
+			$redirect_data = unserialize( $e->getMessage() );
+		}
+
+		$this->assertEquals(
+			'http://example.org/wp-admin/admin.php?page=wpa0-import-settings&error=No%20settings%20JSON%20entered.',
+			$redirect_data['location']
+		);
+
+		$this->assertEquals( 302, $redirect_data['status'] );
+	}
+
+	public function testThatErrorRedirectHappensIfJsonInvalid() {
+		$this->startRedirectHalting();
+		$this->setGlobalUser();
+		$_POST['settings-json'] = uniqid();
+
+		try {
+			wp_auth0_import_settings_admin_action();
+			$redirect_data = [ 'location' => 'No redirect caught' ];
+		} catch ( Exception $e ) {
+			$redirect_data = unserialize( $e->getMessage() );
+		}
+
+		$this->assertEquals(
+			'http://example.org/wp-admin/admin.php?page=wpa0-import-settings&error=Settings%20JSON%20entered%20is%20not%20valid.',
+			$redirect_data['location']
+		);
+
+		$this->assertEquals( 302, $redirect_data['status'] );
+	}
+
+	public function testThatSettingsAreUpdatedWithValidJson() {
+		$this->startRedirectHalting();
+		$this->setGlobalUser();
+		$_POST['settings-json'] = '{"domain":"__test_imported_domain__"}';
+
+		try {
+			wp_auth0_import_settings_admin_action();
+			$redirect_data = [ 'location' => 'No redirect caught' ];
+		} catch ( Exception $e ) {
+			$redirect_data = unserialize( $e->getMessage() );
+		}
+
+		$this->assertEquals( '__test_imported_domain__', wp_auth0_get_option( 'domain' ) );
+		$this->assertEquals( 'http://example.org/wp-admin/admin.php?page=wpa0', $redirect_data['location'] );
+		$this->assertEquals( 302, $redirect_data['status'] );
+	}
+}


### PR DESCRIPTION
### Changes

- Remove ability to upload an import JSON file to avoid potential security problems and additional site configuration (JSON files are not allowed by default in WP).
- Move `WP_Auth0_Import_Settings::init()` actions to functions.
- Remove `WP_Auth0_Import_Settings::show_error()`
- Add explicit checks for admin capabilities on import and export settings pages.

### Testing

* [x] This change adds unit test coverage
* [x] This change has been tested on WP 5.3

### Checklist

* [x] All existing and new tests complete without errors
* [x] All code quality tools/guidelines in the [Contribution guide](CONTRIBUTION.md) have been run/followed
* [x] All active GitHub CI checks have passed
