### PR TITLE
Patch samesite for implicit

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,8 +40,8 @@
         "test": "\"vendor/bin/phpunit\" --coverage-text",
         "test-group": "\"vendor/bin/phpunit\" --coverage-text --group",
         "test-ci": "\"vendor/bin/phpunit\" --coverage-clover=coverage.xml",
-        "pre-commit-no-tests": [ "@phpcbf", "@phpcbf-tests", "@phpcs-tests", "@compat", "@phpcs-i18n" ],
-        "pre-commit": [ "@phpcbf", "@phpcbf-tests", "@phpcs-tests", "@compat", "@phpcs-i18n", "@test" ]
+        "pre-commit-no-tests": [ "@phpcbf", "@phpcbf-tests", "@compat", "@phpcs-i18n" ],
+        "pre-commit": [ "@phpcbf", "@phpcbf-tests", "@compat", "@phpcs-i18n", "@test" ]
     },
     "autoload-dev": {
         "classmap": ["tests/classes/", "tests/traits/"]

--- a/functions.php
+++ b/functions.php
@@ -103,6 +103,15 @@ function wp_auth0_can_show_wp_login_form() {
 	return false;
 }
 
+/**
+ *
+ * @return bool
+ */
+function wp_auth0_uses_secure_callback() {
+	$callback_url = WP_Auth0_Options::Instance()->get_wp_auth0_url();
+	return 'https' === parse_url( $callback_url, PHP_URL_SCHEME );
+}
+
 if ( ! function_exists( 'get_auth0userinfo' ) ) {
 	function get_auth0userinfo( $user_id ) {
 		$profile = WP_Auth0_UsersRepo::get_meta( $user_id, 'auth0_obj' );

--- a/lib/WP_Auth0_LoginManager.php
+++ b/lib/WP_Auth0_LoginManager.php
@@ -569,11 +569,10 @@ class WP_Auth0_LoginManager {
 	 * @return array
 	 */
 	public static function get_authorize_params( $connection = null, $redirect_to = null ) {
-		$params       = array();
-		$options      = WP_Auth0_Options::Instance();
-		$lock_options = new WP_Auth0_Lock10_Options();
-		$is_implicit  = (bool) $options->get( 'auth0_implicit_workflow', false );
-		$nonce        = WP_Auth0_Nonce_Handler::get_instance()->get_unique();
+		$params      = array();
+		$options     = WP_Auth0_Options::Instance();
+		$is_implicit = (bool) $options->get( 'auth0_implicit_workflow', false );
+		$nonce       = WP_Auth0_Nonce_Handler::get_instance()->get_unique();
 
 		$params['client_id']     = $options->get( 'client_id' );
 		$params['scope']         = self::get_userinfo_scope( 'authorize_url' );

--- a/lib/WP_Auth0_LoginManager.php
+++ b/lib/WP_Auth0_LoginManager.php
@@ -578,9 +578,7 @@ class WP_Auth0_LoginManager {
 		$params['client_id']     = $options->get( 'client_id' );
 		$params['scope']         = self::get_userinfo_scope( 'authorize_url' );
 		$params['response_type'] = $is_implicit ? 'id_token' : 'code';
-		$params['redirect_uri']  = $is_implicit
-			? $lock_options->get_implicit_callback_url()
-			: $options->get_wp_auth0_url();
+		$params['redirect_uri']  = $options->get_wp_auth0_url( null, $is_implicit );
 
 		if ( $is_implicit ) {
 			$params['nonce']         = $nonce;

--- a/lib/WP_Auth0_Nonce_Handler.php
+++ b/lib/WP_Auth0_Nonce_Handler.php
@@ -40,6 +40,14 @@ class WP_Auth0_Nonce_Handler {
 	private $unique;
 
 	/**
+	 * SameSite cookie attribute set to None.
+	 * Used for Implicit login flow.
+	 *
+	 * @var bool
+	 */
+	private $same_site_none;
+
+	/**
 	 * Private to prevent cloning.
 	 */
 	private function __clone() {}
@@ -69,6 +77,8 @@ class WP_Auth0_Nonce_Handler {
 			// No cookie, need to create one.
 			$this->unique = $this->generate_unique();
 		}
+
+		$this->same_site_none = (bool) wp_auth0_get_option( 'auth0_implicit_workflow' );
 	}
 
 	/**
@@ -125,6 +135,9 @@ class WP_Auth0_Nonce_Handler {
 	public function validate( $value ) {
 		$cookie_name = static::get_storage_cookie_name();
 		$valid       = isset( $_COOKIE[ $cookie_name ] ) ? $_COOKIE[ $cookie_name ] === $value : false;
+		if ( $this->same_site_none && ! $valid ) {
+			$valid = isset( $_COOKIE[ '_' . $cookie_name ] ) ? $_COOKIE[ '_' . $cookie_name ] === $value : false;
+		}
 		$this->reset();
 		return $valid;
 	}
@@ -166,13 +179,94 @@ class WP_Auth0_Nonce_Handler {
 	 * @return bool
 	 */
 	protected function handle_cookie( $cookie_name, $cookie_value, $cookie_exp ) {
-		if ( $cookie_exp <= time() ) {
-			unset( $_COOKIE[ $cookie_name ] );
-			$cookie_exp = 0;
-		} else {
-			$_COOKIE[ $cookie_name ] = $cookie_value;
+		$illegal_chars = ",; \t\r\n\013\014";
+		if ( strpbrk( $cookie_name, $illegal_chars ) != null ) {
+			WP_Auth0_ErrorManager::insert_auth0_error(
+				__METHOD__,
+				new WP_Error(
+					'invalid_nonce',
+					'Cookie names and values cannot contain any of the following: ' . wp_slash( $illegal_chars )
+				)
+			);
+			return false;
 		}
-		return setcookie( $cookie_name, $cookie_value, $cookie_exp, '/' );
+
+		// Cookie is being deleted.
+		if ( $cookie_exp <= time() ) {
+
+			// Delete SameSite=None fallback cookie.
+			if ( $this->same_site_none ) {
+				unset( $_COOKIE[ '_' . $cookie_name ] );
+				$this->setCookie( '_' . $cookie_name, '', 0 );
+			}
+
+			unset( $_COOKIE[ $cookie_name ] );
+			return $this->setCookie( $cookie_name, '', 0 );
+		}
+
+		$_COOKIE[ $cookie_name ] = $cookie_value;
+
+		// Set SameSite=None fallback cookie and use headers for main cookie.
+		if ( $this->same_site_none ) {
+			$_COOKIE[ '_' . $cookie_name ] = $cookie_value;
+			$this->setCookieHeader( $cookie_name, $cookie_value, $cookie_exp );
+			return $this->setCookie( '_' . $cookie_name, $cookie_value, $cookie_exp );
+		}
+
+		return $this->setCookie( $cookie_name, $cookie_value, $cookie_exp );
+	}
+
+	/**
+	 * Build the header to use when setting SameSite cookies.
+	 *
+	 * @param string  $name   Cookie name.
+	 * @param string  $value  Cookie value.
+	 * @param integer $expire Cookie expiration timecode.
+	 *
+	 * @return string
+	 *
+	 * @see https://github.com/php/php-src/blob/master/ext/standard/head.c#L77
+	 */
+	protected function getSameSiteCookieHeader( $name, $value, $expire ) {
+		$date = new \Datetime();
+		$date->setTimestamp( $expire )->setTimezone( new \DateTimeZone( 'GMT' ) );
+
+		return sprintf(
+			'Set-Cookie: %s=%s; path=/; expires=%s; HttpOnly; SameSite=None; Secure',
+			$name,
+			$value,
+			$date->format( $date::COOKIE )
+		);
+	}
+
+	/**
+	 * Wrapper around PHP core setcookie() function to assist with testing.
+	 *
+	 * @param string  $name   Complete cookie name to set.
+	 * @param string  $value  Value of the cookie to set.
+	 * @param integer $expire Expiration time in Unix timecode format.
+	 *
+	 * @return boolean
+	 *
+	 * @codeCoverageIgnore
+	 */
+	protected function setCookie( $name, $value, $expire ) {
+		return setcookie( $name, $value, $expire, '/', '', false, true );
+	}
+
+	/**
+	 * Wrapper around PHP core header() function to assist with testing.
+	 *
+	 * @param string  $name   Complete cookie name to set.
+	 * @param string  $value  Value of the cookie to set.
+	 * @param integer $expire Expiration time in Unix timecode format.
+	 *
+	 * @return void
+	 *
+	 * @codeCoverageIgnore
+	 */
+	protected function setCookieHeader( $name, $value, $expire ) {
+		header( $this->getSameSiteCookieHeader( $name, $value, $expire ), false );
 	}
 
 	/**
@@ -181,6 +275,7 @@ class WP_Auth0_Nonce_Handler {
 	 * @return string
 	 */
 	public static function get_storage_cookie_name() {
+		// phpcs:ignore
 		return apply_filters( 'auth0_nonce_cookie_name', static::NONCE_COOKIE_NAME );
 	}
 }

--- a/lib/WP_Auth0_Nonce_Handler.php
+++ b/lib/WP_Auth0_Nonce_Handler.php
@@ -59,7 +59,6 @@ class WP_Auth0_Nonce_Handler {
 
 	/**
 	 * WP_Auth0_Nonce_Handler constructor.
-	 * Private to prevent new instances of this class.
 	 */
 	public function __construct() {
 		$this->init();
@@ -180,7 +179,7 @@ class WP_Auth0_Nonce_Handler {
 	 */
 	protected function handle_cookie( $cookie_name, $cookie_value, $cookie_exp ) {
 		$illegal_chars = ",; \t\r\n\013\014";
-		if ( strpbrk( $cookie_name, $illegal_chars ) != null ) {
+		if ( strpbrk( $cookie_name, $illegal_chars ) || strpbrk( $cookie_value, $illegal_chars ) ) {
 			WP_Auth0_ErrorManager::insert_auth0_error(
 				__METHOD__,
 				new WP_Error(
@@ -218,6 +217,7 @@ class WP_Auth0_Nonce_Handler {
 
 	/**
 	 * Build the header to use when setting SameSite cookies.
+	 * NOTE: Validity of $name and $value is not checked here; see handle_cookie().
 	 *
 	 * @param string  $name   Cookie name.
 	 * @param string  $value  Cookie value.
@@ -243,6 +243,7 @@ class WP_Auth0_Nonce_Handler {
 
 	/**
 	 * Wrapper around PHP core setcookie() function to assist with testing.
+	 * NOTE: Validity of $name and $value is not checked here; see handle_cookie().
 	 *
 	 * @param string  $name   Complete cookie name to set.
 	 * @param string  $value  Value of the cookie to set.
@@ -258,6 +259,7 @@ class WP_Auth0_Nonce_Handler {
 
 	/**
 	 * Wrapper around PHP core header() function to assist with testing.
+	 * NOTE: Validity of $name and $value is not checked here; see handle_cookie().
 	 *
 	 * @param string  $name   Complete cookie name to set.
 	 * @param string  $value  Value of the cookie to set.

--- a/lib/WP_Auth0_Options.php
+++ b/lib/WP_Auth0_Options.php
@@ -94,6 +94,9 @@ class WP_Auth0_Options extends WP_Auth0_Options_Generic {
 	 * @return string
 	 */
 	public function get_wp_auth0_url( $protocol = null, $implicit = false ) {
+		if ( is_null( $protocol ) && $this->get( 'force_https_callback' ) ) {
+			$protocol = 'https';
+		}
 		$site_url = site_url( 'index.php', $protocol );
 		return add_query_arg( 'auth0', ( $implicit ? 'implicit' : '1' ), $site_url );
 	}

--- a/lib/admin/WP_Auth0_Admin_Advanced.php
+++ b/lib/admin/WP_Auth0_Admin_Advanced.php
@@ -115,13 +115,20 @@ class WP_Auth0_Admin_Advanced extends WP_Auth0_Admin_Generic {
 				'id'       => 'wpa0_auto_login',
 				'function' => 'render_auto_login',
 			),
-			array(
+			);
+
+		// TODO: Remove this once feature has been removed
+		if ( $this->options->get( 'auth0_implicit_workflow' ) ) {
+			$options[] = array(
 				'name'     => __( 'Implicit Login Flow', 'wp-auth0' ),
 				'opt'      => 'auth0_implicit_workflow',
 				'id'       => 'wpa0_auth0_implicit_workflow',
 				'function' => 'render_auth0_implicit_workflow',
-			),
-			array(
+			);
+		}
+
+		$options = $options + array(
+			( count( $options ) ) => array(
 				'name'     => __( 'Valid Proxy IP', 'wp-auth0' ),
 				'opt'      => 'valid_proxy_ip',
 				'id'       => 'wpa0_valid_proxy_ip',
@@ -455,6 +462,18 @@ class WP_Auth0_Admin_Advanced extends WP_Auth0_Admin_Generic {
 	 */
 	public function render_auth0_implicit_workflow( $args = array() ) {
 		$this->render_switch( $args['label_for'], $args['opt_name'] );
+
+		if ( ! wp_auth0_uses_secure_callback() ) {
+			$this->render_field_description(
+				'<span style="color: red">' .
+				__( 'This setting requires the site to be served over HTTPS', 'wp-auth0' ) . '</span>'
+			);
+		}
+
+		$this->render_field_description(
+			'<strong>' . __( 'This setting is deprecated and will be removed in the next major', 'wp-auth0' ) . '</strong>'
+		);
+
 		$this->render_field_description(
 			__( 'Turns on implicit login flow, which most sites will not need. ', 'wp-auth0' ) .
 			__( 'Only enable this if outbound connections to auth0.com are disabled on your server. ', 'wp-auth0' ) .

--- a/lib/admin/WP_Auth0_Admin_Advanced.php
+++ b/lib/admin/WP_Auth0_Admin_Advanced.php
@@ -115,7 +115,7 @@ class WP_Auth0_Admin_Advanced extends WP_Auth0_Admin_Generic {
 				'id'       => 'wpa0_auto_login',
 				'function' => 'render_auto_login',
 			),
-			);
+		);
 
 		// TODO: Remove this once feature has been removed
 		if ( $this->options->get( 'auth0_implicit_workflow' ) ) {

--- a/tests/classes/WP_Auth0_Test_Case.php
+++ b/tests/classes/WP_Auth0_Test_Case.php
@@ -76,6 +76,8 @@ abstract class WP_Auth0_Test_Case extends \PHPUnit\Framework\TestCase {
 	public function tearDown() {
 		parent::tearDown();
 
+		$_COOKIE = [];
+
 		update_option( 'users_can_register', false );
 		update_option( 'home', self::$home_url );
 		update_option( 'siteurl', self::$site_url );

--- a/tests/classes/WP_Auth0_Test_Case.php
+++ b/tests/classes/WP_Auth0_Test_Case.php
@@ -38,13 +38,20 @@ abstract class WP_Auth0_Test_Case extends \PHPUnit\Framework\TestCase {
 	public static $home_url;
 
 	/**
+	 * Existing site_url value before tests.
+	 *
+	 * @var string
+	 */
+	public static $site_url;
+
+	/**
 	 * Runs before test suite starts.
 	 */
 	public static function setUpBeforeClass() {
 		parent::setUpBeforeClass();
 		self::$opts      = WP_Auth0_Options::Instance();
 		self::$error_log = new WP_Auth0_ErrorLog();
-		self::$home_url  = home_url();
+		self::$site_url  = site_url();
 	}
 
 	/**
@@ -70,7 +77,8 @@ abstract class WP_Auth0_Test_Case extends \PHPUnit\Framework\TestCase {
 		parent::tearDown();
 
 		update_option( 'users_can_register', false );
-		update_option( 'home_url', self::$home_url );
+		update_option( 'home', self::$home_url );
+		update_option( 'siteurl', self::$site_url );
 
 		delete_transient( WPA0_JWKS_CACHE_TRANSIENT_NAME );
 

--- a/tests/testFunctionUsesSecureCallback.php
+++ b/tests/testFunctionUsesSecureCallback.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * Contains Class TestFunctionUsesSecureCallback.
+ *
+ * @package WP-Auth0
+ *
+ * @since 3.11.2
+ */
+
+/**
+ * Class TestFunctionUsesSecureCallback.
+ */
+class TestFunctionUsesSecureCallback extends WP_Auth0_Test_Case {
+
+	public function tearDown() {
+		parent::tearDown();
+		unset( $_SERVER['HTTPS'] );
+	}
+
+	public function testThatDefaultCallbackUrlIsNotSecure() {
+		$this->assertFalse( wp_auth0_uses_secure_callback() );
+	}
+
+	public function testThatDefaultCallbackUrlIsSecureIfSsl() {
+		$this->assertFalse( wp_auth0_uses_secure_callback() );
+		$_SERVER['HTTPS'] = 1;
+		$this->assertTrue( wp_auth0_uses_secure_callback() );
+	}
+
+	public function testThatDefaultCallbackUrlIsSecureIfForced() {
+		$this->assertFalse( wp_auth0_uses_secure_callback() );
+		self::$opts->set( 'force_https_callback', 1 );
+		$this->assertTrue( wp_auth0_uses_secure_callback() );
+	}
+}

--- a/tests/testNonceHandler.php
+++ b/tests/testNonceHandler.php
@@ -1,0 +1,160 @@
+<?php
+/**
+ * Contains Class TestNonceHandler.
+ *
+ * @package WP-Auth0
+ *
+ * @since 3.11.2
+ */
+
+/**
+ * Class TestNonceHandler.
+ */
+class TestNonceHandler extends WP_Auth0_Test_Case {
+
+	/**
+	 * @var WP_Auth0_Nonce_Handler
+	 */
+	public static $nonceHandler;
+
+	/**
+	 * @var \PHPUnit\Framework\MockObject\Matcher\AnyInvokedCount
+	 */
+	private static $mockSpyCookie;
+
+	/**
+	 * @var \PHPUnit\Framework\MockObject\Matcher\AnyInvokedCount
+	 */
+	private static $mockSpyHeader;
+
+	/**
+	 * Run after each test in this suite.
+	 */
+	public function tearDown() {
+		parent::tearDown();
+		self::$mockSpyCookie = null;
+		self::$mockSpyHeader = null;
+	}
+
+	public function testDefaults() {
+		$this->assertEquals( 'auth0_nonce', WP_Auth0_Nonce_Handler::NONCE_COOKIE_NAME );
+		$this->assertEquals( 'auth0_nonce', WP_Auth0_Nonce_Handler::get_storage_cookie_name() );
+		$this->assertEquals( 3600, WP_Auth0_Nonce_Handler::COOKIE_EXPIRES );
+		$this->assertGreaterThanOrEqual( 32, strlen( WP_Auth0_Nonce_Handler::get_instance()->get_unique() ) );
+	}
+
+	public function testCookieNameFilter() {
+		add_filter( 'auth0_nonce_cookie_name', [ $this, 'cookieFilter' ] );
+		$this->assertEquals( '__test_custom_cookie_name__', WP_Auth0_Nonce_Handler::get_storage_cookie_name() );
+		remove_filter( 'auth0_nonce_cookie_name', [ $this, 'cookieFilter' ] );
+	}
+
+	public function testThatValidateReturnsFalseAndCookieResetWhenNoCookie() {
+		$mockNonceHandler = $this->getMock();
+		$this->assertFalse( $mockNonceHandler->validate( uniqid() ) );
+		$this->assertCount( 1, (array) self::$mockSpyCookie->getInvocations() );
+
+		$setCookieParams = self::$mockSpyCookie->getInvocations()[0]->getParameters();
+
+		$this->assertEquals( 'auth0_nonce', $setCookieParams[0] );
+		$this->assertEquals( '', $setCookieParams[1] );
+		$this->assertEquals( 0, $setCookieParams[2] );
+	}
+
+	public function testThatValidateReturnsFalseWhenCookieInvalid() {
+		$mockNonceHandler      = $this->getMock();
+		$_COOKIE['auth_nonce'] = '__invalid_nonce__';
+		$this->assertFalse( $mockNonceHandler->validate( '__valid_nonce__' ) );
+		$this->assertArrayNotHasKey( 'auth0_nonce', $_COOKIE );
+	}
+
+	public function testThatBackupCookieIsCheckedAndResetWhenImplicit() {
+		self::$opts->set( 'auth0_implicit_workflow', 1 );
+		$mockNonceHandler        = $this->getMock();
+		$_COOKIE['auth0_nonce']  = '';
+		$_COOKIE['_auth0_nonce'] = '__valid_nonce__';
+		$this->assertTrue( $mockNonceHandler->validate( '__valid_nonce__' ) );
+		$this->assertCount( 2, (array) self::$mockSpyCookie->getInvocations() );
+
+		$setCookieParamsMain = self::$mockSpyCookie->getInvocations()[1]->getParameters();
+
+		$this->assertEquals( 'auth0_nonce', $setCookieParamsMain[0] );
+		$this->assertEquals( '', $setCookieParamsMain[1] );
+		$this->assertEquals( 0, $setCookieParamsMain[2] );
+
+		$setCookieParamsBackup = self::$mockSpyCookie->getInvocations()[0]->getParameters();
+
+		$this->assertEquals( '_auth0_nonce', $setCookieParamsBackup[0] );
+		$this->assertEquals( '', $setCookieParamsBackup[1] );
+		$this->assertEquals( 0, $setCookieParamsBackup[2] );
+
+		$this->assertArrayNotHasKey( '_auth0_nonce', $_COOKIE );
+		$this->assertArrayNotHasKey( 'auth0_nonce', $_COOKIE );
+	}
+
+	public function testThatCookieValueIsSet() {
+		$mockNonceHandler = $this->getMock();
+		$mockNonceHandler->set_cookie( '__test_cookie_value__' );
+
+		$this->assertEquals( '__test_cookie_value__', $_COOKIE['auth0_nonce'] );
+		$this->assertArrayNotHasKey( '_auth0_nonce', $_COOKIE );
+		$this->assertCount( 1, (array) self::$mockSpyCookie->getInvocations() );
+
+		$setCookieParams = self::$mockSpyCookie->getInvocations()[0]->getParameters();
+
+		$this->assertEquals( 'auth0_nonce', $setCookieParams[0] );
+		$this->assertEquals( '__test_cookie_value__', $setCookieParams[1] );
+		$this->assertGreaterThanOrEqual( time() + 3600, $setCookieParams[2] );
+	}
+
+	public function testThatMainAndBackupCookiesAreSetForImplicit() {
+		self::$opts->set( 'auth0_implicit_workflow', 1 );
+		$mockNonceHandler = $this->getMock();
+		$mockNonceHandler->set_cookie( '__test_cookie_value__' );
+
+		$this->assertEquals( '__test_cookie_value__', $_COOKIE['auth0_nonce'] );
+		$this->assertEquals( '__test_cookie_value__', $_COOKIE['_auth0_nonce'] );
+		$this->assertCount( 1, (array) self::$mockSpyCookie->getInvocations() );
+		$this->assertCount( 1, (array) self::$mockSpyHeader->getInvocations() );
+
+		$setCookieParams = self::$mockSpyCookie->getInvocations()[0]->getParameters();
+
+		$this->assertEquals( '_auth0_nonce', $setCookieParams[0] );
+		$this->assertEquals( '__test_cookie_value__', $setCookieParams[1] );
+		$this->assertGreaterThanOrEqual( time() + 3600, $setCookieParams[2] );
+
+		$setHeaderParams = self::$mockSpyHeader->getInvocations()[0]->getParameters();
+
+		$this->assertEquals( 'auth0_nonce', $setHeaderParams[0] );
+		$this->assertEquals( '__test_cookie_value__', $setHeaderParams[1] );
+		$this->assertGreaterThanOrEqual( time() + 3600, $setHeaderParams[2] );
+	}
+
+	/*
+	 * Helper methods
+	 */
+
+	/**
+	 * @param array $args
+	 *
+	 * @return \PHPUnit\Framework\MockObject\MockObject|WP_Auth0_Nonce_Handler
+	 */
+	public function getMock( array $args = [] ) {
+		$mockStore = $this->getMockBuilder( WP_Auth0_Nonce_Handler::class )
+						  ->setMethods( [ 'write_cookie', 'write_cookie_header' ] )
+						  ->getMock();
+
+		$mockStore->expects( self::$mockSpyCookie = $this->any() )
+				  ->method( 'write_cookie' )
+				  ->willReturn( true );
+
+		$mockStore->expects( self::$mockSpyHeader = $this->any() )
+				  ->method( 'write_cookie_header' );
+
+		return $mockStore;
+	}
+
+	public function cookieFilter() {
+		return '__test_custom_cookie_name__';
+	}
+}

--- a/tests/testNonceHandler.php
+++ b/tests/testNonceHandler.php
@@ -54,7 +54,7 @@ class TestNonceHandler extends WP_Auth0_Test_Case {
 		$this->assertFalse( $mockNonceHandler->validate( uniqid() ) );
 		$this->assertCount( 1, (array) self::$mockSpyCookie->getInvocations() );
 
-		$setCookieParams = self::$mockSpyCookie->getInvocations()[0]->getParameters();
+		$setCookieParams = $this->getSpyParameters( self::$mockSpyCookie->getInvocations()[0] );
 
 		$this->assertEquals( 'auth0_nonce', $setCookieParams[0] );
 		$this->assertEquals( '', $setCookieParams[1] );
@@ -76,13 +76,13 @@ class TestNonceHandler extends WP_Auth0_Test_Case {
 		$this->assertTrue( $mockNonceHandler->validate( '__valid_nonce__' ) );
 		$this->assertCount( 2, (array) self::$mockSpyCookie->getInvocations() );
 
-		$setCookieParamsMain = self::$mockSpyCookie->getInvocations()[1]->getParameters();
+		$setCookieParamsMain = $this->getSpyParameters( self::$mockSpyCookie->getInvocations()[1] );
 
 		$this->assertEquals( 'auth0_nonce', $setCookieParamsMain[0] );
 		$this->assertEquals( '', $setCookieParamsMain[1] );
 		$this->assertEquals( 0, $setCookieParamsMain[2] );
 
-		$setCookieParamsBackup = self::$mockSpyCookie->getInvocations()[0]->getParameters();
+		$setCookieParamsBackup = $this->getSpyParameters( self::$mockSpyCookie->getInvocations()[0] );
 
 		$this->assertEquals( '_auth0_nonce', $setCookieParamsBackup[0] );
 		$this->assertEquals( '', $setCookieParamsBackup[1] );
@@ -100,7 +100,7 @@ class TestNonceHandler extends WP_Auth0_Test_Case {
 		$this->assertArrayNotHasKey( '_auth0_nonce', $_COOKIE );
 		$this->assertCount( 1, (array) self::$mockSpyCookie->getInvocations() );
 
-		$setCookieParams = self::$mockSpyCookie->getInvocations()[0]->getParameters();
+		$setCookieParams = $this->getSpyParameters( self::$mockSpyCookie->getInvocations()[0] );
 
 		$this->assertEquals( 'auth0_nonce', $setCookieParams[0] );
 		$this->assertEquals( '__test_cookie_value__', $setCookieParams[1] );
@@ -117,13 +117,13 @@ class TestNonceHandler extends WP_Auth0_Test_Case {
 		$this->assertCount( 1, (array) self::$mockSpyCookie->getInvocations() );
 		$this->assertCount( 1, (array) self::$mockSpyHeader->getInvocations() );
 
-		$setCookieParams = self::$mockSpyCookie->getInvocations()[0]->getParameters();
+		$setCookieParams = $this->getSpyParameters( self::$mockSpyCookie->getInvocations()[0] );
 
 		$this->assertEquals( '_auth0_nonce', $setCookieParams[0] );
 		$this->assertEquals( '__test_cookie_value__', $setCookieParams[1] );
 		$this->assertGreaterThanOrEqual( time() + 3600, $setCookieParams[2] );
 
-		$setHeaderParams = self::$mockSpyHeader->getInvocations()[0]->getParameters();
+		$setHeaderParams = $this->getSpyParameters( self::$mockSpyHeader->getInvocations()[0] );
 
 		$this->assertEquals( 'auth0_nonce', $setHeaderParams[0] );
 		$this->assertEquals( '__test_cookie_value__', $setHeaderParams[1] );
@@ -133,6 +133,14 @@ class TestNonceHandler extends WP_Auth0_Test_Case {
 	/*
 	 * Helper methods
 	 */
+
+	public function getSpyParameters( $spyInvocation ) {
+		if ( method_exists( $spyInvocation, 'getParameters' ) ) {
+			return $spyInvocation->getParameters();
+		} else {
+			return $spyInvocation->parameters;
+		}
+	}
 
 	/**
 	 * @param array $args

--- a/tests/testWPAuth0Options.php
+++ b/tests/testWPAuth0Options.php
@@ -198,4 +198,23 @@ class TestWPAuth0Options extends WP_Auth0_Test_Case {
 		$db_options = get_option( $opts->get_options_name() );
 		$this->assertEquals( '__test_domain__', $db_options['domain'] );
 	}
+
+	public function testThatDefaultCallbackUrlsAreCorrect() {
+		$opts = new WP_Auth0_Options();
+		$this->assertEquals( 'http://example.org/index.php?auth0=1', $opts->get_wp_auth0_url() );
+		$this->assertEquals( 'http://example.org/index.php?auth0=implicit', $opts->get_wp_auth0_url( null, true ) );
+	}
+
+	public function testThatCustomProtocolCallbackUrlsAreCorrect() {
+		$opts = new WP_Auth0_Options();
+		$this->assertEquals( 'https://example.org/index.php?auth0=1', $opts->get_wp_auth0_url( 'https' ) );
+		$this->assertEquals( 'https://example.org/index.php?auth0=implicit', $opts->get_wp_auth0_url( 'https', true ) );
+	}
+
+	public function testThatForcedHttpsCallbackUrlsAreCorrect() {
+		$opts = new WP_Auth0_Options();
+		$opts->set( 'force_https_callback', 1 );
+		$this->assertEquals( 'https://example.org/index.php?auth0=1', $opts->get_wp_auth0_url() );
+		$this->assertEquals( 'https://example.org/index.php?auth0=implicit', $opts->get_wp_auth0_url( null, true ) );
+	}
 }


### PR DESCRIPTION
### Changes

- Add SameSite=None and Secure attribute to nonce and state cookies when implicit mode is turned on
- Add notice for implicit mode deprecation and HTTPS check if this setting is turned on

### References 

[Web.dev: SameSite cookies explained](https://web.dev/samesite-cookies-explained/)

### Testing

* [x] This change adds unit test coverage
* [x] This change has been tested on PHP 7.2 and WP 5.3.2

### Checklist

* [x] All existing and new tests complete without errors
* [x] All code quality tools/guidelines in the [Contribution guide](CONTRIBUTION.md) have been run/followed
* [x] All active GitHub CI checks have passed
