### PR TITLE
Adding advanced setting validation; normalize values throughout

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,8 +42,8 @@
         "test-cov": "\"vendor/bin/phpunit\" --coverage-text",
         "test-group": "\"vendor/bin/phpunit\" --coverage-text --group",
         "test-ci": "\"vendor/bin/phpunit\" --coverage-clover=coverage.xml",
-        "pre-commit-no-tests": [ "@phpcbf", "@phpcbf-tests", "@phpcs-tests", "@compat", "@phpcs-i18n" ],
-        "pre-commit": [ "@phpcbf", "@phpcbf-tests", "@phpcs-tests", "@compat", "@phpcs-i18n", "@test" ]
+        "pre-commit-no-tests": [ "@phpcbf", "@phpcbf-tests", "@compat", "@phpcs-i18n" ],
+        "pre-commit": [ "@phpcbf", "@phpcbf-tests", "@compat", "@phpcs-i18n", "@test" ]
     },
     "autoload-dev": {
         "classmap": ["tests/classes/", "tests/traits/"]

--- a/lib/WP_Auth0_Options.php
+++ b/lib/WP_Auth0_Options.php
@@ -385,7 +385,7 @@ class WP_Auth0_Options {
 			'singlelogout'              => 1,
 			'override_wp_avatars'       => 1,
 
-			// Appearance
+			// Embedded
 			'passwordless_enabled'      => false,
 			'icon_url'                  => '',
 			'form_title'                => '',
@@ -405,10 +405,10 @@ class WP_Auth0_Options {
 			'force_https_callback'      => false,
 			'auto_provisioning'         => false,
 			'migration_ws'              => false,
-			'migration_token'           => null,
+			'migration_token'           => '',
 			'migration_ips_filter'      => false,
-			'migration_ips'             => null,
-			'valid_proxy_ip'            => null,
+			'migration_ips'             => '',
+			'valid_proxy_ip'            => '',
 			'auth0_server_domain'       => 'auth0.auth0.com',
 		];
 	}

--- a/lib/admin/WP_Auth0_Admin_Appearance.php
+++ b/lib/admin/WP_Auth0_Admin_Appearance.php
@@ -290,10 +290,11 @@ class WP_Auth0_Admin_Appearance extends WP_Auth0_Admin_Generic {
 	 * @return array
 	 */
 	public function basic_validation( $old_options, $input ) {
-		$input['form_title']    = empty( $input['form_title'] ) ? '' : sanitize_text_field( $input['form_title'] );
-		$input['icon_url']      = empty( $input['icon_url'] ) ? '' : esc_url( $input['icon_url'], [ 'http', 'https' ] );
-		$input['gravatar']      = empty( $input['gravatar'] ) ? 0 : 1;
-		$input['primary_color'] = empty( $input['primary_color'] ) ? '' : sanitize_text_field( $input['primary_color'] );
+		$input['passwordless_enabled'] = ( isset( $input['passwordless_enabled'] ) ? $input['passwordless_enabled'] : 0 ) == 1;
+		$input['form_title']           = empty( $input['form_title'] ) ? '' : sanitize_text_field( $input['form_title'] );
+		$input['icon_url']             = empty( $input['icon_url'] ) ? '' : esc_url( $input['icon_url'], [ 'http', 'https' ] );
+		$input['gravatar']             = empty( $input['gravatar'] ) ? 0 : 1;
+		$input['primary_color']        = empty( $input['primary_color'] ) ? '' : sanitize_text_field( $input['primary_color'] );
 
 		$input['custom_cdn_url'] = empty( $input['custom_cdn_url'] ) ? 0 : 1;
 
@@ -303,6 +304,17 @@ class WP_Auth0_Admin_Appearance extends WP_Auth0_Admin_Generic {
 		if ( ! filter_var( $input['cdn_url'], FILTER_VALIDATE_URL ) ) {
 			$input['cdn_url'] = isset( $old_options['cdn_url'] ) ? $old_options['cdn_url'] : WPA0_LOCK_CDN_URL;
 			self::add_validation_error( __( 'The Lock JS CDN URL used is not a valid URL.', 'wp-auth0' ) );
+		}
+
+		$input['lock_connections'] = isset( $input['lock_connections'] ) ?
+			trim( $input['lock_connections'] ) : '';
+
+		$input['extra_conf'] = isset( $input['extra_conf'] ) ? trim( $input['extra_conf'] ) : '';
+		if ( ! empty( $input['extra_conf'] ) ) {
+			if ( json_decode( $input['extra_conf'] ) === null ) {
+				$error = __( 'The Extra settings parameter should be a valid json object', 'wp-auth0' );
+				self::add_validation_error( $error );
+			}
 		}
 
 		return $input;

--- a/lib/admin/WP_Auth0_Admin_Generic.php
+++ b/lib/admin/WP_Auth0_Admin_Generic.php
@@ -258,4 +258,12 @@ class WP_Auth0_Admin_Generic {
 		$text = empty( $text ) ? __( 'here', 'wp-auth0' ) : sanitize_text_field( $text );
 		return sprintf( '<a href="https://auth0.com/docs/%s" target="_blank">%s</a>', $path, $text );
 	}
+
+	protected function sanitize_switch_val( $val ) {
+		return in_array( $val, [ 1, '1', true ] ) ? true : false;
+	}
+
+	protected function sanitize_text_val( $val ) {
+		return sanitize_text_field( trim( strval( $val ) ) );
+	}
 }

--- a/lib/initial-setup/WP_Auth0_InitialSetup_Consent.php
+++ b/lib/initial-setup/WP_Auth0_InitialSetup_Consent.php
@@ -131,7 +131,7 @@ class WP_Auth0_InitialSetup_Consent {
 		if ( $should_create_connection ) {
 			$migration_token = $this->a0_options->get( 'migration_token' );
 			if ( empty( $migration_token ) ) {
-				$migration_token = wp_auth0_url_base64_encode( openssl_random_pseudo_bytes( 64 ) );
+				$migration_token = wp_auth0_generate_token();
 			}
 			$operations = new WP_Auth0_Api_Operations( $this->a0_options );
 			$operations->create_wordpress_connection(

--- a/tests/testLoginManagerRedirectLogin.php
+++ b/tests/testLoginManagerRedirectLogin.php
@@ -38,7 +38,7 @@ class TestLoginManagerRedirectLogin extends WP_Auth0_Test_Case {
 		parent::setUp();
 		$this->login = new WP_Auth0_LoginManager( new WP_Auth0_UsersRepo( self::$opts ), self::$opts );
 
-		self::$opts->set( 'requires_verified_email', 0 );
+		self::$opts->set( 'requires_verified_email', false );
 
 		self::$users_repo = new WP_Auth0_UsersRepo( self::$opts );
 		$users_repo       = self::$users_repo; // PHP 5.6.

--- a/tests/testOptionMigrationWs.php
+++ b/tests/testOptionMigrationWs.php
@@ -126,12 +126,12 @@ class TestOptionMigrationWs extends WP_Auth0_Test_Case {
 	public function testThatChangingMigrationToOffKeepsTokenData() {
 		self::$opts->set( 'migration_token', 'existing_token' );
 		$input     = [
-			'migration_ws'       => 0,
 			'migration_token_id' => 'existing_token_id',
 		];
 		$validated = self::$admin->migration_ws_validation( [], $input );
 
-		$this->assertEquals( $input['migration_ws'], $validated['migration_ws'] );
+		$this->assertArrayHasKey( 'migration_ws', $validated );
+		$this->assertEmpty( $validated['migration_ws'] );
 		$this->assertEquals( $input['migration_token_id'], $validated['migration_token_id'] );
 		$this->assertEquals( 'existing_token', $validated['migration_token'] );
 	}
@@ -142,7 +142,7 @@ class TestOptionMigrationWs extends WP_Auth0_Test_Case {
 	public function testThatChangingMigrationToOnKeepsToken() {
 		self::$opts->set( 'migration_token', 'new_token' );
 		$input = [
-			'migration_ws'  => 1,
+			'migration_ws'  => '1',
 			'client_secret' => '__test_client_secret__',
 		];
 
@@ -161,7 +161,7 @@ class TestOptionMigrationWs extends WP_Auth0_Test_Case {
 		$migration_token = self::makeToken( [ 'jti' => '__test_token_id__' ], $client_secret );
 		self::$opts->set( 'migration_token', $migration_token );
 		$input = [
-			'migration_ws'  => 1,
+			'migration_ws'  => '1',
 			'client_secret' => $client_secret,
 		];
 
@@ -176,7 +176,7 @@ class TestOptionMigrationWs extends WP_Auth0_Test_Case {
 	 * Test that turning on migration endpoints without a stored token will generate one.
 	 */
 	public function testThatChangingMigrationToOnGeneratesNewToken() {
-		$input = [ 'migration_ws' => 1 ];
+		$input = [ 'migration_ws' => '1' ];
 
 		$validated = self::$admin->migration_ws_validation( [], $input );
 
@@ -194,7 +194,7 @@ class TestOptionMigrationWs extends WP_Auth0_Test_Case {
 		define( 'AUTH0_ENV_MIGRATION_TOKEN', '__test_constant_setting__' );
 		self::$opts->set( 'migration_token', '__test_saved_setting__' );
 		$input = [
-			'migration_ws'  => 1,
+			'migration_ws'  => '1',
 			'client_secret' => '__test_client_secret__',
 		];
 

--- a/tests/testRequiredEmail.php
+++ b/tests/testRequiredEmail.php
@@ -73,22 +73,23 @@ class TestRequiredEmail extends WP_Auth0_Test_Case {
 	 * Test that the required email field is properly validated.
 	 */
 	public function testRequiredEmailValidation() {
-		$opt_name = 'requires_verified_email';
+		$validated_opts = self::$admin->basic_validation( [], [ 'requires_verified_email' => '1' ] );
+		$this->assertEquals( true, $validated_opts['requires_verified_email'] );
 
-		$validated_opts = self::$admin->basic_validation( [], [ $opt_name => 1 ] );
-		$this->assertEquals( 1, $validated_opts[ $opt_name ] );
+		$validated_opts = self::$admin->basic_validation( [], [ 'requires_verified_email' => 1 ] );
+		$this->assertEquals( true, $validated_opts['requires_verified_email'] );
 
-		$validated_opts = self::$admin->basic_validation( [], [ $opt_name => true ] );
-		$this->assertEquals( 1, $validated_opts[ $opt_name ] );
+		$validated_opts = self::$admin->basic_validation( [], [ 'requires_verified_email' => true ] );
+		$this->assertEquals( true, $validated_opts['requires_verified_email'] );
 
 		$validated_opts = self::$admin->basic_validation( [], [] );
-		$this->assertEquals( 0, $validated_opts[ $opt_name ] );
+		$this->assertEquals( false, $validated_opts['requires_verified_email'] );
 
-		$validated_opts = self::$admin->basic_validation( [], [ $opt_name => 0 ] );
-		$this->assertEquals( 0, $validated_opts[ $opt_name ] );
+		$validated_opts = self::$admin->basic_validation( [], [ 'requires_verified_email' => 0 ] );
+		$this->assertEquals( false, $validated_opts['requires_verified_email'] );
 
-		$validated_opts = self::$admin->basic_validation( [], [ $opt_name => '' ] );
-		$this->assertEquals( 0, $validated_opts[ $opt_name ] );
+		$validated_opts = self::$admin->basic_validation( [], [ 'requires_verified_email' => '' ] );
+		$this->assertEquals( false, $validated_opts['requires_verified_email'] );
 	}
 
 	/**

--- a/tests/testRoutesGetUser.php
+++ b/tests/testRoutesGetUser.php
@@ -63,8 +63,8 @@ class TestRoutesGetUser extends WP_Auth0_Test_Case {
 	 * If the incoming IP address is invalid, the route should fail with an error.
 	 */
 	public function testThatGetUserRouteIsUnauthorizedIfWrongIp() {
-		self::$opts->set( 'migration_ws', 1 );
-		self::$opts->set( 'migration_ips_filter', 1 );
+		self::$opts->set( 'migration_ws', true );
+		self::$opts->set( 'migration_ips_filter', true );
 
 		$output = json_decode( wp_auth0_custom_requests( self::$wp, true ) );
 
@@ -77,7 +77,7 @@ class TestRoutesGetUser extends WP_Auth0_Test_Case {
 	 * If there is no token, the route should fail with an error.
 	 */
 	public function testThatGetUserRouteIsUnauthorizedIfNoToken() {
-		self::$opts->set( 'migration_ws', 1 );
+		self::$opts->set( 'migration_ws', true );
 
 		$output = json_decode( wp_auth0_custom_requests( self::$wp, true ) );
 
@@ -94,7 +94,7 @@ class TestRoutesGetUser extends WP_Auth0_Test_Case {
 	 */
 	public function testThatGetUserRouteIsUnauthorizedIfWrongJti() {
 		$client_secret = '__test_client_secret__';
-		self::$opts->set( 'migration_ws', 1 );
+		self::$opts->set( 'migration_ws', true );
 		self::$opts->set( 'client_secret', $client_secret );
 		self::$opts->set( 'migration_token_id', '__test_token_id__' );
 
@@ -115,7 +115,7 @@ class TestRoutesGetUser extends WP_Auth0_Test_Case {
 	 */
 	public function testThatGetUserRouteIsBadRequestIfNoUsername() {
 		$migration_token = uniqid();
-		self::$opts->set( 'migration_ws', 1 );
+		self::$opts->set( 'migration_ws', true );
 		self::$opts->set( 'migration_token', $migration_token );
 
 		$_POST['access_token'] = $migration_token;
@@ -135,7 +135,7 @@ class TestRoutesGetUser extends WP_Auth0_Test_Case {
 	 */
 	public function testThatGetUserRouteIsUnauthorizedIfUserNotFound() {
 		$migration_token = uniqid();
-		self::$opts->set( 'migration_ws', 1 );
+		self::$opts->set( 'migration_ws', true );
 		self::$opts->set( 'migration_token', $migration_token );
 
 		$_POST['access_token'] = $migration_token;
@@ -156,7 +156,7 @@ class TestRoutesGetUser extends WP_Auth0_Test_Case {
 	 */
 	public function testThatGetUserRouteReturnsEmptyIfEmailUpdate() {
 		$migration_token = uniqid();
-		self::$opts->set( 'migration_ws', 1 );
+		self::$opts->set( 'migration_ws', true );
 		self::$opts->set( 'migration_token', $migration_token );
 
 		$_POST['access_token'] = $migration_token;
@@ -181,7 +181,7 @@ class TestRoutesGetUser extends WP_Auth0_Test_Case {
 		$user              = $this->createUser( [ 'user_email' => $_POST['username'] ] );
 
 		$migration_token = uniqid();
-		self::$opts->set( 'migration_ws', 1 );
+		self::$opts->set( 'migration_ws', true );
 		self::$opts->set( 'migration_token', $migration_token );
 
 		$_POST['access_token'] = $migration_token;

--- a/tests/testRoutesLogin.php
+++ b/tests/testRoutesLogin.php
@@ -64,8 +64,8 @@ class TestRoutesLogin extends WP_Auth0_Test_Case {
 	 * If the incoming IP address is invalid, the route should fail with an error.
 	 */
 	public function testThatLoginRouteIsUnauthorizedIfWrongIp() {
-		self::$opts->set( 'migration_ws', 1 );
-		self::$opts->set( 'migration_ips_filter', 1 );
+		self::$opts->set( 'migration_ws', true );
+		self::$opts->set( 'migration_ips_filter', true );
 		self::$wp->query_vars['a0_action'] = 'migration-ws-login';
 
 		$output = json_decode( wp_auth0_custom_requests( self::$wp, true ) );
@@ -80,7 +80,7 @@ class TestRoutesLogin extends WP_Auth0_Test_Case {
 	 * If there is no token, the route should fail with an error.
 	 */
 	public function testThatLoginRouteIsUnauthorizedIfNoToken() {
-		self::$opts->set( 'migration_ws', 1 );
+		self::$opts->set( 'migration_ws', true );
 		self::$wp->query_vars['a0_action'] = 'migration-ws-login';
 
 		$output = json_decode( wp_auth0_custom_requests( self::$wp, true ) );
@@ -98,7 +98,7 @@ class TestRoutesLogin extends WP_Auth0_Test_Case {
 	 */
 	public function testThatLoginRouteIsUnauthorizedIfWrongJti() {
 		$client_secret = '__test_client_secret__';
-		self::$opts->set( 'migration_ws', 1 );
+		self::$opts->set( 'migration_ws', true );
 		self::$opts->set( 'client_secret', $client_secret );
 		self::$opts->set( 'migration_token_id', '__test_token_id__' );
 
@@ -120,7 +120,7 @@ class TestRoutesLogin extends WP_Auth0_Test_Case {
 	 */
 	public function testThatLoginRouteIsUnauthorizedIfMissingJti() {
 		$client_secret = '__test_client_secret__';
-		self::$opts->set( 'migration_ws', 1 );
+		self::$opts->set( 'migration_ws', true );
 		self::$opts->set( 'client_secret', $client_secret );
 		self::$opts->set( 'migration_token_id', '__test_token_id__' );
 
@@ -144,7 +144,7 @@ class TestRoutesLogin extends WP_Auth0_Test_Case {
 		$client_secret   = '__test_client_secret__';
 		$token_id        = '__test_token_id__';
 		$migration_token = self::makeToken( [ 'jti' => $token_id ], $client_secret );
-		self::$opts->set( 'migration_ws', 1 );
+		self::$opts->set( 'migration_ws', true );
 		self::$opts->set( 'client_secret', $client_secret );
 		self::$opts->set( 'migration_token', $migration_token );
 
@@ -168,7 +168,7 @@ class TestRoutesLogin extends WP_Auth0_Test_Case {
 		$client_secret   = '__test_client_secret__';
 		$token_id        = '__test_token_id__';
 		$migration_token = self::makeToken( [ 'jti' => $token_id ], $client_secret );
-		self::$opts->set( 'migration_ws', 1 );
+		self::$opts->set( 'migration_ws', true );
 		self::$opts->set( 'client_secret', $client_secret );
 		self::$opts->set( 'migration_token', $migration_token );
 
@@ -193,7 +193,7 @@ class TestRoutesLogin extends WP_Auth0_Test_Case {
 		$client_secret   = '__test_client_secret__';
 		$token_id        = '__test_token_id__';
 		$migration_token = self::makeToken( [ 'jti' => $token_id ], $client_secret );
-		self::$opts->set( 'migration_ws', 1 );
+		self::$opts->set( 'migration_ws', true );
 		self::$opts->set( 'client_secret', $client_secret );
 		self::$opts->set( 'migration_token', $migration_token );
 
@@ -228,7 +228,7 @@ class TestRoutesLogin extends WP_Auth0_Test_Case {
 			]
 		);
 		$migration_token   = self::makeToken( [ 'jti' => $token_id ], $client_secret );
-		self::$opts->set( 'migration_ws', 1 );
+		self::$opts->set( 'migration_ws', true );
 		self::$opts->set( 'client_secret', $client_secret );
 		self::$opts->set( 'migration_token', $migration_token );
 

--- a/tests/testUserRepoCreate.php
+++ b/tests/testUserRepoCreate.php
@@ -49,7 +49,7 @@ class TestUserRepoCreate extends WP_Auth0_Test_Case {
 		$this->createUser( [ 'user_email' => $userinfo->email ] );
 
 		// Require a verified email.
-		self::$opts->set( 'requires_verified_email', 1 );
+		self::$opts->set( 'requires_verified_email', true );
 
 		$this->expectException( WP_Auth0_EmailNotVerifiedException::class );
 		self::$repo->create( $userinfo, self::TOKEN );
@@ -68,7 +68,7 @@ class TestUserRepoCreate extends WP_Auth0_Test_Case {
 		self::$repo->update_auth0_object( $user->ID, $userinfo );
 
 		// Require a verified email.
-		self::$opts->set( 'requires_verified_email', 1 );
+		self::$opts->set( 'requires_verified_email', true );
 
 		// Modify the Auth0 sub so we get a mis-match.
 		$userinfo->sub .= uniqid();
@@ -109,7 +109,7 @@ class TestUserRepoCreate extends WP_Auth0_Test_Case {
 		update_option( 'users_can_register', 1 );
 
 		// Do not equire a verified email.
-		self::$opts->set( 'requires_verified_email', 1 );
+		self::$opts->set( 'requires_verified_email', true );
 
 		$this->expectException( WP_Auth0_CouldNotCreateUserException::class );
 		self::$repo->create( $userinfo, self::TOKEN );
@@ -152,7 +152,7 @@ class TestUserRepoCreate extends WP_Auth0_Test_Case {
 		$user     = $this->createUser( [ 'user_email' => $userinfo->email ] );
 
 		// Require a verified email.
-		self::$opts->set( 'requires_verified_email', 0 );
+		self::$opts->set( 'requires_verified_email', false );
 
 		$expected_uid = self::$repo->create( $userinfo, self::TOKEN );
 		$this->assertEquals( $expected_uid, $user->ID );
@@ -170,7 +170,7 @@ class TestUserRepoCreate extends WP_Auth0_Test_Case {
 		$user     = $this->createUser( [ 'user_email' => $userinfo->email ] );
 
 		// Require a verified email.
-		self::$opts->set( 'requires_verified_email', 1 );
+		self::$opts->set( 'requires_verified_email', true );
 
 		// Make the email verified to pass the check.
 		$userinfo->email_verified = 1;
@@ -191,7 +191,7 @@ class TestUserRepoCreate extends WP_Auth0_Test_Case {
 		$user     = $this->createUser( [ 'user_email' => $userinfo->email ] );
 
 		// Require a verified email.
-		self::$opts->set( 'requires_verified_email', 1 );
+		self::$opts->set( 'requires_verified_email', true );
 
 		// Skip the auth0 strategy.
 		self::$opts->set( 'skip_strategies', 'auth0' );


### PR DESCRIPTION
### Description

- Normalize settings validation for the Advanced tab
- Normalize defaults for the Advanced tab
- Remove `WP_Auth0_Admin_Advanced->render_auto_login()`

### References

[WP guidance on sanitization and escaping](https://developer.wordpress.org/themes/theme-security/data-sanitization-escaping/)

### Testing

- [x] This change improves test coverage for new/changed/fixed functionality
