### PR TITLE
Remove error_log calls and add auth0_insert_error action

### DIFF
--- a/lib/WP_Auth0_Api_Client.php
+++ b/lib/WP_Auth0_Api_Client.php
@@ -127,13 +127,11 @@ class WP_Auth0_Api_Client {
 
 		if ( $response instanceof WP_Error ) {
 			WP_Auth0_ErrorLog::insert_error( __METHOD__, $response );
-			error_log( $response->get_error_message() );
 			return false;
 		}
 
 		if ( $response['response']['code'] !== 200 ) {
 			WP_Auth0_ErrorLog::insert_error( __METHOD__, $response['body'] );
-			error_log( $response['body'] );
 			return false;
 		}
 
@@ -216,13 +214,11 @@ class WP_Auth0_Api_Client {
 
 		if ( $response instanceof WP_Error ) {
 			WP_Auth0_ErrorLog::insert_error( __METHOD__, $response->get_error_message() );
-			error_log( $response->get_error_message() );
 			return false;
 		}
 
 		if ( $response['response']['code'] != 201 ) {
 			WP_Auth0_ErrorLog::insert_error( __METHOD__, $response['body'] );
-			error_log( $response['body'] );
 			return false;
 		}
 
@@ -256,7 +252,6 @@ class WP_Auth0_Api_Client {
 
 		if ( $response instanceof WP_Error ) {
 			WP_Auth0_ErrorLog::insert_error( __METHOD__, $response );
-			error_log( $response->get_error_message() );
 			return false;
 		}
 
@@ -279,7 +274,6 @@ class WP_Auth0_Api_Client {
 		} elseif ( $response['response']['code'] != 201 ) {
 
 			WP_Auth0_ErrorLog::insert_error( __METHOD__, $response['body'] );
-			error_log( $response['body'] );
 			return false;
 		}
 
@@ -314,13 +308,11 @@ class WP_Auth0_Api_Client {
 
 		if ( $response instanceof WP_Error ) {
 			WP_Auth0_ErrorLog::insert_error( __METHOD__, $response );
-			error_log( $response->get_error_message() );
 			return false;
 		}
 
 		if ( $response['response']['code'] != 201 ) {
 			WP_Auth0_ErrorLog::insert_error( __METHOD__, $response['body'] );
-			error_log( $response['body'] );
 			return false;
 		}
 
@@ -356,13 +348,11 @@ class WP_Auth0_Api_Client {
 
 		if ( $response instanceof WP_Error ) {
 			WP_Auth0_ErrorLog::insert_error( __METHOD__, $response );
-			error_log( $response->get_error_message() );
 			return false;
 		}
 
 		if ( $response['response']['code'] != 200 ) {
 			WP_Auth0_ErrorLog::insert_error( __METHOD__, $response['body'] );
-			error_log( $response['body'] );
 			return false;
 		}
 
@@ -411,13 +401,11 @@ class WP_Auth0_Api_Client {
 
 		if ( $response instanceof WP_Error ) {
 			WP_Auth0_ErrorLog::insert_error( __METHOD__, $response );
-			error_log( $response->get_error_message() );
 			return false;
 		}
 
 		if ( $response['response']['code'] != 200 ) {
 			WP_Auth0_ErrorLog::insert_error( __METHOD__, $response['body'] );
-			error_log( $response['body'] );
 			return false;
 		}
 

--- a/lib/WP_Auth0_ErrorLog.php
+++ b/lib/WP_Auth0_ErrorLog.php
@@ -145,6 +145,7 @@ class WP_Auth0_ErrorLog {
 			$new_entry['message'] = is_object( $error ) || is_array( $error ) ? serialize( $error ) : $error;
 		}
 
+		do_action( 'auth0_insert_error', $new_entry, $error, $section );
 		return ( new self )->add( $new_entry );
 	}
 }


### PR DESCRIPTION
### Changes

- Remove all calls to PHP core `error_log`
- Add `auth0_insert_error` action to allow additional error handling

### Testing

* [x] This change adds unit test coverage
* [x] This change has been tested on PHP 7.1 and WP 5.3.2
