### PR TITLE
Remove custom signup fields setting

### DIFF
--- a/lib/WP_Auth0_DBManager.php
+++ b/lib/WP_Auth0_DBManager.php
@@ -174,6 +174,7 @@ class WP_Auth0_DBManager {
 			$options->remove( 'custom_js' );
 			$options->remove( 'auth0_implicit_workflow' );
 			$options->remove( 'client_secret_b64_encoded' );
+			$options->remove( 'custom_signup_fields' );
 		}
 
 		$options->update_all();

--- a/lib/WP_Auth0_Options.php
+++ b/lib/WP_Auth0_Options.php
@@ -392,7 +392,6 @@ class WP_Auth0_Options {
 			'gravatar'                  => true,
 			'username_style'            => '',
 			'primary_color'             => '',
-			'custom_signup_fields'      => '',
 			'extra_conf'                => '',
 			'custom_cdn_url'            => null,
 			'cdn_url'                   => WPA0_LOCK_CDN_URL,

--- a/lib/admin/WP_Auth0_Admin_Advanced.php
+++ b/lib/admin/WP_Auth0_Admin_Advanced.php
@@ -386,9 +386,6 @@ class WP_Auth0_Admin_Advanced extends WP_Auth0_Admin_Generic {
 		$input['lock_connections'] = isset( $input['lock_connections'] ) ?
 			trim( $input['lock_connections'] ) : '';
 
-		$input['custom_signup_fields'] = isset( $input['custom_signup_fields'] ) ?
-			trim( $input['custom_signup_fields'] ) : '';
-
 		$input['extra_conf'] = isset( $input['extra_conf'] ) ? trim( $input['extra_conf'] ) : '';
 		if ( ! empty( $input['extra_conf'] ) ) {
 			if ( json_decode( $input['extra_conf'] ) === null ) {

--- a/lib/admin/WP_Auth0_Admin_Appearance.php
+++ b/lib/admin/WP_Auth0_Admin_Appearance.php
@@ -58,12 +58,6 @@ class WP_Auth0_Admin_Appearance extends WP_Auth0_Admin_Generic {
 				'function' => 'render_primary_color',
 			],
 			[
-				'name'     => __( 'Custom Signup Fields', 'wp-auth0' ),
-				'opt'      => 'custom_signup_fields',
-				'id'       => 'wpa0_custom_signup_fields',
-				'function' => 'render_custom_signup_fields',
-			],
-			[
 				'name'     => __( 'Extra Settings', 'wp-auth0' ),
 				'opt'      => 'extra_conf',
 				'id'       => 'wpa0_extra_conf',
@@ -284,26 +278,6 @@ class WP_Auth0_Admin_Appearance extends WP_Auth0_Admin_Generic {
 		$this->render_field_description(
 			__( 'Valid JSON for Lock options configuration; will override all options set elsewhere. ', 'wp-auth0' ) .
 			$this->get_docs_link( 'libraries/lock/customization', 'See options and examples' )
-		);
-	}
-
-	/**
-	 * Render form field and description for the `custom_signup_fields` option.
-	 * IMPORTANT: Internal callback use only, do not call this function directly!
-	 *
-	 * @param array $args - callback args passed in from add_settings_field().
-	 *
-	 * @see WP_Auth0_Admin_Generic::init_option_section()
-	 * @see add_settings_field()
-	 */
-	public function render_custom_signup_fields( $args = [] ) {
-		$this->render_textarea_field( $args['label_for'], $args['opt_name'] );
-		$this->render_field_description(
-			__( 'Valid array of JSON objects for additional signup fields in the Auth0 signup form. ', 'wp-auth0' ) .
-			$this->get_docs_link(
-				'libraries/lock/v11/configuration#additionalsignupfields-array-',
-				__( 'More information and examples', 'wp-auth0' )
-			)
 		);
 	}
 

--- a/templates/auth0-login-form.php
+++ b/templates/auth0-login-form.php
@@ -18,15 +18,3 @@ $wle           = $auth0_options->get( 'wordpress_login_enabled' );
 	<style type="text/css">
 		<?php echo apply_filters( 'auth0_login_css', '' ); ?>
 	</style>
-
-<?php
-$custom_signup_fields = (string) trim( $auth0_options->get( 'custom_signup_fields' ) );
-
-if ( $custom_signup_fields ) {
-	echo '<script type="text/javascript">';
-	if ( $custom_signup_fields ) {
-		echo 'var ' . WP_Auth0_Lock::LOCK_GLOBAL_JS_VAR_NAME . 'Fields=' . $custom_signup_fields . ';';
-	}
-	echo '</script>';
-}
-?>

--- a/tests/testWPAuth0DbMigrations.php
+++ b/tests/testWPAuth0DbMigrations.php
@@ -168,6 +168,7 @@ class TestWPAuth0DbMigrations extends WP_Auth0_Test_Case {
 		self::$opts->set( 'custom_js', '__test_js__' );
 		self::$opts->set( 'auth0_implicit_workflow', 1 );
 		self::$opts->set( 'client_secret_b64_encoded', 1 );
+		self::$opts->set( 'custom_signup_fields', '__test_fields__' );
 		$db_manager->install_db( $test_version );
 		$this->assertNull( self::$opts->get( 'jwt_auth_integration' ) );
 		$this->assertNull( self::$opts->get( 'link_auth0_users' ) );
@@ -175,6 +176,7 @@ class TestWPAuth0DbMigrations extends WP_Auth0_Test_Case {
 		$this->assertNull( self::$opts->get( 'custom_js' ) );
 		$this->assertNull( self::$opts->get( 'auth0_implicit_workflow' ) );
 		$this->assertNull( self::$opts->get( 'client_secret_b64_encoded' ) );
+		$this->assertNull( self::$opts->get( 'custom_signup_fields' ) );
 	}
 
 	/**

--- a/tests/testWPAuth0Options.php
+++ b/tests/testWPAuth0Options.php
@@ -20,7 +20,7 @@ class TestWPAuth0Options extends WP_Auth0_Test_Case {
 	/**
 	 * Total number of options.
 	 */
-	const DEFAULT_OPTIONS_COUNT = 38;
+	const DEFAULT_OPTIONS_COUNT = 37;
 
 	/**
 	 * Test the basic options functionality.


### PR DESCRIPTION
### Changes

Remove database-stored extra signup fields setting for the embedded login form. Custom fields must now be added by enqueueing a JS file before the embedded form loads:

```php
function namespace_login_enqueue_scripts() {
        // This example assumes that this file is loaded from your theme.
	wp_enqueue_script( 'lock-signup-fields', get_stylesheet_directory_uri() . '/assets/js/lock-signup-fields.js' );
}
add_action( 'login_enqueue_scripts', 'namespace_login_enqueue_scripts' );
```

... that defines a specific global variable `wpAuth0LockGlobalFields` with the signup fields defined:

```js
// lock-signup-fields.js
var wpAuth0LockGlobalFields = [
  {
    name: "full_name",
    placeholder: "your full name",
    validator: function(address) {
      return {
        valid: address.length >= 10,
        hint: "Must have 10 or more chars" // optional
      };
    }
  }
];
```

### Checklist

* [x] All existing and new tests complete without errors
* [x] All code quality tools/guidelines in the [Contribution guide](CONTRIBUTION.md) have been run/followed
* [x] All active GitHub CI checks have passed
