### PR TITLE
Change all redirects to wp_safe_redirect

### DIFF
--- a/WP_Auth0.php
+++ b/WP_Auth0.php
@@ -152,6 +152,16 @@ add_action( 'activated_plugin', 'wp_auth0_activated_plugin_redirect' );
  * Core WP hooks
  */
 
+function wp_auth0_add_allowed_redirect_hosts( $hosts ) {
+	$hosts[] = 'auth0.auth0.com';
+	$hosts[] = wp_auth0_get_option( 'domain' );
+	$hosts[] = wp_auth0_get_option( 'custom_domain' );
+	$hosts[] = wp_auth0_get_option( 'auth0_server_domain' );
+	return $hosts;
+}
+
+add_filter( 'allowed_redirect_hosts', 'wp_auth0_add_allowed_redirect_hosts' );
+
 /**
  * Enqueue login page CSS if plugin is configured.
  */
@@ -457,7 +467,7 @@ add_action( 'wp_ajax_auth0_delete_data', 'wp_auth0_delete_user_data' );
 function wp_auth0_init_admin_menu() {
 
 	if ( wp_auth0_is_admin_page( 'wpa0-help' ) ) {
-		wp_redirect( admin_url( 'admin.php?page=wpa0#help' ), 301 );
+		wp_safe_redirect( admin_url( 'admin.php?page=wpa0#help' ), 301 );
 		exit;
 	}
 

--- a/lib/WP_Auth0_LoginManager.php
+++ b/lib/WP_Auth0_LoginManager.php
@@ -110,7 +110,7 @@ class WP_Auth0_LoginManager {
 
 		// No need to process a login if the user is already logged in and there is no error.
 		if ( is_user_logged_in() ) {
-			wp_redirect( $this->a0_options->get( 'default_login_redirection' ) );
+			wp_safe_redirect( $this->a0_options->get( 'default_login_redirection' ) );
 			exit;
 		}
 
@@ -373,13 +373,13 @@ class WP_Auth0_LoginManager {
 			$return_to    = apply_filters( 'auth0_slo_return_to', home_url() );
 			$redirect_url = $this->auth0_logout_url( $return_to );
 			$redirect_url = apply_filters( 'auth0_logout_url', $redirect_url );
-			wp_redirect( $redirect_url );
+			wp_safe_redirect( $redirect_url );
 			exit;
 		}
 
 		// If auto-login is in use, cannot redirect back to login page.
 		if ( $this->a0_options->get( 'auto_login' ) ) {
-			wp_redirect( home_url() );
+			wp_safe_redirect( home_url() );
 			exit;
 		}
 	}

--- a/lib/initial-setup/WP_Auth0_InitialSetup_AdminUser.php
+++ b/lib/initial-setup/WP_Auth0_InitialSetup_AdminUser.php
@@ -26,7 +26,7 @@ class WP_Auth0_InitialSetup_AdminUser {
 		$admin_user = WP_Auth0_Api_Client::signup_user( $this->a0_options->get_auth_domain(), $data );
 
 		if ( $admin_user === false ) {
-			wp_redirect( admin_url( 'admin.php?page=wpa0-setup&step=3&result=error' ) );
+			wp_safe_redirect( admin_url( 'admin.php?page=wpa0-setup&step=3&result=error' ) );
 		} else {
 
 			$admin_user->sub = 'auth0|' . $admin_user->_id;
@@ -35,7 +35,7 @@ class WP_Auth0_InitialSetup_AdminUser {
 			$user_repo = new WP_Auth0_UsersRepo( WP_Auth0_Options::Instance() );
 			$user_repo->update_auth0_object( $current_user->ID, $admin_user );
 
-			wp_redirect( admin_url( 'admin.php?page=wpa0-setup&step=4' ) );
+			wp_safe_redirect( admin_url( 'admin.php?page=wpa0-setup&step=4' ) );
 		}
 		exit;
 	}

--- a/lib/initial-setup/WP_Auth0_InitialSetup_ConnectionProfile.php
+++ b/lib/initial-setup/WP_Auth0_InitialSetup_ConnectionProfile.php
@@ -3,11 +3,11 @@
 class WP_Auth0_InitialSetup_ConnectionProfile {
 
 	protected $a0_options;
-	protected $domain = 'auth0.auth0.com';
+	protected $domain;
 
 	public function __construct( WP_Auth0_Options $a0_options ) {
 		$this->a0_options = $a0_options;
-		$this->domain     = $this->a0_options->get( 'auth0_server_domain' );
+		$this->domain     = $this->a0_options->get( 'auth0_server_domain', 'auth0.auth0.com' );
 	}
 
 	public function render( $step ) {
@@ -26,7 +26,7 @@ class WP_Auth0_InitialSetup_ConnectionProfile {
 
 		} else {
 			$consent_url = $this->build_consent_url();
-			wp_redirect( $consent_url );
+			wp_safe_redirect( $consent_url );
 		}
 		exit();
 	}

--- a/lib/initial-setup/WP_Auth0_InitialSetup_Connections.php
+++ b/lib/initial-setup/WP_Auth0_InitialSetup_Connections.php
@@ -13,11 +13,11 @@ class WP_Auth0_InitialSetup_Connections {
 	}
 
 	public function callback() {
-		wp_redirect( admin_url( 'admin.php?page=wpa0-setup&step=5' ) );
+		wp_safe_redirect( admin_url( 'admin.php?page=wpa0-setup&step=5' ) );
 	}
 
 	public function add_validation_error( $error ) {
-		wp_redirect(
+		wp_safe_redirect(
 			admin_url(
 				'admin.php?page=wpa0-setup&step=5&error=' .
 				urlencode( 'There was an error setting up your connections.' )

--- a/lib/initial-setup/WP_Auth0_InitialSetup_Consent.php
+++ b/lib/initial-setup/WP_Auth0_InitialSetup_Consent.php
@@ -43,14 +43,14 @@ class WP_Auth0_InitialSetup_Consent {
 		$access_token = $this->exchange_code();
 
 		if ( $access_token === null ) {
-			wp_redirect( admin_url( 'admin.php?page=wpa0-setup&error=cant_exchange_token' ) );
+			wp_safe_redirect( admin_url( 'admin.php?page=wpa0-setup&error=cant_exchange_token' ) );
 			exit;
 		}
 
 		$app_domain = $this->parse_token_domain( $access_token );
 
 		if ( ! isset( $_REQUEST['state'] ) ) {
-			wp_redirect( admin_url( 'admin.php?page=wpa0-setup&error=missing_state' ) );
+			wp_safe_redirect( admin_url( 'admin.php?page=wpa0-setup&error=missing_state' ) );
 			exit;
 		}
 
@@ -105,7 +105,7 @@ class WP_Auth0_InitialSetup_Consent {
 			$client_response = WP_Auth0_Api_Client::create_client( $domain, $this->access_token, $name );
 
 			if ( $client_response === false ) {
-				wp_redirect( admin_url( 'admin.php?page=wpa0-setup&error=cant_create_client' ) );
+				wp_safe_redirect( admin_url( 'admin.php?page=wpa0-setup&error=cant_create_client' ) );
 				exit;
 			}
 
@@ -154,11 +154,11 @@ class WP_Auth0_InitialSetup_Consent {
 		$grant_response = WP_Auth0_Api_Client::create_client_grant( $this->access_token, $client_id );
 
 		if ( false === $grant_response ) {
-			wp_redirect( admin_url( 'admin.php?page=wpa0-setup&error=cant_create_client_grant' ) );
+			wp_safe_redirect( admin_url( 'admin.php?page=wpa0-setup&error=cant_create_client_grant' ) );
 			exit;
 		}
 
-		wp_redirect( admin_url( 'admin.php?page=wpa0-setup&step=2' ) );
+		wp_safe_redirect( admin_url( 'admin.php?page=wpa0-setup&step=2' ) );
 		exit;
 	}
 }

--- a/tests/testSafeRedirects.php
+++ b/tests/testSafeRedirects.php
@@ -1,0 +1,90 @@
+<?php
+/**
+ * Contains Class TestSafeRedirects.
+ *
+ * @package WP-Auth0
+ *
+ * @since 4.0.0
+ */
+
+/**
+ * Class TestSafeRedirects.
+ */
+class TestSafeRedirects extends WP_Auth0_Test_Case {
+
+	use RedirectHelpers;
+
+	public function testThatDomainIsAllowedToSafeRedirect() {
+		$this->startRedirectHalting();
+		self::auth0Ready();
+		self::$opts->set( 'domain', 'test.auth0.com' );
+		self::$opts->set( 'singlelogout', 1 );
+
+		$login = new WP_Auth0_LoginManager( new WP_Auth0_UsersRepo( self::$opts ), self::$opts );
+
+		try {
+			// Calls wp_safe_redirect.
+			$login->logout();
+			$redirect_data = [ 'location' => 'Redirect not found' ];
+		} catch ( Exception $e ) {
+			$redirect_data = unserialize( $e->getMessage() );
+		}
+
+		$this->assertStringStartsWith( 'https://test.auth0.com', $redirect_data['location'] );
+	}
+
+	public function testThatCustomDomainIsAllowedToSafeRedirect() {
+		$this->startRedirectHalting();
+		self::auth0Ready();
+		self::$opts->set( 'custom_domain', 'custom-test.auth0.com' );
+		self::$opts->set( 'singlelogout', 1 );
+
+		$login = new WP_Auth0_LoginManager( new WP_Auth0_UsersRepo( self::$opts ), self::$opts );
+
+		try {
+			// Calls wp_safe_redirect.
+			$login->logout();
+			$redirect_data = [ 'location' => 'Redirect not found' ];
+		} catch ( Exception $e ) {
+			$redirect_data = unserialize( $e->getMessage() );
+		}
+
+		$this->assertStringStartsWith( 'https://custom-test.auth0.com', $redirect_data['location'] );
+	}
+
+	public function testThatAuth0ServerDomainIsAllowedToSafeRedirect() {
+		$this->startRedirectHalting();
+		self::auth0Ready();
+		self::$opts->set( 'auth0_server_domain', 'auth0-server-test.auth0.com' );
+
+		$conn_profile = new WP_Auth0_InitialSetup_ConnectionProfile( self::$opts );
+
+		try {
+			// Calls wp_safe_redirect.
+			$conn_profile->callback();
+			$redirect_data = [ 'location' => 'Redirect not found' ];
+		} catch ( Exception $e ) {
+			$redirect_data = unserialize( $e->getMessage() );
+		}
+
+		$this->assertStringStartsWith( 'https://auth0-server-test.auth0.com', $redirect_data['location'] );
+	}
+
+	public function testThatDefaultAuth0ServerDomainIsAllowedToSafeRedirect() {
+		$this->startRedirectHalting();
+		self::auth0Ready();
+
+		$conn_profile = new WP_Auth0_InitialSetup_ConnectionProfile( self::$opts );
+
+		try {
+			// Calls wp_safe_redirect.
+			$conn_profile->callback();
+			$redirect_data = [ 'location' => 'Redirect not found' ];
+		} catch ( Exception $e ) {
+			$redirect_data = unserialize( $e->getMessage() );
+		}
+
+		$this->assertStringStartsWith( 'https://auth0.auth0.com', $redirect_data['location'] );
+	}
+
+}


### PR DESCRIPTION
### Changes

Change all instances of `wp_redirect` to `wp_safe_redirect` and filter necessary hosts.

### References

https://developer.wordpress.org/reference/functions/wp_safe_redirect/

https://developer.wordpress.org/reference/hooks/allowed_redirect_hosts/

### Testing

* [x] This change adds unit test coverage
* [x] This change has been tested on WP 5.3 and PHP 7.1

### Checklist

* [x] All existing and new tests complete without errors
* [x] All code quality tools/guidelines in the [Contribution guide](CONTRIBUTION.md) have been run/followed
* [x] All active GitHub CI checks have passed
