### PR TITLE
urlencode the wle request parameter for security against XSS

### DIFF
--- a/WP_Auth0.php
+++ b/WP_Auth0.php
@@ -735,7 +735,8 @@ add_filter( 'login_url', 'wp_auth0_filter_login_override_url', 100 );
  */
 function wp_auth0_filter_login_override_form() {
 	if ( wp_auth0_can_show_wp_login_form() && isset( $_REQUEST['wle'] ) ) {
-		printf( '<input type="hidden" name="wle" value="%s" />', $_REQUEST['wle'] );
+                $wle_encoded = urlencode($_REQUEST['wle']);
+		printf( '<input type="hidden" name="wle" value="%s" />', $wle_encoded );
 	}
 }
 

--- a/WP_Auth0.php
+++ b/WP_Auth0.php
@@ -735,7 +735,7 @@ add_filter( 'login_url', 'wp_auth0_filter_login_override_url', 100 );
  */
 function wp_auth0_filter_login_override_form() {
 	if ( wp_auth0_can_show_wp_login_form() && isset( $_REQUEST['wle'] ) ) {
-                $wle_encoded = urlencode($_REQUEST['wle']);
+              $wle_encoded = esc_attr($_REQUEST['wle']);
 		printf( '<input type="hidden" name="wle" value="%s" />', $wle_encoded );
 	}
 }


### PR DESCRIPTION
### Changes

the wle query parameter is nakedly added to the HTML in this plugin. Our team had a security analysis who was able to show how to inject code into the page should it not be encoded.

### Testing

Given a URL like YOUR_SITE_HERE/wp-login.php?wle=%22%20onEvent%3DX186697040Y2Z%20

it's possible in a situation to inject code into the page in this hidden input type. with the item encoded, we have been able to still login using auth0 and/or the wordpress default login

### Checklist

* [x ] I read [Auth0's general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)?
* [x ] I read [Auth0's code of conduct guidelines](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
* [ x] All existing and new tests complete without errors
* [ x] All code quality tools/guidelines in the [Contribution guide](CONTRIBUTION.md) have been run/followed
* [x ] All relevant assets have been compiled as directed in the [Contribution guide](CONTRIBUTION.md), if applicable
* [x ] All active GitHub CI checks have passed
