### PR TITLE
Fix include path for functions file

### DIFF
--- a/WP_Auth0.php
+++ b/WP_Auth0.php
@@ -30,8 +30,8 @@ define( 'WPA0_JWKS_CACHE_TRANSIENT_NAME', 'WP_Auth0_JWKS_cache' );
 
 define( 'WPA0_LANG', 'wp-auth0' ); // deprecated; do not use for translations
 
-require_once 'vendor/autoload.php';
-require_once 'functions.php';
+require_once WPA0_PLUGIN_DIR.'vendor/autoload.php';
+require_once WPA0_PLUGIN_DIR.'functions.php';
 
 /*
  * Localization


### PR DESCRIPTION
### Changes

Add absolute path constant to included files.

### References

https://wordpress.org/support/topic/call-to-functions-php/

