### PR TITLE
Add ability to break cache if RS256 ID token kid is not found

### DIFF
--- a/lib/WP_Auth0_LoginManager.php
+++ b/lib/WP_Auth0_LoginManager.php
@@ -523,8 +523,7 @@ class WP_Auth0_LoginManager {
 		$expectedIss = 'https://' . $this->a0_options->get( 'domain' ) . '/';
 		$expectedAlg = $this->a0_options->get( 'client_signing_algorithm' );
 		if ( 'RS256' === $expectedAlg ) {
-			$jwks        = ( new WP_Auth0_JwksFetcher() )->getKeys();
-			$sigVerifier = new WP_Auth0_AsymmetricVerifier( $jwks );
+			$sigVerifier = new WP_Auth0_AsymmetricVerifier( new WP_Auth0_JwksFetcher() );
 		} elseif ( 'HS256' === $expectedAlg ) {
 			$sigVerifier = new WP_Auth0_SymmetricVerifier( $this->a0_options->get( 'client_secret' ) );
 		} else {

--- a/lib/token-verifier/WP_Auth0_JwksFetcher.php
+++ b/lib/token-verifier/WP_Auth0_JwksFetcher.php
@@ -34,12 +34,31 @@ class WP_Auth0_JwksFetcher {
 	}
 
 	/**
+	 * Get a key using a kid.
+	 *
+	 * @param string $kid Key ID to get.
+	 *
+	 * @return string
+	 */
+	public function getKey( string $kid ) {
+		$keys = $this->getKeys();
+
+		if ( ! empty( $keys ) && empty( $keys[ $kid ] ) ) {
+			$keys = $this->getKeys( false );
+		}
+
+		return $keys[ $kid ] ?? null;
+	}
+
+	/**
 	 * Gets an array of keys from the JWKS as kid => x5c.
+	 *
+	 * @param bool $use_cache Defaults to true to use a cached value.
 	 *
 	 * @return array
 	 */
-	public function getKeys() : array {
-		$keys = get_transient( WPA0_JWKS_CACHE_TRANSIENT_NAME );
+	public function getKeys( $use_cache = true ) : array {
+		$keys = $use_cache ? get_transient( WPA0_JWKS_CACHE_TRANSIENT_NAME ) : [];
 		if ( is_array( $keys ) && ! empty( $keys ) ) {
 			return $keys;
 		}

--- a/tests/testApiGetJwks.php
+++ b/tests/testApiGetJwks.php
@@ -57,7 +57,7 @@ class TestApiGetJwks extends WP_Auth0_Test_Case {
 	}
 
 	/**
-	 * Test that a network error (caught by WP and returned as a WP_Error) is handled properly.
+	 * Test that an Auth0 API error (caught by WP and returned as a WP_Error) is handled properly.
 	 */
 	public function testThatApiErrorIsHandled() {
 		$this->startHttpMocking();
@@ -74,7 +74,7 @@ class TestApiGetJwks extends WP_Auth0_Test_Case {
 	}
 
 	/**
-	 * Test that a network error (caught by WP and returned as a WP_Error) is handled properly.
+	 * Test that a successful call is handled correctly.
 	 */
 	public function testThatSuccessfulCallIsReturned() {
 		$this->startHttpMocking();

--- a/tests/testJwksFetcher.php
+++ b/tests/testJwksFetcher.php
@@ -1,0 +1,110 @@
+<?php
+/**
+ * Contains Class TestJwksFetcher.
+ *
+ * @package WP-Auth0
+ *
+ * @since 4.0.0
+ */
+
+/**
+ * Class TestJwksFetcher.
+ * Test the WP_Auth0_LoginManager::init_auth0() method.
+ */
+class TestJwksFetcher extends WP_Auth0_Test_Case {
+
+	use HttpHelpers;
+
+	use TokenHelper;
+
+	public function setUp() {
+		parent::setUp();
+		$this->assertFalse( get_transient( 'WP_Auth0_JWKS_cache' ) );
+	}
+
+	public function testThatGetKeysUsesCache() {
+		set_transient( 'WP_Auth0_JWKS_cache', [ '__test_key__' ], 3600 );
+		$jwks = new WP_Auth0_JwksFetcher();
+
+		$this->assertEquals( [ '__test_key__' ], $jwks->getKeys() );
+	}
+
+	public function testThatNotUsingCacheCallsEndpoint() {
+		$this->startHttpMocking();
+		$this->http_request_type = 'success_jwks';
+
+		set_transient( 'WP_Auth0_JWKS_cache', [ '__test_key__' ], 3600 );
+
+		$this->assertEquals( [ '__test_key__' ], get_transient( 'WP_Auth0_JWKS_cache' ) );
+
+		$jwks = new WP_Auth0_JwksFetcher();
+		$keys = $jwks->getKeys( false );
+
+		$this->assertEquals(
+			[ '__test_kid_1__' => "-----BEGIN CERTIFICATE-----\n__test_x5c_1__\n-----END CERTIFICATE-----\n" ],
+			$keys
+		);
+
+		$this->assertEquals( $keys, get_transient( 'WP_Auth0_JWKS_cache' ) );
+	}
+
+	public function testThatNonArrayCacheCallsEndpoint() {
+		$this->startHttpMocking();
+		$this->http_request_type = 'success_jwks';
+
+		set_transient( 'WP_Auth0_JWKS_cache', '__invalid_cache__', 3600 );
+		$jwks = new WP_Auth0_JwksFetcher();
+
+		$this->assertEquals(
+			[ '__test_kid_1__' => "-----BEGIN CERTIFICATE-----\n__test_x5c_1__\n-----END CERTIFICATE-----\n" ],
+			$jwks->getKeys()
+		);
+	}
+
+	public function testThatInvalidJwksReturnsEmptyArray() {
+		$this->startHttpMocking();
+		$this->http_request_type = 'auth0_api_error';
+
+		$jwks = new WP_Auth0_JwksFetcher();
+		$this->assertEquals( [], $jwks->getKeys() );
+	}
+
+	public function testThatGetKeyPullsFromCache() {
+		$this->startHttpMocking();
+		$this->http_request_type = 'halt';
+
+		set_transient(
+			'WP_Auth0_JWKS_cache',
+			[ '__test_kid_1__' => "-----BEGIN CERTIFICATE-----\n__test_x5c_1__\n-----END CERTIFICATE-----\n" ],
+			3600
+		);
+
+		$jwks = new WP_Auth0_JwksFetcher();
+
+		$this->assertEquals(
+			"-----BEGIN CERTIFICATE-----\n__test_x5c_1__\n-----END CERTIFICATE-----\n",
+			$jwks->getKey( '__test_kid_1__' )
+		);
+	}
+
+	public function testThatGetKeyNotFoundForcesEndpointCall() {
+		$this->startHttpMocking();
+		$this->http_request_type = 'success_jwks';
+
+		set_transient( 'WP_Auth0_JWKS_cache', [ '__invalid_kid__' => '__invalid_x5c__' ], 3600 );
+
+		$jwks      = new WP_Auth0_JwksFetcher();
+		$found_x5c = $jwks->getKey( '__test_kid_1__' );
+
+		$this->assertEquals( $found_x5c, $jwks->getKey( '__test_kid_1__' ) );
+		$this->assertEquals( [ '__test_kid_1__' => $found_x5c ], get_transient( 'WP_Auth0_JWKS_cache' ) );
+	}
+
+	public function testThatNotFoundKidReturnsNull() {
+		$this->startHttpMocking();
+		$this->http_request_type = 'success_jwks';
+
+		$jwks = new WP_Auth0_JwksFetcher();
+		$this->assertNull( $jwks->getKey( '__not_found_kid__' ) );
+	}
+}

--- a/tests/testOptionMigrationWs.php
+++ b/tests/testOptionMigrationWs.php
@@ -158,7 +158,7 @@ class TestOptionMigrationWs extends WP_Auth0_Test_Case {
 	 */
 	public function testThatChangingMigrationToOnKeepsWithJwtSetsId() {
 		$client_secret   = '__test_client_secret__';
-		$migration_token = self::makeToken( [ 'jti' => '__test_token_id__' ], $client_secret );
+		$migration_token = self::makeHsToken( [ 'jti' => '__test_token_id__' ], $client_secret );
 		self::$opts->set( 'migration_token', $migration_token );
 		$input = [
 			'migration_ws'  => '1',

--- a/tests/testRoutesGetUser.php
+++ b/tests/testRoutesGetUser.php
@@ -98,7 +98,7 @@ class TestRoutesGetUser extends WP_Auth0_Test_Case {
 		self::$opts->set( 'client_secret', $client_secret );
 		self::$opts->set( 'migration_token_id', '__test_token_id__' );
 
-		$_POST['access_token'] = self::makeToken( [ 'jti' => uniqid() ], $client_secret );
+		$_POST['access_token'] = self::makeHsToken( [ 'jti' => uniqid() ], $client_secret );
 
 		$output = json_decode( wp_auth0_custom_requests( self::$wp, true ) );
 

--- a/tests/testRoutesLogin.php
+++ b/tests/testRoutesLogin.php
@@ -103,7 +103,7 @@ class TestRoutesLogin extends WP_Auth0_Test_Case {
 		self::$opts->set( 'migration_token_id', '__test_token_id__' );
 
 		self::$wp->query_vars['a0_action'] = 'migration-ws-login';
-		$_POST['access_token']             = self::makeToken( [ 'jti' => uniqid() ], $client_secret );
+		$_POST['access_token']             = self::makeHsToken( [ 'jti' => uniqid() ], $client_secret );
 
 		$output = json_decode( wp_auth0_custom_requests( self::$wp, true ) );
 
@@ -125,7 +125,7 @@ class TestRoutesLogin extends WP_Auth0_Test_Case {
 		self::$opts->set( 'migration_token_id', '__test_token_id__' );
 
 		self::$wp->query_vars['a0_action'] = 'migration-ws-login';
-		$_POST['access_token']             = self::makeToken( [ 'iss' => uniqid() ], $client_secret );
+		$_POST['access_token']             = self::makeHsToken( [ 'iss' => uniqid() ], $client_secret );
 
 		$output = json_decode( wp_auth0_custom_requests( self::$wp, true ) );
 
@@ -143,7 +143,8 @@ class TestRoutesLogin extends WP_Auth0_Test_Case {
 	public function testThatLoginRouteIsBadRequestIfNoUsername() {
 		$client_secret   = '__test_client_secret__';
 		$token_id        = '__test_token_id__';
-		$migration_token = self::makeToken( [ 'jti' => $token_id ], $client_secret );
+		$migration_token = self::makeHsToken( [ 'jti' => $token_id ], $client_secret );
+
 		self::$opts->set( 'migration_ws', true );
 		self::$opts->set( 'client_secret', $client_secret );
 		self::$opts->set( 'migration_token', $migration_token );
@@ -167,7 +168,8 @@ class TestRoutesLogin extends WP_Auth0_Test_Case {
 	public function testThatLoginRouteIsBadRequestIfNoPassword() {
 		$client_secret   = '__test_client_secret__';
 		$token_id        = '__test_token_id__';
-		$migration_token = self::makeToken( [ 'jti' => $token_id ], $client_secret );
+		$migration_token = self::makeHsToken( [ 'jti' => $token_id ], $client_secret );
+
 		self::$opts->set( 'migration_ws', true );
 		self::$opts->set( 'client_secret', $client_secret );
 		self::$opts->set( 'migration_token', $migration_token );
@@ -192,7 +194,8 @@ class TestRoutesLogin extends WP_Auth0_Test_Case {
 	public function testThatLoginRouteIsUnauthorizedIfNotAuthenticated() {
 		$client_secret   = '__test_client_secret__';
 		$token_id        = '__test_token_id__';
-		$migration_token = self::makeToken( [ 'jti' => $token_id ], $client_secret );
+		$migration_token = self::makeHsToken( [ 'jti' => $token_id ], $client_secret );
+
 		self::$opts->set( 'migration_ws', true );
 		self::$opts->set( 'client_secret', $client_secret );
 		self::$opts->set( 'migration_token', $migration_token );
@@ -227,7 +230,7 @@ class TestRoutesLogin extends WP_Auth0_Test_Case {
 				'user_pass'  => $_POST['password'],
 			]
 		);
-		$migration_token   = self::makeToken( [ 'jti' => $token_id ], $client_secret );
+		$migration_token   = self::makeHsToken( [ 'jti' => $token_id ], $client_secret );
 		self::$opts->set( 'migration_ws', true );
 		self::$opts->set( 'client_secret', $client_secret );
 		self::$opts->set( 'migration_token', $migration_token );


### PR DESCRIPTION
### Changes

Add `WP_Auth0_JwksFetcher->getKey()` for use in `WP_Auth0_AsymmetricVerifier` to fetch a new JWKS when an incoming token KID is not found in the cached set. This library doesn't accept arbitrary requests that involve token validation and the endpoint that validates tokens is protected by a `state` parameter so there is not much of a risk of invalid `kid` spamming.

### References

SDK-1224

### Testing

* [x] This change adds unit test coverage
* [x] This change has been tested on WP 5.3.2 and PHP 7.1

### Checklist

* [x] All existing and new tests complete without errors
* [x] All code quality tools/guidelines in the [Contribution guide](CONTRIBUTION.md) have been run/followed
* [x] All active GitHub CI checks have passed
