### PR TITLE
Update Embedded settings validation and defaults

### DIFF
--- a/WP_Auth0.php
+++ b/WP_Auth0.php
@@ -22,8 +22,8 @@ define( 'WPA0_PLUGIN_IMG_URL', WPA0_PLUGIN_URL . 'assets/img/' );
 define( 'WPA0_PLUGIN_LIB_URL', WPA0_PLUGIN_URL . 'assets/lib/' );
 define( 'WPA0_PLUGIN_BS_URL', WPA0_PLUGIN_URL . 'assets/bootstrap/' );
 
-define( 'WPA0_LOCK_CDN_URL', 'https://cdn.auth0.com/js/lock/11.16/lock.min.js' );
-define( 'WPA0_AUTH0_JS_CDN_URL', 'https://cdn.auth0.com/js/auth0/9.10/auth0.min.js' );
+define( 'WPA0_LOCK_CDN_URL', 'https://cdn.auth0.com/js/lock/11.21/lock.min.js' );
+define( 'WPA0_AUTH0_JS_CDN_URL', 'https://cdn.auth0.com/js/auth0/9.12/auth0.min.js' );
 
 define( 'WPA0_AUTH0_LOGIN_FORM_ID', 'auth0-login-form' );
 define( 'WPA0_CACHE_GROUP', 'wp_auth0' );

--- a/lib/WP_Auth0_DBManager.php
+++ b/lib/WP_Auth0_DBManager.php
@@ -105,9 +105,9 @@ class WP_Auth0_DBManager {
 
 			if ( 'https://cdn.auth0.com/js/lock/11.5/lock.min.js' === $options->get( 'cdn_url' ) ) {
 				$options->set( 'cdn_url', WPA0_LOCK_CDN_URL, false );
-				$options->set( 'custom_cdn_url', null, false );
+				$options->set( 'custom_cdn_url', false, false );
 			} else {
-				$options->set( 'custom_cdn_url', 1, false );
+				$options->set( 'custom_cdn_url', true, false );
 			}
 
 			// Nullify and delete all removed options.

--- a/lib/WP_Auth0_Lock.php
+++ b/lib/WP_Auth0_Lock.php
@@ -171,7 +171,7 @@ class WP_Auth0_Lock {
 		printf(
 			'<div id="extra-options"><a href="?">%s</a></div>',
 			// translators: The $title variable is the admin-controlled form title.
-			printf( __( '← Back to %s login', 'wp-auth0' ), $title )
+			sanitize_text_field( sprintf( __( '← Back to %s login', 'wp-auth0' ), $title ) )
 		);
 	}
 
@@ -209,7 +209,7 @@ class WP_Auth0_Lock {
 				'clientId'        => $options->get( 'client_id' ),
 				'stateCookieName' => WP_Auth0_State_Handler::get_storage_cookie_name(),
 				'nonceCookieName' => WP_Auth0_Nonce_Handler::get_storage_cookie_name(),
-				'usePasswordless' => $options->get( 'passwordless_enabled', false ),
+				'usePasswordless' => $options->get( 'passwordless_enabled' ),
 				'loginFormId'     => WPA0_AUTH0_LOGIN_FORM_ID,
 				'showAsModal'     => ! empty( $specialSettings['show_as_modal'] ),
 				'i18n'            => [

--- a/lib/WP_Auth0_Options.php
+++ b/lib/WP_Auth0_Options.php
@@ -290,7 +290,7 @@ class WP_Auth0_Options {
 	 */
 	public function get_lock_url() {
 		$cdn_url = $this->get( 'cdn_url' );
-		return $cdn_url && $this->get( 'custom_cdn_url' ) ? $cdn_url : WPA0_LOCK_CDN_URL;
+		return ( $cdn_url && $this->get( 'custom_cdn_url' ) ) ? $cdn_url : WPA0_LOCK_CDN_URL;
 	}
 
 	/**
@@ -393,7 +393,7 @@ class WP_Auth0_Options {
 			'username_style'            => '',
 			'primary_color'             => '',
 			'extra_conf'                => '',
-			'custom_cdn_url'            => null,
+			'custom_cdn_url'            => false,
 			'cdn_url'                   => WPA0_LOCK_CDN_URL,
 			'lock_connections'          => '',
 

--- a/lib/admin/WP_Auth0_Admin_Appearance.php
+++ b/lib/admin/WP_Auth0_Admin_Appearance.php
@@ -290,32 +290,35 @@ class WP_Auth0_Admin_Appearance extends WP_Auth0_Admin_Generic {
 	 * @return array
 	 */
 	public function basic_validation( $old_options, $input ) {
-		$input['passwordless_enabled'] = ( isset( $input['passwordless_enabled'] ) ? $input['passwordless_enabled'] : 0 ) == 1;
-		$input['form_title']           = empty( $input['form_title'] ) ? '' : sanitize_text_field( $input['form_title'] );
-		$input['icon_url']             = empty( $input['icon_url'] ) ? '' : esc_url( $input['icon_url'], [ 'http', 'https' ] );
-		$input['gravatar']             = empty( $input['gravatar'] ) ? 0 : 1;
-		$input['primary_color']        = empty( $input['primary_color'] ) ? '' : sanitize_text_field( $input['primary_color'] );
+		$input['passwordless_enabled'] = $this->sanitize_switch_val( $input['passwordless_enabled'] ?? null );
 
-		$input['custom_cdn_url'] = empty( $input['custom_cdn_url'] ) ? 0 : 1;
-
-		$input['cdn_url'] = empty( $input['cdn_url'] ) ? WPA0_LOCK_CDN_URL : sanitize_text_field( $input['cdn_url'] );
-
-		// If an invalid URL is used, default to previously saved (if there is one) or default URL.
-		if ( ! filter_var( $input['cdn_url'], FILTER_VALIDATE_URL ) ) {
-			$input['cdn_url'] = isset( $old_options['cdn_url'] ) ? $old_options['cdn_url'] : WPA0_LOCK_CDN_URL;
-			self::add_validation_error( __( 'The Lock JS CDN URL used is not a valid URL.', 'wp-auth0' ) );
+		$input['icon_url'] = esc_url_raw( $this->sanitize_text_val( $input['icon_url'] ?? null ) );
+		if ( ! filter_var( $input['icon_url'], FILTER_VALIDATE_URL ) ) {
+			$input['icon_url'] = $this->options->get( 'icon_url' );
+			self::add_validation_error( __( 'The Icon URL used is not valid.', 'wp-auth0' ) );
 		}
 
-		$input['lock_connections'] = isset( $input['lock_connections'] ) ?
-			trim( $input['lock_connections'] ) : '';
+		$input['form_title']     = $this->sanitize_text_val( $input['form_title'] ?? null );
+		$input['gravatar']       = $this->sanitize_switch_val( $input['gravatar'] ?? null );
+		$input['username_style'] = $this->sanitize_text_val( $input['username_style'] ?? null );
+		$input['primary_color']  = $this->sanitize_text_val( $input['primary_color'] ?? null );
 
-		$input['extra_conf'] = isset( $input['extra_conf'] ) ? trim( $input['extra_conf'] ) : '';
-		if ( ! empty( $input['extra_conf'] ) ) {
-			if ( json_decode( $input['extra_conf'] ) === null ) {
-				$error = __( 'The Extra settings parameter should be a valid json object', 'wp-auth0' );
-				self::add_validation_error( $error );
-			}
+		$input['extra_conf'] = $this->sanitize_text_val( $input['extra_conf'] ?? null );
+		if ( ! empty( $input['extra_conf'] ) && ! json_decode( $input['extra_conf'] ) ) {
+			$input['extra_conf'] = $this->options->get( 'extra_conf', '' );
+			$error               = __( 'The Extra Settings parameter should be a valid JSON object.', 'wp-auth0' );
+			self::add_validation_error( $error );
 		}
+
+		$input['custom_cdn_url'] = $this->sanitize_switch_val( $input['custom_cdn_url'] ?? null );
+
+		$input['cdn_url'] = esc_url_raw( $this->sanitize_text_val( $input['cdn_url'] ?? null ) );
+		if ( $input['custom_cdn_url'] && ! filter_var( $input['cdn_url'], FILTER_VALIDATE_URL ) ) {
+			$input['cdn_url'] = $this->options->get( 'cdn_url', WPA0_LOCK_CDN_URL );
+			self::add_validation_error( __( 'The Custom Lock JS URL used is not valid.', 'wp-auth0' ) );
+		}
+
+		$input['lock_connections'] = $this->sanitize_text_val( $input['lock_connections'] ?? null );
 
 		return $input;
 	}

--- a/tests/testAdminAppearanceValidation.php
+++ b/tests/testAdminAppearanceValidation.php
@@ -12,8 +12,6 @@
  */
 class TestAdminAppearanceValidation extends WP_Auth0_Test_Case {
 
-	use DomDocumentHelpers;
-
 	/**
 	 * WP_Auth0_Admin_Appearance instance.
 	 *
@@ -60,13 +58,5 @@ class TestAdminAppearanceValidation extends WP_Auth0_Test_Case {
 
 		$validated = self::$admin->basic_validation( [], [ 'primary_color' => '<script>alert("hi")</script>' ] );
 		$this->assertNotContains( '<script>', $validated['primary_color'] );
-	}
-
-	/**
-	 * Test that the social_big_buttons option is gone.
-	 */
-	public function testThatSocialBigButtonsIsNotAdded() {
-		$validated = self::$admin->basic_validation( [], [] );
-		$this->assertArrayNotHasKey( 'social_big_buttons', $validated );
 	}
 }

--- a/tests/testOptionLockCdn.php
+++ b/tests/testOptionLockCdn.php
@@ -16,9 +16,9 @@ class TestOptionLockCdn extends WP_Auth0_Test_Case {
 	use DomDocumentHelpers;
 
 	/**
-	 * WP_Auth0_Admin_Advanced instance.
+	 * WP_Auth0_Admin_Appearance instance.
 	 *
-	 * @var WP_Auth0_Admin_Advanced
+	 * @var WP_Auth0_Admin_Appearance
 	 */
 	public static $admin;
 
@@ -27,7 +27,7 @@ class TestOptionLockCdn extends WP_Auth0_Test_Case {
 	 */
 	public static function setUpBeforeClass() {
 		parent::setUpBeforeClass();
-		self::$admin = new WP_Auth0_Admin_Appearance( self::$opts, new WP_Auth0_Routes( self::$opts ) );
+		self::$admin = new WP_Auth0_Admin_Appearance( self::$opts );
 	}
 
 	/**
@@ -141,16 +141,19 @@ class TestOptionLockCdn extends WP_Auth0_Test_Case {
 	public function testThatCustomLockCdnIsValidatedOnSave() {
 
 		$validated = self::$admin->basic_validation( [], [ 'custom_cdn_url' => false ] );
-		$this->assertEquals( 0, $validated['custom_cdn_url'] );
+		$this->assertEquals( false, $validated['custom_cdn_url'] );
 
 		$validated = self::$admin->basic_validation( [], [ 'custom_cdn_url' => 0 ] );
-		$this->assertEquals( 0, $validated['custom_cdn_url'] );
+		$this->assertEquals( false, $validated['custom_cdn_url'] );
 
 		$validated = self::$admin->basic_validation( [], [ 'custom_cdn_url' => 1 ] );
-		$this->assertEquals( 1, $validated['custom_cdn_url'] );
+		$this->assertEquals( true, $validated['custom_cdn_url'] );
+
+		$validated = self::$admin->basic_validation( [], [ 'custom_cdn_url' => '1' ] );
+		$this->assertEquals( true, $validated['custom_cdn_url'] );
 
 		$validated = self::$admin->basic_validation( [], [ 'custom_cdn_url' => uniqid() ] );
-		$this->assertEquals( 1, $validated['custom_cdn_url'] );
+		$this->assertEquals( false, $validated['custom_cdn_url'] );
 	}
 
 	/**
@@ -161,8 +164,7 @@ class TestOptionLockCdn extends WP_Auth0_Test_Case {
 		$validated = self::$admin->basic_validation(
 			[],
 			[
-				'custom_cdn_url' => 0,
-				'cdn_url'        => WPA0_LOCK_CDN_URL,
+				'cdn_url' => WPA0_LOCK_CDN_URL,
 			]
 		);
 		$this->assertEquals( WPA0_LOCK_CDN_URL, $validated['cdn_url'] );
@@ -170,7 +172,7 @@ class TestOptionLockCdn extends WP_Auth0_Test_Case {
 		$validated = self::$admin->basic_validation(
 			[],
 			[
-				'custom_cdn_url' => 1,
+				'custom_cdn_url' => '1',
 				'cdn_url'        => WPA0_LOCK_CDN_URL,
 			]
 		);
@@ -191,15 +193,23 @@ class TestOptionLockCdn extends WP_Auth0_Test_Case {
 		$validated = self::$admin->basic_validation( [], [ 'cdn_url' => ' ' . WPA0_LOCK_CDN_URL . ' ' ] );
 		$this->assertEquals( WPA0_LOCK_CDN_URL, $validated['cdn_url'] );
 
+		self::$opts->set( 'cdn_url', '__old_cdn_url__' );
 		$validated = self::$admin->basic_validation(
-			[ 'cdn_url' => '__old_cdn_url__' ],
-			[ 'cdn_url' => '__invalid_cdn_url__' ]
+			[],
+			[
+				'custom_cdn_url' => true,
+				'cdn_url' => '__invalid_cdn_url__'
+			]
 		);
 		$this->assertEquals( '__old_cdn_url__', $validated['cdn_url'] );
 
+		self::$opts->set( 'cdn_url', null );
 		$validated = self::$admin->basic_validation(
-			[ 'cdn_url' => '__old_cdn_url__' ],
-			[ 'cdn_url' => '' ]
+			[],
+			[
+				'custom_cdn_url' => true,
+				'cdn_url' => ''
+			]
 		);
 		$this->assertEquals( WPA0_LOCK_CDN_URL, $validated['cdn_url'] );
 	}
@@ -211,7 +221,7 @@ class TestOptionLockCdn extends WP_Auth0_Test_Case {
 		self::$opts->set( 'cdn_url', 'https://auth0.com' );
 		$this->assertEquals( WPA0_LOCK_CDN_URL, self::$opts->get_lock_url() );
 
-		self::$opts->set( 'custom_cdn_url', 1 );
+		self::$opts->set( 'custom_cdn_url', true );
 		$this->assertEquals( 'https://auth0.com', self::$opts->get_lock_url() );
 
 		self::$opts->set( 'cdn_url', '' );

--- a/tests/testWPAuth0DbMigrations.php
+++ b/tests/testWPAuth0DbMigrations.php
@@ -100,7 +100,7 @@ class TestWPAuth0DbMigrations extends WP_Auth0_Test_Case {
 
 		// Check that Lock URL was updated.
 		$this->assertEquals( WPA0_LOCK_CDN_URL, self::$opts->get( 'cdn_url' ) );
-		$this->assertNull( self::$opts->get( 'custom_cdn_url' ) );
+		$this->assertFalse( self::$opts->get( 'custom_cdn_url' ) );
 
 		self::$opts->reset();
 		update_option( 'auth0_db_version', $test_version - 1 );
@@ -113,7 +113,7 @@ class TestWPAuth0DbMigrations extends WP_Auth0_Test_Case {
 
 		// Check that Lock URL was not updated.
 		$this->assertEquals( 'https://cdn.auth0.com/js/lock/12.0/lock.min.js', self::$opts->get( 'cdn_url' ) );
-		$this->assertEquals( 1, self::$opts->get( 'custom_cdn_url' ) );
+		$this->assertTrue( self::$opts->get( 'custom_cdn_url' ) );
 	}
 
 	/**


### PR DESCRIPTION
### Description

- Normalize settings validation for the Embedded tab
- Normalize defaults for the Embedded tab
- Update Lock from `11.16.x` to `11.21.x`
- Update Auth0.js from `9.10` to `9.12`

### References

[WP guidance on sanitization and escaping](https://developer.wordpress.org/themes/theme-security/data-sanitization-escaping/)

### Testing

- [x] This change improves test coverage for new/changed/fixed functionality
