### PR TITLE
Update Basic settings validation and defaults

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -12,10 +12,12 @@
  *
  * @since 4.0.0
  *
- * @return string
+ * @param int $size Size of the token, in bytes.
+ *
+ * @return mixed
  */
-function wp_auth0_generate_token() {
-	$token = WP_Auth0_Nonce_Handler::get_instance()->generate_unique( 64 );
+function wp_auth0_generate_token( $size = 64 ) {
+	$token = WP_Auth0_Nonce_Handler::get_instance()->generate_unique( $size );
 	return wp_auth0_url_base64_encode( $token );
 }
 
@@ -177,11 +179,10 @@ function wp_auth0_is_admin_page( $page ) {
  * @return bool
  */
 function wp_auth0_is_ready() {
-	$options = WP_Auth0_Options::Instance();
-	if ( ! $options->get( 'domain' ) || ! $options->get( 'client_id' ) || ! $options->get( 'client_secret' ) ) {
-		return false;
+	if ( wp_auth0_get_option( 'domain' ) && wp_auth0_get_option( 'client_id' ) && wp_auth0_get_option( 'client_secret' ) ) {
+		return true;
 	}
-	return true;
+	return false;
 }
 
 /**
@@ -206,8 +207,7 @@ function wp_auth0_get_tenant_region( $domain ) {
 function wp_auth0_get_tenant( $domain = null ) {
 
 	if ( empty( $domain ) ) {
-		$options = WP_Auth0_Options::Instance();
-		$domain  = $options->get( 'domain' );
+		$domain = wp_auth0_get_option( 'domain' );
 	}
 
 	$parts = explode( '.', $domain );

--- a/lib/WP_Auth0_Api_Client.php
+++ b/lib/WP_Auth0_Api_Client.php
@@ -34,8 +34,7 @@ class WP_Auth0_Api_Client {
 	private static function get_endpoint( $path = '', $domain = '' ) {
 
 		if ( empty( $domain ) ) {
-			$a0_options = WP_Auth0_Options::Instance();
-			$domain     = $a0_options->get( 'domain' );
+			$domain = wp_auth0_get_option( 'domain' );
 		}
 
 		if ( ! empty( $path[0] ) && '/' === $path[0] ) {
@@ -57,12 +56,10 @@ class WP_Auth0_Api_Client {
 	public static function get_connect_info( $opt = '' ) {
 
 		if ( is_null( self::$connect_info ) ) {
-			$a0_options = WP_Auth0_Options::Instance();
-
 			self::$connect_info = [
-				'domain'        => $a0_options->get( 'domain' ),
-				'client_id'     => $a0_options->get( 'client_id' ),
-				'client_secret' => $a0_options->get( 'client_secret' ),
+				'domain'        => wp_auth0_get_option( 'domain' ),
+				'client_id'     => wp_auth0_get_option( 'client_id' ),
+				'client_secret' => wp_auth0_get_option( 'client_secret' ),
 				'app_token'     => null,
 				'audience'      => self::get_endpoint( 'api/v2/' ),
 			];

--- a/lib/WP_Auth0_Import_Settings.php
+++ b/lib/WP_Auth0_Import_Settings.php
@@ -26,7 +26,7 @@ class WP_Auth0_Import_Settings {
 		}
 
 		$settings = json_decode( $settings_json, true );
-		if ( empty( $settings ) ) {
+		if ( empty( $settings ) || ! is_array( $settings ) ) {
 			wp_safe_redirect( $this->make_error_url( __( 'Settings JSON entered is not valid.', 'wp-auth0' ) ) );
 			exit;
 		}

--- a/lib/admin/WP_Auth0_Admin_Basic.php
+++ b/lib/admin/WP_Auth0_Admin_Basic.php
@@ -13,15 +13,7 @@
  */
 class WP_Auth0_Admin_Basic extends WP_Auth0_Admin_Generic {
 
-	/**
-	 * WP_Auth0_Admin_Basic constructor.
-	 *
-	 * @param WP_Auth0_Options $options - Instance of the WP_Auth0_Options class.
-	 */
-	public function __construct( WP_Auth0_Options $options ) {
-		parent::__construct( $options );
-		$this->actions_middlewares[] = 'wle_validation';
-	}
+	const ALLOWED_ID_TOKEN_ALGS = [ 'HS256', 'RS256' ];
 
 	/**
 	 * All settings in the Basic tab
@@ -30,6 +22,7 @@ class WP_Auth0_Admin_Basic extends WP_Auth0_Admin_Generic {
 	 * @see \WP_Auth0_Admin_Generic::init_option_section
 	 */
 	public function init() {
+
 		$options = [
 			[
 				'name'     => __( 'Domain', 'wp-auth0' ),
@@ -92,6 +85,7 @@ class WP_Auth0_Admin_Basic extends WP_Auth0_Admin_Generic {
 	 * @see add_settings_field()
 	 */
 	public function render_domain( $args = [] ) {
+
 		$style = $this->options->get( $args['opt_name'] ) ? '' : self::ERROR_FIELD_STYLE;
 		$this->render_text_field( $args['label_for'], $args['opt_name'], 'text', 'your-tenant.auth0.com', $style );
 		$this->render_field_description(
@@ -112,6 +106,7 @@ class WP_Auth0_Admin_Basic extends WP_Auth0_Admin_Generic {
 	 * @since 3.7.0
 	 */
 	public function render_custom_domain( $args = [] ) {
+
 		$this->render_text_field( $args['label_for'], $args['opt_name'], 'text', 'login.yourdomain.com' );
 		$this->render_field_description(
 			__( 'Custom login domain. ', 'wp-auth0' ) .
@@ -129,6 +124,7 @@ class WP_Auth0_Admin_Basic extends WP_Auth0_Admin_Generic {
 	 * @see add_settings_field()
 	 */
 	public function render_client_id( $args = [] ) {
+
 		$style = $this->options->get( $args['opt_name'] ) ? '' : self::ERROR_FIELD_STYLE;
 		$this->render_text_field( $args['label_for'], $args['opt_name'], 'text', '', $style );
 		$this->render_field_description(
@@ -147,6 +143,7 @@ class WP_Auth0_Admin_Basic extends WP_Auth0_Admin_Generic {
 	 * @see add_settings_field()
 	 */
 	public function render_client_secret( $args = [] ) {
+
 		$style = $this->options->get( $args['opt_name'] ) ? '' : self::ERROR_FIELD_STYLE;
 		$this->render_text_field( $args['label_for'], $args['opt_name'], 'password', '', $style );
 		$this->render_field_description(
@@ -165,9 +162,10 @@ class WP_Auth0_Admin_Basic extends WP_Auth0_Admin_Generic {
 	 * @see add_settings_field()
 	 */
 	public function render_client_signing_algorithm( $args = [] ) {
+
 		$curr_value = $this->options->get( $args['opt_name'] ) ?: WP_Auth0_Api_Client::DEFAULT_CLIENT_ALG;
 		$this->render_radio_buttons(
-			[ 'HS256', 'RS256' ],
+			self::ALLOWED_ID_TOKEN_ALGS,
 			$args['label_for'],
 			$args['opt_name'],
 			$curr_value
@@ -189,13 +187,13 @@ class WP_Auth0_Admin_Basic extends WP_Auth0_Admin_Generic {
 	 * @see add_settings_field()
 	 */
 	public function render_cache_expiration( $args = [] ) {
+
 		$this->render_text_field( $args['label_for'], $args['opt_name'], 'number' );
 		printf(
 			' <button id="auth0_delete_cache_transient" class="button button-secondary">%s</button>',
 			__( 'Delete Cache', 'wp-auth0' )
 		);
 		$this->render_field_description( __( 'JWKS cache expiration in minutes (use 0 for no caching)', 'wp-auth0' ) );
-
 		$domain = $this->options->get( 'domain' );
 		if ( $domain ) {
 			$this->render_field_description(
@@ -224,13 +222,11 @@ class WP_Auth0_Admin_Basic extends WP_Auth0_Admin_Generic {
 			wp_login_url(),
 			wp_login_url()
 		);
-
-		$code_desc = '<code class="code-block">' . __( 'Save settings to generate URL.', 'wp-auth0' ) . '</code>';
-		$wle_code  = $this->options->get( 'wle_code' );
+		$code_desc  = '<code class="code-block">' . __( 'Save settings to generate URL.', 'wp-auth0' ) . '</code>';
+		$wle_code   = $this->options->get( 'wle_code' );
 		if ( $wle_code ) {
 			$code_desc = str_replace( '?wle', '?wle=' . $wle_code, $isset_desc );
 		}
-
 		$buttons = [
 			[
 				'label' => __( 'Never', 'wp-auth0' ),
@@ -252,12 +248,10 @@ class WP_Auth0_Admin_Basic extends WP_Auth0_Admin_Generic {
 				'desc'  => $code_desc,
 			],
 		];
-
 		printf(
 			'<div class="subelement"><span class="description">%s.</span></div><br>',
 			__( 'Logins and signups using the original form will NOT be pushed to Auth0', 'wp-auth0' )
 		);
-
 		$this->render_radio_buttons(
 			$buttons,
 			$args['label_for'],
@@ -275,6 +269,7 @@ class WP_Auth0_Admin_Basic extends WP_Auth0_Admin_Generic {
 	 * @see add_settings_field()
 	 */
 	public function render_allow_signup() {
+
 		if ( is_multisite() ) {
 			$settings_text = __(
 				'"Allow new registrations" in the Network Admin > Settings > Network Settings',
@@ -305,48 +300,41 @@ class WP_Auth0_Admin_Basic extends WP_Auth0_Admin_Generic {
 			return $input;
 		}
 
-		$input['domain']           = sanitize_text_field( $input['domain'] );
-		$input['custom_domain']    = sanitize_text_field( $input['custom_domain'] );
-		$input['client_id']        = sanitize_text_field( $input['client_id'] );
-		$input['cache_expiration'] = absint( $input['cache_expiration'] );
-
-		$input['client_secret'] = sanitize_text_field( $input['client_secret'] );
-		if ( __( '[REDACTED]', 'wp-auth0' ) === $input['client_secret'] ) {
-			$input['client_secret'] = $old_options['client_secret'];
-		}
-
-		if ( ! in_array( $input['client_signing_algorithm'], [ 'HS256', 'RS256' ] ) ) {
-			$input['client_signing_algorithm'] = WP_Auth0_Api_Client::DEFAULT_CLIENT_ALG;
-		}
-
+		$input['domain'] = $this->sanitize_text_val( $input['domain'] ?? null );
 		if ( empty( $input['domain'] ) ) {
 			$this->add_validation_error( __( 'You need to specify a domain', 'wp-auth0' ) );
 		}
 
+		$input['custom_domain'] = $this->sanitize_text_val( $input['custom_domain'] ?? null );
+
+		$input['client_id'] = $this->sanitize_text_val( $input['client_id'] ?? null );
 		if ( empty( $input['client_id'] ) ) {
 			$this->add_validation_error( __( 'You need to specify a Client ID', 'wp-auth0' ) );
 		}
 
-		if ( empty( $input['client_secret'] ) && empty( $old_options['client_secret'] ) ) {
+		$input['client_secret'] = $this->sanitize_text_val( $input['client_secret'] ?? null );
+		if ( __( '[REDACTED]', 'wp-auth0' ) === $input['client_secret'] ) {
+			// The field is loaded with "[REDACTED]" so if that value is saved, we keep the existing secret.
+			$input['client_secret'] = $old_options['client_secret'];
+		}
+		if ( empty( $input['client_secret'] ) ) {
 			$this->add_validation_error( __( 'You need to specify a Client Secret', 'wp-auth0' ) );
 		}
 
-		return $input;
-	}
+		$id_token_alg = $input['client_signing_algorithm'] ?? null;
+		if ( ! in_array( $id_token_alg, self::ALLOWED_ID_TOKEN_ALGS ) ) {
+			$input['client_signing_algorithm'] = $this->options->get_default( 'client_signing_algorithm' );
+		}
 
-	/**
-	 * Validation for the WordPress Login Enabled setting.
-	 *
-	 * @param array $old_options - Previous option values.
-	 * @param array $input - Option values being saved.
-	 *
-	 * @return mixed
-	 */
-	public function wle_validation( $old_options, $input ) {
-		if ( ! in_array( $input['wordpress_login_enabled'], [ 'link', 'isset', 'code', 'no' ] ) ) {
+		$input['cache_expiration'] = absint( $input['cache_expiration'] ?? 0 );
+
+		$wle = $input['wordpress_login_enabled'] ?? null;
+		if ( ! in_array( $wle, [ 'link', 'isset', 'code', 'no' ] ) ) {
 			$input['wordpress_login_enabled'] = $this->options->get_default( 'wordpress_login_enabled' );
 		}
-		$input['wle_code'] = $this->options->get( 'wle_code' ) ?: str_shuffle( uniqid() . uniqid() );
+
+		$input['wle_code'] = $this->options->get( 'wle_code' ) ?: wp_auth0_generate_token( 24 );
+
 		return $input;
 	}
 }

--- a/lib/initial-setup/WP_Auth0_InitialSetup.php
+++ b/lib/initial-setup/WP_Auth0_InitialSetup.php
@@ -100,7 +100,7 @@ class WP_Auth0_InitialSetup {
 					<a target="_blank" href="<?php echo admin_url( 'admin.php?page=wpa0-errors' ); ?>"><?php _e( 'Error log', 'wp-auth0' ); ?></a>
 					<?php _e( ' for more information.', 'wp-auth0' ); ?>
 					<?php _e( 'Please check that your server has internet access and can reach ', 'wp-auth0' ); ?>
-					<code>https://<?php echo $this->a0_options->get( 'domain' ); ?></code>
+					<code><?php echo esc_url( 'https://' . $this->a0_options->get( 'domain' ) ); ?></code>
 				  </strong>
 			  </p>
 		  </div>

--- a/tests/testOptionWle.php
+++ b/tests/testOptionWle.php
@@ -132,22 +132,22 @@ class TestOptionWle extends WP_Auth0_Test_Case {
 	 * Test that wordpress_login_enabled is validated properly on save.
 	 */
 	public function testThatWleIsValiatedOnSave() {
-		$validated = self::$admin->wle_validation( [], [ 'wordpress_login_enabled' => 'link' ] );
+		$validated = self::$admin->basic_validation( [], [ 'wordpress_login_enabled' => 'link' ] );
 		$this->assertEquals( 'link', $validated['wordpress_login_enabled'] );
 
-		$validated = self::$admin->wle_validation( [], [ 'wordpress_login_enabled' => 'isset' ] );
+		$validated = self::$admin->basic_validation( [], [ 'wordpress_login_enabled' => 'isset' ] );
 		$this->assertEquals( 'isset', $validated['wordpress_login_enabled'] );
 
-		$validated = self::$admin->wle_validation( [], [ 'wordpress_login_enabled' => 'code' ] );
+		$validated = self::$admin->basic_validation( [], [ 'wordpress_login_enabled' => 'code' ] );
 		$this->assertEquals( 'code', $validated['wordpress_login_enabled'] );
 
-		$validated = self::$admin->wle_validation( [], [ 'wordpress_login_enabled' => 'no' ] );
+		$validated = self::$admin->basic_validation( [], [ 'wordpress_login_enabled' => 'no' ] );
 		$this->assertEquals( 'no', $validated['wordpress_login_enabled'] );
 
-		$validated = self::$admin->wle_validation( [], [ 'wordpress_login_enabled' => uniqid() ] );
+		$validated = self::$admin->basic_validation( [], [ 'wordpress_login_enabled' => uniqid() ] );
 		$this->assertEquals( 'link', $validated['wordpress_login_enabled'] );
 
-		$validated = self::$admin->wle_validation( [], [ 'wordpress_login_enabled' => false ] );
+		$validated = self::$admin->basic_validation( [], [ 'wordpress_login_enabled' => false ] );
 		$this->assertEquals( 'link', $validated['wordpress_login_enabled'] );
 	}
 
@@ -157,15 +157,15 @@ class TestOptionWle extends WP_Auth0_Test_Case {
 	public function testThatWleCodeIsKeptIfSavedGeneratedIfEmpty() {
 		$wle_code = uniqid();
 		self::$opts->set( 'wle_code', $wle_code );
-		$validated = self::$admin->wle_validation( [], [ 'wordpress_login_enabled' => uniqid() ] );
+		$validated = self::$admin->basic_validation( [], [ 'wordpress_login_enabled' => uniqid() ] );
 		$this->assertEquals( $wle_code, $validated['wle_code'] );
 
 		self::$opts->set( 'wle_code', null );
-		$validated = self::$admin->wle_validation( [], [ 'wordpress_login_enabled' => uniqid() ] );
+		$validated = self::$admin->basic_validation( [], [ 'wordpress_login_enabled' => uniqid() ] );
 		$this->assertGreaterThan( 24, strlen( $validated['wle_code'] ) );
 
 		self::$opts->set( 'wle_code', '' );
-		$validated = self::$admin->wle_validation( [], [ 'wordpress_login_enabled' => uniqid() ] );
+		$validated = self::$admin->basic_validation( [], [ 'wordpress_login_enabled' => uniqid() ] );
 		$this->assertGreaterThan( 24, strlen( $validated['wle_code'] ) );
 	}
 }

--- a/tests/testWPAuth0Options.php
+++ b/tests/testWPAuth0Options.php
@@ -89,56 +89,53 @@ class TestWPAuth0Options extends WP_Auth0_Test_Case {
 	 * Test that options can be set in memory without a DB update
 	 */
 	public function testSetWithoutSave() {
-		$opt_name     = 'domain';
 		$expected_val = rand();
 		$opts         = new WP_Auth0_Options();
 
 		// Set the option and do not save.
-		$opts->set( $opt_name, $expected_val, false );
-		$this->assertEquals( $expected_val, $opts->get( $opt_name ) );
+		$opts->set( 'domain', $expected_val, false );
+		$this->assertEquals( $expected_val, $opts->get( 'domain' ) );
 
 		// Get the DB-saved options and make sure it was not saved.
 		$db_options = get_option( $opts->get_options_name() );
-		$this->assertNotEquals( $expected_val, $db_options[ $opt_name ] );
+		$this->assertNotEquals( $expected_val, $db_options['domain'] );
 	}
 
 	/**
 	 * Test that options can be set and saved to the DB.
 	 */
 	public function testSetWithSave() {
-		$opt_name     = 'domain';
 		$expected_val = rand();
 		$opts         = new WP_Auth0_Options();
 
 		// Set the option and flag to save (default).
-		$opts->set( $opt_name, $expected_val );
-		$this->assertEquals( $expected_val, $opts->get( $opt_name ) );
+		$opts->set( 'domain', $expected_val );
+		$this->assertEquals( $expected_val, $opts->get( 'domain' ) );
 
 		// Make sure the saved value is correct.
 		$db_options = get_option( $opts->get_options_name() );
-		$this->assertEquals( $expected_val, $db_options[ $opt_name ] );
+		$this->assertEquals( $expected_val, $db_options['domain'] );
 	}
 
 	/**
 	 * Test that update_all works.
 	 */
 	public function testUpdateAll() {
-		$opt_name     = 'domain';
 		$expected_val = rand();
 		$opts         = new WP_Auth0_Options();
 
 		// Set the option and flag to skip saving.
-		$opts->set( $opt_name, $expected_val, false );
-		$this->assertEquals( $expected_val, $opts->get( $opt_name ) );
+		$opts->set( 'domain', $expected_val, false );
+		$this->assertEquals( $expected_val, $opts->get( 'domain' ) );
 
 		// Get the database option to make sure it was not saved.
 		$db_options = get_option( $opts->get_options_name() );
-		$this->assertNotEquals( $expected_val, $db_options[ $opt_name ] );
+		$this->assertNotEquals( $expected_val, $db_options['domain'] );
 
 		// Explicitly save to the DB and make sure it's correct.
 		$opts->update_all();
 		$db_options = get_option( $opts->get_options_name() );
-		$this->assertEquals( $expected_val, $db_options[ $opt_name ] );
+		$this->assertEquals( $expected_val, $db_options['domain'] );
 	}
 
 	/**
@@ -165,24 +162,23 @@ class TestWPAuth0Options extends WP_Auth0_Test_Case {
 	 * Test that options can be set in memory and in the DB.
 	 */
 	public function testSet() {
-		$opt_name       = 'domain';
 		$expected_val_1 = rand();
 		$expected_val_2 = rand();
 		$opts           = new WP_Auth0_Options();
 
 		// Test that a basic set without DB update works.
-		$result = $opts->set( $opt_name, $expected_val_1, false );
+		$result = $opts->set( 'domain', $expected_val_1, false );
 		$this->assertTrue( $result );
-		$this->assertEquals( $expected_val_1, $opts->get( $opt_name ) );
+		$this->assertEquals( $expected_val_1, $opts->get( 'domain' ) );
 		$db_options = get_option( $opts->get_options_name() );
-		$this->assertNotEquals( $expected_val_1, $db_options[ $opt_name ] );
+		$this->assertNotEquals( $expected_val_1, $db_options['domain'] );
 
 		// Test that a basic set with DB update works.
-		$result = $opts->set( $opt_name, $expected_val_2, true );
+		$result = $opts->set( 'domain', $expected_val_2, true );
 		$this->assertTrue( $result );
-		$this->assertEquals( $expected_val_2, $opts->get( $opt_name ) );
+		$this->assertEquals( $expected_val_2, $opts->get( 'domain' ) );
 		$db_options = get_option( $opts->get_options_name() );
-		$this->assertEquals( $expected_val_2, $db_options[ $opt_name ] );
+		$this->assertEquals( $expected_val_2, $db_options['domain'] );
 	}
 
 	/**


### PR DESCRIPTION
### Description

- Normalize settings validation for the Basic tab
- Normalize defaults for the Basic tab
- Remove `WP_Auth0_Admin_Basic->wle_validation()`

### References

[WP guidance on sanitization and escaping](https://developer.wordpress.org/themes/theme-security/data-sanitization-escaping/)

### Testing

- [x] This change improves test coverage for new/changed/fixed functionality
