### PR TITLE
Add settings validation to import

### DIFF
--- a/lib/WP_Auth0_Embed_Widget.php
+++ b/lib/WP_Auth0_Embed_Widget.php
@@ -72,11 +72,10 @@ class WP_Auth0_Embed_Widget extends WP_Widget {
 				new WP_Auth0_Routes( WP_Auth0_Options::Instance() )
 			);
 
-			$validated_opts              = $admin_advanced->loginredirection_validation(
-				[ 'default_login_redirection' => $old_instance['redirect_to'] ],
-				[ 'default_login_redirection' => $new_instance['redirect_to'] ]
+			$new_instance['redirect_to'] = $admin_advanced->validate_login_redirect(
+				$new_instance['redirect_to'],
+				$old_instance['redirect_to']
 			);
-			$new_instance['redirect_to'] = $validated_opts['default_login_redirection'];
 		}
 
 		return $new_instance;

--- a/lib/WP_Auth0_Import_Settings.php
+++ b/lib/WP_Auth0_Import_Settings.php
@@ -31,8 +31,19 @@ class WP_Auth0_Import_Settings {
 			exit;
 		}
 
-		foreach ( $settings as $key => $value ) {
-			$this->a0_options->set( $key, $value, false );
+		// Keep original settings keys so we only save imported values.
+		$settings_keys = array_keys( $settings );
+
+		$admin = new WP_Auth0_Admin( $this->a0_options, new WP_Auth0_Routes( $this->a0_options ) );
+
+		// Default setting values will be added to the array.
+		$settings_validated = $admin->input_validator( $settings );
+
+		foreach ( $settings_keys as $settings_key ) {
+			// Invalid settings keys are removed in WP_Auth0_Admin::input_validator().
+			if ( isset( $settings_validated[ $settings_key ] ) ) {
+				$this->a0_options->set( $settings_key, $settings_validated[ $settings_key ], false );
+			}
 		}
 
 		$this->a0_options->update_all();

--- a/lib/admin/WP_Auth0_Admin.php
+++ b/lib/admin/WP_Auth0_Admin.php
@@ -74,7 +74,7 @@ class WP_Auth0_Admin {
 			$this->a0_options->get_options_name() . '_basic',
 			$this->a0_options->get_options_name(),
 			[
-				'sanitize_callback' => [ $this, 'input_validator' ]
+				'sanitize_callback' => [ $this, 'input_validator' ],
 			]
 		);
 	}

--- a/lib/admin/WP_Auth0_Admin.php
+++ b/lib/admin/WP_Auth0_Admin.php
@@ -73,7 +73,9 @@ class WP_Auth0_Admin {
 		register_setting(
 			$this->a0_options->get_options_name() . '_basic',
 			$this->a0_options->get_options_name(),
-			[ $this, 'input_validator' ]
+			[
+				'sanitize_callback' => [ $this, 'input_validator' ]
+			]
 		);
 	}
 

--- a/lib/admin/WP_Auth0_Admin_Appearance.php
+++ b/lib/admin/WP_Auth0_Admin_Appearance.php
@@ -284,12 +284,11 @@ class WP_Auth0_Admin_Appearance extends WP_Auth0_Admin_Generic {
 	/**
 	 * Validation for Basic settings tab.
 	 *
-	 * @param array $old_options - Options before saving the settings form.
 	 * @param array $input - New options being saved.
 	 *
 	 * @return array
 	 */
-	public function basic_validation( $old_options, $input ) {
+	public function basic_validation( array $input ) {
 		$input['passwordless_enabled'] = $this->sanitize_switch_val( $input['passwordless_enabled'] ?? null );
 
 		$input['icon_url'] = esc_url_raw( $this->sanitize_text_val( $input['icon_url'] ?? null ) );

--- a/lib/admin/WP_Auth0_Admin_Basic.php
+++ b/lib/admin/WP_Auth0_Admin_Basic.php
@@ -289,12 +289,11 @@ class WP_Auth0_Admin_Basic extends WP_Auth0_Admin_Generic {
 	/**
 	 * Validation for Basic settings tab.
 	 *
-	 * @param array $old_options - Options before saving the settings form.
 	 * @param array $input - New options being saved.
 	 *
 	 * @return array
 	 */
-	public function basic_validation( $old_options, $input ) {
+	public function basic_validation( array $input ) {
 
 		if ( wp_cache_get( 'doing_db_update', WPA0_CACHE_GROUP ) ) {
 			return $input;
@@ -315,7 +314,7 @@ class WP_Auth0_Admin_Basic extends WP_Auth0_Admin_Generic {
 		$input['client_secret'] = $this->sanitize_text_val( $input['client_secret'] ?? null );
 		if ( __( '[REDACTED]', 'wp-auth0' ) === $input['client_secret'] ) {
 			// The field is loaded with "[REDACTED]" so if that value is saved, we keep the existing secret.
-			$input['client_secret'] = $old_options['client_secret'];
+			$input['client_secret'] = $this->options->get( 'client_secret' );
 		}
 		if ( empty( $input['client_secret'] ) ) {
 			$this->add_validation_error( __( 'You need to specify a Client Secret', 'wp-auth0' ) );

--- a/lib/admin/WP_Auth0_Admin_Features.php
+++ b/lib/admin/WP_Auth0_Admin_Features.php
@@ -126,12 +126,11 @@ class WP_Auth0_Admin_Features extends WP_Auth0_Admin_Generic {
 	/**
 	 * Validation for Basic settings tab.
 	 *
-	 * @param array $old_options - Options before saving the settings form.
 	 * @param array $input - New options being saved.
 	 *
 	 * @return array
 	 */
-	public function basic_validation( array $old_options, array $input ) {
+	public function basic_validation( array $input ) {
 		$input['auto_login']          = $this->sanitize_switch_val( $input['auto_login'] ?? null );
 		$input['auto_login_method']   = $this->sanitize_text_val( $input['auto_login_method'] ?? null );
 		$input['singlelogout']        = $this->sanitize_switch_val( $input['singlelogout'] ?? null );

--- a/lib/admin/WP_Auth0_Admin_Generic.php
+++ b/lib/admin/WP_Auth0_Admin_Generic.php
@@ -66,13 +66,10 @@ class WP_Auth0_Admin_Generic {
 		}
 	}
 
-	public function input_validator( $input, $old_options = null ) {
-		if ( empty( $old_options ) ) {
-			$old_options = $this->options->get_options();
-		}
+	public function input_validator( $input ) {
 
 		foreach ( $this->actions_middlewares as $action ) {
-			$input = $this->$action( $old_options, $input );
+			$input = $this->$action( $input );
 		}
 
 		return $input;

--- a/templates/import_settings.php
+++ b/templates/import_settings.php
@@ -7,6 +7,7 @@ $constant_keys = $opts->get_all_constant_keys();
   <div class="container-fluid">
 
 	  <h1><?php _e( 'Import and Export Settings', 'wp-auth0' ); ?></h1>
+
 	  <p class="a0-step-text top-margin">
 			<?php _e( 'You can import and export your Auth0 WordPress plugin settings here. ', 'wp-auth0' ); ?>
 			<?php _e( 'This allows you to either backup the data, or to move your settings to a new WordPress instance.', 'wp-auth0' ); ?>
@@ -28,7 +29,12 @@ $constant_keys = $opts->get_all_constant_keys();
 		  <form action="options.php" method="post" enctype="multipart/form-data">
 			<input type="hidden" name="action" value="wpauth0_import_settings" />
 
-			  <p class="a0-step-text top-margin"><?php _e( 'Paste the settings JSON in the field below:', 'wp-auth0' ); ?>
+			  <p class="a0-step-text top-margin">
+			  <?php
+					  _e( 'Paste the settings JSON in the field below. ', 'wp-auth0' );
+					  _e( 'Settings that are not in the imported JSON will use existing values. ', 'wp-auth0' );
+					  _e( 'Setting values will be validated so check the final values once import is complete. ', 'wp-auth0' );
+				?>
 			  <div class="a0-step-text top-margin"><textarea name="settings-json" class="large-text code" rows="6"></textarea></div>
 
 			<div class="a0-buttons">

--- a/templates/settings.php
+++ b/templates/settings.php
@@ -6,6 +6,18 @@
 
 			<?php settings_errors(); ?>
 
+		<?php if ( wp_auth0_get_option( 'client_id' ) ) : ?>
+		<a href="https://manage.auth0.com/#/applications/
+			<?php
+			echo esc_attr( wp_auth0_get_option( 'client_id' ) );
+			?>
+			" target="_blank">
+			<?php
+			_e( 'Manage this application at Auth0', 'wp-auth0' );
+			?>
+			</a>
+		<?php endif; ?>
+
 			<p class="nav nav-tabs" role="tablist">
 					<a id="tab-basic" href="#basic" class="js-a0-settings-tabs">
 						<?php _e( 'Basic', 'wp-auth0' ); ?>

--- a/tests/testAdminAppearanceValidation.php
+++ b/tests/testAdminAppearanceValidation.php
@@ -13,9 +13,9 @@
 class TestAdminAppearanceValidation extends WP_Auth0_Test_Case {
 
 	/**
-	 * WP_Auth0_Admin_Appearance instance.
+	 * WP_Auth0_Admin instance.
 	 *
-	 * @var WP_Auth0_Admin_Appearance
+	 * @var WP_Auth0_Admin
 	 */
 	public static $admin;
 
@@ -24,17 +24,26 @@ class TestAdminAppearanceValidation extends WP_Auth0_Test_Case {
 	 */
 	public static function setUpBeforeClass() {
 		parent::setUpBeforeClass();
-		self::$admin = new WP_Auth0_Admin_Appearance( self::$opts );
+		self::$admin = new WP_Auth0_Admin( self::$opts, new WP_Auth0_Routes( self::$opts ) );
+		self::$admin->init_admin();
+	}
+
+	public static function tearDownAfterClass() {
+		parent::tearDownAfterClass();
+		unregister_setting(
+			'wp_auth0_settings_basic',
+			'wp_auth0_settings'
+		);
 	}
 
 	/**
 	 * Test that the form_title setting is skipped if empty and removes HTML.
 	 */
 	public function testThatFormTitleIsValidatedProperly() {
-		$validated = self::$admin->basic_validation( [] );
+		$validated = self::$admin->input_validator( [] );
 		$this->assertEquals( '', $validated['form_title'] );
 
-		$validated = self::$admin->basic_validation( [ 'form_title' => '<script>alert("hi")</script>' ] );
+		$validated = self::$admin->input_validator( [ 'form_title' => '<script>alert("hi")</script>' ] );
 		$this->assertNotContains( '<script>', $validated['form_title'] );
 	}
 
@@ -42,10 +51,10 @@ class TestAdminAppearanceValidation extends WP_Auth0_Test_Case {
 	 * Test that the icon_url setting is skipped if empty and tries to create a valid URL for display.
 	 */
 	public function testThatIconUrlIsValidatedProperly() {
-		$validated = self::$admin->basic_validation( [] );
+		$validated = self::$admin->input_validator( [] );
 		$this->assertEquals( '', $validated['icon_url'] );
 
-		$validated = self::$admin->basic_validation( [ 'icon_url' => 'example.org' ] );
+		$validated = self::$admin->input_validator( [ 'icon_url' => 'example.org' ] );
 		$this->assertEquals( 'http://example.org', $validated['icon_url'] );
 	}
 
@@ -53,10 +62,10 @@ class TestAdminAppearanceValidation extends WP_Auth0_Test_Case {
 	 * Test that the primary_color setting is skipped if empty and removes HTML.
 	 */
 	public function testThatPrimaryColorIsValidatedProperly() {
-		$validated = self::$admin->basic_validation( [] );
+		$validated = self::$admin->input_validator( [] );
 		$this->assertEquals( '', $validated['primary_color'] );
 
-		$validated = self::$admin->basic_validation( [ 'primary_color' => '<script>alert("hi")</script>' ] );
+		$validated = self::$admin->input_validator( [ 'primary_color' => '<script>alert("hi")</script>' ] );
 		$this->assertNotContains( '<script>', $validated['primary_color'] );
 	}
 }

--- a/tests/testAdminAppearanceValidation.php
+++ b/tests/testAdminAppearanceValidation.php
@@ -31,10 +31,10 @@ class TestAdminAppearanceValidation extends WP_Auth0_Test_Case {
 	 * Test that the form_title setting is skipped if empty and removes HTML.
 	 */
 	public function testThatFormTitleIsValidatedProperly() {
-		$validated = self::$admin->basic_validation( [], [] );
+		$validated = self::$admin->basic_validation( [] );
 		$this->assertEquals( '', $validated['form_title'] );
 
-		$validated = self::$admin->basic_validation( [], [ 'form_title' => '<script>alert("hi")</script>' ] );
+		$validated = self::$admin->basic_validation( [ 'form_title' => '<script>alert("hi")</script>' ] );
 		$this->assertNotContains( '<script>', $validated['form_title'] );
 	}
 
@@ -42,10 +42,10 @@ class TestAdminAppearanceValidation extends WP_Auth0_Test_Case {
 	 * Test that the icon_url setting is skipped if empty and tries to create a valid URL for display.
 	 */
 	public function testThatIconUrlIsValidatedProperly() {
-		$validated = self::$admin->basic_validation( [], [] );
+		$validated = self::$admin->basic_validation( [] );
 		$this->assertEquals( '', $validated['icon_url'] );
 
-		$validated = self::$admin->basic_validation( [], [ 'icon_url' => 'example.org' ] );
+		$validated = self::$admin->basic_validation( [ 'icon_url' => 'example.org' ] );
 		$this->assertEquals( 'http://example.org', $validated['icon_url'] );
 	}
 
@@ -53,10 +53,10 @@ class TestAdminAppearanceValidation extends WP_Auth0_Test_Case {
 	 * Test that the primary_color setting is skipped if empty and removes HTML.
 	 */
 	public function testThatPrimaryColorIsValidatedProperly() {
-		$validated = self::$admin->basic_validation( [], [] );
+		$validated = self::$admin->basic_validation( [] );
 		$this->assertEquals( '', $validated['primary_color'] );
 
-		$validated = self::$admin->basic_validation( [], [ 'primary_color' => '<script>alert("hi")</script>' ] );
+		$validated = self::$admin->basic_validation( [ 'primary_color' => '<script>alert("hi")</script>' ] );
 		$this->assertNotContains( '<script>', $validated['primary_color'] );
 	}
 }

--- a/tests/testAdminAppearanceValidation.php
+++ b/tests/testAdminAppearanceValidation.php
@@ -25,15 +25,6 @@ class TestAdminAppearanceValidation extends WP_Auth0_Test_Case {
 	public static function setUpBeforeClass() {
 		parent::setUpBeforeClass();
 		self::$admin = new WP_Auth0_Admin( self::$opts, new WP_Auth0_Routes( self::$opts ) );
-		self::$admin->init_admin();
-	}
-
-	public static function tearDownAfterClass() {
-		parent::tearDownAfterClass();
-		unregister_setting(
-			'wp_auth0_settings_basic',
-			'wp_auth0_settings'
-		);
 	}
 
 	/**

--- a/tests/testAdminBasicValidation.php
+++ b/tests/testAdminBasicValidation.php
@@ -33,78 +33,79 @@ class TestAdminBasicValidation extends WP_Auth0_Test_Case {
 	 */
 	public static function setUpBeforeClass() {
 		parent::setUpBeforeClass();
-		self::$admin  = new WP_Auth0_Admin_Basic( self::$opts );
-		self::$fields = [
-			'domain'                   => 'test.auth0.com',
-			'custom_domain'            => '',
-			'client_id'                => '__test_client_id__',
-			'client_secret'            => '__test_client_secret__',
-			'client_signing_algorithm' => WP_Auth0_Api_Client::DEFAULT_CLIENT_ALG,
-			'cache_expiration'         => '',
-		];
+		self::$admin = new WP_Auth0_Admin( self::$opts, new WP_Auth0_Routes( self::$opts ) );
+		self::$admin->init_admin();
+	}
+
+	public static function tearDownAfterClass() {
+		parent::tearDownAfterClass();
+		unregister_setting(
+			'wp_auth0_settings_basic',
+			'wp_auth0_settings'
+		);
 	}
 
 	public function testThatDomainIsValidatedProperly() {
-		$validated = self::$admin->basic_validation( [ 'domain' => 'test.auth0.com' ] );
+		$validated = self::$admin->input_validator( [ 'domain' => 'test.auth0.com' ] );
 
 		$this->assertEquals( 'test.auth0.com', $validated['domain'] );
 	}
 
 	public function testThatEmptyDomainIsAllowed() {
-		$validated = self::$admin->basic_validation( [ 'domain' => '' ] );
+		$validated = self::$admin->input_validator( [ 'domain' => '' ] );
 
 		$this->assertEmpty( $validated['domain'] );
 	}
 
 	public function testThatHtmlIsRemovedFromDomain() {
-		$validated = self::$admin->basic_validation( [ 'domain' => '<script>alert("hi")</script>test1.auth0.com' ] );
+		$validated = self::$admin->input_validator( [ 'domain' => '<script>alert("hi")</script>test1.auth0.com' ] );
 
 		$this->assertEquals( 'test1.auth0.com', $validated['domain'] );
 	}
 
 	public function testThatClientSecretIsValidatedProperly() {
-		$validated = self::$admin->basic_validation( [ 'client_secret' => '__test_client_secret__' ] );
+		$validated = self::$admin->input_validator( [ 'client_secret' => '__test_client_secret__' ] );
 
 		$this->assertEquals( '__test_client_secret__', $validated['client_secret'] );
 	}
 
 	public function testThatEmptyClientSecretIsAllowed() {
-		$validated = self::$admin->basic_validation( [ 'client_secret' => '' ] );
+		$validated = self::$admin->input_validator( [ 'client_secret' => '' ] );
 
 		$this->assertEmpty( $validated['client_secret'] );
 	}
 
 	public function testThatHtmlIsRemovedFromClientSecret() {
-		$validated = self::$admin->basic_validation( [ 'client_secret' => '<script>alert("hi")</script>__secret__' ] );
+		$validated = self::$admin->input_validator( [ 'client_secret' => '<script>alert("hi")</script>__secret__' ] );
 
 		$this->assertEquals( '__secret__', $validated['client_secret'] );
 	}
 
 	public function testThatUnchangedClientSecretIsKept() {
 		self::$opts->set( 'client_secret', '__test_client_secret__' );
-		$validated = self::$admin->basic_validation( [ 'client_secret' => '[REDACTED]' ] );
+		$validated = self::$admin->input_validator( [ 'client_secret' => '[REDACTED]' ] );
 
 		$this->assertEquals( '__test_client_secret__', $validated['client_secret'] );
 	}
 
 	public function testThatValidAlgorithmIsValidatedProperly() {
-		$validated = self::$admin->basic_validation( [ 'client_signing_algorithm' => 'HS256' ] );
+		$validated = self::$admin->input_validator( [ 'client_signing_algorithm' => 'HS256' ] );
 
 		$this->assertEquals( 'HS256', $validated['client_signing_algorithm'] );
 
-		$validated = self::$admin->basic_validation( [ 'client_signing_algorithm' => 'RS256' ] );
+		$validated = self::$admin->input_validator( [ 'client_signing_algorithm' => 'RS256' ] );
 
 		$this->assertEquals( 'RS256', $validated['client_signing_algorithm'] );
 	}
 
 	public function testThatEmptyAlgorithmIsResetToDefault() {
-		$validated = self::$admin->basic_validation( [ 'client_signing_algorithm' => '' ] );
+		$validated = self::$admin->input_validator( [ 'client_signing_algorithm' => '' ] );
 
 		$this->assertEquals( 'RS256', $validated['client_signing_algorithm'] );
 	}
 
 	public function testThatInvalidAlgorithmIsResetToDefault() {
-		$validated = self::$admin->basic_validation( [ 'client_signing_algorithm' => '__invalid_alg__' ] );
+		$validated = self::$admin->input_validator( [ 'client_signing_algorithm' => '__invalid_alg__' ] );
 
 		$this->assertEquals( 'RS256', $validated['client_signing_algorithm'] );
 	}

--- a/tests/testAdminBasicValidation.php
+++ b/tests/testAdminBasicValidation.php
@@ -45,81 +45,66 @@ class TestAdminBasicValidation extends WP_Auth0_Test_Case {
 	}
 
 	public function testThatDomainIsValidatedProperly() {
-		$old_input = array_merge( self::$fields, [ 'domain' => uniqid() ] );
-		$validated = self::$admin->basic_validation( $old_input, self::$fields );
+		$validated = self::$admin->basic_validation( [ 'domain' => 'test.auth0.com' ] );
 
 		$this->assertEquals( 'test.auth0.com', $validated['domain'] );
 	}
 
 	public function testThatEmptyDomainIsAllowed() {
-		$old_input = array_merge( self::$fields, [ 'domain' => uniqid() ] );
-		$new_input = array_merge( self::$fields, [ 'domain' => '' ] );
-		$validated = self::$admin->basic_validation( $old_input, $new_input );
+		$validated = self::$admin->basic_validation( [ 'domain' => '' ] );
 
 		$this->assertEmpty( $validated['domain'] );
 	}
 
 	public function testThatHtmlIsRemovedFromDomain() {
-		$new_input = array_merge( self::$fields, [ 'domain' => '<script>alert("hi")</script>test1.auth0.com' ] );
-		$validated = self::$admin->basic_validation( self::$fields, $new_input );
+		$validated = self::$admin->basic_validation( [ 'domain' => '<script>alert("hi")</script>test1.auth0.com' ] );
 
 		$this->assertEquals( 'test1.auth0.com', $validated['domain'] );
 	}
 
 	public function testThatClientSecretIsValidatedProperly() {
-		$old_input = array_merge( self::$fields, [ 'client_secret' => uniqid() ] );
-		$validated = self::$admin->basic_validation( $old_input, self::$fields );
+		$validated = self::$admin->basic_validation( [ 'client_secret' => '__test_client_secret__' ] );
 
 		$this->assertEquals( '__test_client_secret__', $validated['client_secret'] );
 	}
 
 	public function testThatEmptyClientSecretIsAllowed() {
-		$old_input = array_merge( self::$fields, [ 'client_secret' => uniqid() ] );
-		$new_input = array_merge( self::$fields, [ 'client_secret' => '' ] );
-		$validated = self::$admin->basic_validation( $old_input, $new_input );
+		$validated = self::$admin->basic_validation( [ 'client_secret' => '' ] );
 
 		$this->assertEmpty( $validated['client_secret'] );
 	}
 
 	public function testThatHtmlIsRemovedFromClientSecret() {
-		$new_input = array_merge( self::$fields, [ 'client_secret' => '<script>alert("hi")</script>__secret__' ] );
-		$validated = self::$admin->basic_validation( self::$fields, $new_input );
+		$validated = self::$admin->basic_validation( [ 'client_secret' => '<script>alert("hi")</script>__secret__' ] );
 
 		$this->assertEquals( '__secret__', $validated['client_secret'] );
 	}
 
 	public function testThatUnchangedClientSecretIsKept() {
-		$new_input = array_merge( self::$fields, [ 'client_secret' => '[REDACTED]' ] );
-		$validated = self::$admin->basic_validation( self::$fields, $new_input );
+		self::$opts->set( 'client_secret', '__test_client_secret__' );
+		$validated = self::$admin->basic_validation( [ 'client_secret' => '[REDACTED]' ] );
 
 		$this->assertEquals( '__test_client_secret__', $validated['client_secret'] );
 	}
 
 	public function testThatValidAlgorithmIsValidatedProperly() {
-		$old_input = array_merge( self::$fields, [ 'client_signing_algorithm' => uniqid() ] );
-		$new_input = array_merge( self::$fields, [ 'client_signing_algorithm' => 'HS256' ] );
-		$validated = self::$admin->basic_validation( $old_input, $new_input );
+		$validated = self::$admin->basic_validation( [ 'client_signing_algorithm' => 'HS256' ] );
 
 		$this->assertEquals( 'HS256', $validated['client_signing_algorithm'] );
 
-		$new_input['client_signing_algorithm'] = 'RS256';
-		$validated                             = self::$admin->basic_validation( $old_input, $new_input );
+		$validated = self::$admin->basic_validation( [ 'client_signing_algorithm' => 'RS256' ] );
 
 		$this->assertEquals( 'RS256', $validated['client_signing_algorithm'] );
 	}
 
 	public function testThatEmptyAlgorithmIsResetToDefault() {
-		$old_input = array_merge( self::$fields, [ 'client_signing_algorithm' => 'HS256' ] );
-		$new_input = array_merge( self::$fields, [ 'client_signing_algorithm' => '' ] );
-		$validated = self::$admin->basic_validation( $old_input, $new_input );
+		$validated = self::$admin->basic_validation( [ 'client_signing_algorithm' => '' ] );
 
 		$this->assertEquals( 'RS256', $validated['client_signing_algorithm'] );
 	}
 
 	public function testThatInvalidAlgorithmIsResetToDefault() {
-		$old_input = array_merge( self::$fields, [ 'client_signing_algorithm' => 'HS256' ] );
-		$new_input = array_merge( self::$fields, [ 'client_signing_algorithm' => uniqid() ] );
-		$validated = self::$admin->basic_validation( $old_input, $new_input );
+		$validated = self::$admin->basic_validation( [ 'client_signing_algorithm' => '__invalid_alg__' ] );
 
 		$this->assertEquals( 'RS256', $validated['client_signing_algorithm'] );
 	}

--- a/tests/testAdminBasicValidation.php
+++ b/tests/testAdminBasicValidation.php
@@ -34,15 +34,6 @@ class TestAdminBasicValidation extends WP_Auth0_Test_Case {
 	public static function setUpBeforeClass() {
 		parent::setUpBeforeClass();
 		self::$admin = new WP_Auth0_Admin( self::$opts, new WP_Auth0_Routes( self::$opts ) );
-		self::$admin->init_admin();
-	}
-
-	public static function tearDownAfterClass() {
-		parent::tearDownAfterClass();
-		unregister_setting(
-			'wp_auth0_settings_basic',
-			'wp_auth0_settings'
-		);
 	}
 
 	public function testThatDomainIsValidatedProperly() {

--- a/tests/testAdminSettingsValidationPath.php
+++ b/tests/testAdminSettingsValidationPath.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * Contains Class TestAdminSettingsValidationPath.
+ *
+ * @package WP-Auth0
+ *
+ * @since 4.0.0
+ */
+
+/**
+ * Class TestAdminSettingsValidationPath.
+ */
+class TestAdminSettingsValidationPath extends WP_Auth0_Test_Case {
+
+	use HookHelpers;
+
+	public function testThatClearAdminActionFunctionIsHooked() {
+		$expect_hooked = [
+			'wp_auth0_init_admin' => [
+				'priority'      => 10,
+				'accepted_args' => 1,
+			],
+		];
+		$this->assertHookedFunction( 'admin_init', $expect_hooked );
+	}
+
+	public function testThatAuth0SettingIsRegistered() {
+		global $wp_registered_settings;
+
+		wp_auth0_init_admin();
+
+		$this->assertArrayHasKey( WP_Auth0_Options::Instance()->get_options_name(), $wp_registered_settings );
+		$this->assertTrue( is_array( $wp_registered_settings['wp_auth0_settings']['sanitize_callback'] ) );
+		$this->assertInstanceOf(
+			WP_Auth0_Admin::class,
+			$wp_registered_settings['wp_auth0_settings']['sanitize_callback'][0]
+		);
+		$this->assertEquals(
+			'input_validator',
+			$wp_registered_settings['wp_auth0_settings']['sanitize_callback'][1]
+		);
+	}
+}

--- a/tests/testOptionLockCdn.php
+++ b/tests/testOptionLockCdn.php
@@ -140,19 +140,19 @@ class TestOptionLockCdn extends WP_Auth0_Test_Case {
 	 */
 	public function testThatCustomLockCdnIsValidatedOnSave() {
 
-		$validated = self::$admin->basic_validation( [], [ 'custom_cdn_url' => false ] );
+		$validated = self::$admin->basic_validation( [ 'custom_cdn_url' => false ] );
 		$this->assertEquals( false, $validated['custom_cdn_url'] );
 
-		$validated = self::$admin->basic_validation( [], [ 'custom_cdn_url' => 0 ] );
+		$validated = self::$admin->basic_validation( [ 'custom_cdn_url' => 0 ] );
 		$this->assertEquals( false, $validated['custom_cdn_url'] );
 
-		$validated = self::$admin->basic_validation( [], [ 'custom_cdn_url' => 1 ] );
+		$validated = self::$admin->basic_validation( [ 'custom_cdn_url' => 1 ] );
 		$this->assertEquals( true, $validated['custom_cdn_url'] );
 
-		$validated = self::$admin->basic_validation( [], [ 'custom_cdn_url' => '1' ] );
+		$validated = self::$admin->basic_validation( [ 'custom_cdn_url' => '1' ] );
 		$this->assertEquals( true, $validated['custom_cdn_url'] );
 
-		$validated = self::$admin->basic_validation( [], [ 'custom_cdn_url' => uniqid() ] );
+		$validated = self::$admin->basic_validation( [ 'custom_cdn_url' => uniqid() ] );
 		$this->assertEquals( false, $validated['custom_cdn_url'] );
 	}
 
@@ -162,7 +162,6 @@ class TestOptionLockCdn extends WP_Auth0_Test_Case {
 	public function testThatCustomLockCdnDoesNotChangeSavedCdnUrl() {
 
 		$validated = self::$admin->basic_validation(
-			[],
 			[
 				'cdn_url' => WPA0_LOCK_CDN_URL,
 			]
@@ -170,7 +169,6 @@ class TestOptionLockCdn extends WP_Auth0_Test_Case {
 		$this->assertEquals( WPA0_LOCK_CDN_URL, $validated['cdn_url'] );
 
 		$validated = self::$admin->basic_validation(
-			[],
 			[
 				'custom_cdn_url' => '1',
 				'cdn_url'        => WPA0_LOCK_CDN_URL,
@@ -185,30 +183,27 @@ class TestOptionLockCdn extends WP_Auth0_Test_Case {
 	public function testThatLockCdnUrlIsValidatedOnSave() {
 
 		$validated = self::$admin->basic_validation(
-			[ 'cdn_url' => uniqid() ],
 			[ 'cdn_url' => WPA0_LOCK_CDN_URL ]
 		);
 		$this->assertEquals( WPA0_LOCK_CDN_URL, $validated['cdn_url'] );
 
-		$validated = self::$admin->basic_validation( [], [ 'cdn_url' => ' ' . WPA0_LOCK_CDN_URL . ' ' ] );
+		$validated = self::$admin->basic_validation( [ 'cdn_url' => ' ' . WPA0_LOCK_CDN_URL . ' ' ] );
 		$this->assertEquals( WPA0_LOCK_CDN_URL, $validated['cdn_url'] );
 
 		self::$opts->set( 'cdn_url', '__old_cdn_url__' );
 		$validated = self::$admin->basic_validation(
-			[],
 			[
 				'custom_cdn_url' => true,
-				'cdn_url' => '__invalid_cdn_url__'
+				'cdn_url'        => '__invalid_cdn_url__',
 			]
 		);
 		$this->assertEquals( '__old_cdn_url__', $validated['cdn_url'] );
 
 		self::$opts->set( 'cdn_url', null );
 		$validated = self::$admin->basic_validation(
-			[],
 			[
 				'custom_cdn_url' => true,
-				'cdn_url' => ''
+				'cdn_url'        => '',
 			]
 		);
 		$this->assertEquals( WPA0_LOCK_CDN_URL, $validated['cdn_url'] );

--- a/tests/testOptionLockCdn.php
+++ b/tests/testOptionLockCdn.php
@@ -139,20 +139,21 @@ class TestOptionLockCdn extends WP_Auth0_Test_Case {
 	 * Test that the Custom Lock CDN URL setting is validated properly.
 	 */
 	public function testThatCustomLockCdnIsValidatedOnSave() {
+		$admin = new WP_Auth0_Admin( self::$opts, new WP_Auth0_Routes( self::$opts ) );
 
-		$validated = self::$admin->basic_validation( [ 'custom_cdn_url' => false ] );
+		$validated = $admin->input_validator( [ 'custom_cdn_url' => false ] );
 		$this->assertEquals( false, $validated['custom_cdn_url'] );
 
-		$validated = self::$admin->basic_validation( [ 'custom_cdn_url' => 0 ] );
+		$validated = $admin->input_validator( [ 'custom_cdn_url' => 0 ] );
 		$this->assertEquals( false, $validated['custom_cdn_url'] );
 
-		$validated = self::$admin->basic_validation( [ 'custom_cdn_url' => 1 ] );
+		$validated = $admin->input_validator( [ 'custom_cdn_url' => 1 ] );
 		$this->assertEquals( true, $validated['custom_cdn_url'] );
 
-		$validated = self::$admin->basic_validation( [ 'custom_cdn_url' => '1' ] );
+		$validated = $admin->input_validator( [ 'custom_cdn_url' => '1' ] );
 		$this->assertEquals( true, $validated['custom_cdn_url'] );
 
-		$validated = self::$admin->basic_validation( [ 'custom_cdn_url' => uniqid() ] );
+		$validated = $admin->input_validator( [ 'custom_cdn_url' => uniqid() ] );
 		$this->assertEquals( false, $validated['custom_cdn_url'] );
 	}
 
@@ -160,15 +161,16 @@ class TestOptionLockCdn extends WP_Auth0_Test_Case {
 	 * Test that the Custom Lock CDN URL setting does not change the Lock CDN URL.
 	 */
 	public function testThatCustomLockCdnDoesNotChangeSavedCdnUrl() {
+		$admin = new WP_Auth0_Admin( self::$opts, new WP_Auth0_Routes( self::$opts ) );
 
-		$validated = self::$admin->basic_validation(
+		$validated = $admin->input_validator(
 			[
 				'cdn_url' => WPA0_LOCK_CDN_URL,
 			]
 		);
 		$this->assertEquals( WPA0_LOCK_CDN_URL, $validated['cdn_url'] );
 
-		$validated = self::$admin->basic_validation(
+		$validated = $admin->input_validator(
 			[
 				'custom_cdn_url' => '1',
 				'cdn_url'        => WPA0_LOCK_CDN_URL,
@@ -181,17 +183,18 @@ class TestOptionLockCdn extends WP_Auth0_Test_Case {
 	 * Test that the Lock CDN URL setting is validated properly.
 	 */
 	public function testThatLockCdnUrlIsValidatedOnSave() {
+		$admin = new WP_Auth0_Admin( self::$opts, new WP_Auth0_Routes( self::$opts ) );
 
-		$validated = self::$admin->basic_validation(
+		$validated = $admin->input_validator(
 			[ 'cdn_url' => WPA0_LOCK_CDN_URL ]
 		);
 		$this->assertEquals( WPA0_LOCK_CDN_URL, $validated['cdn_url'] );
 
-		$validated = self::$admin->basic_validation( [ 'cdn_url' => ' ' . WPA0_LOCK_CDN_URL . ' ' ] );
+		$validated = $admin->input_validator( [ 'cdn_url' => ' ' . WPA0_LOCK_CDN_URL . ' ' ] );
 		$this->assertEquals( WPA0_LOCK_CDN_URL, $validated['cdn_url'] );
 
 		self::$opts->set( 'cdn_url', '__old_cdn_url__' );
-		$validated = self::$admin->basic_validation(
+		$validated = $admin->input_validator(
 			[
 				'custom_cdn_url' => true,
 				'cdn_url'        => '__invalid_cdn_url__',
@@ -200,7 +203,7 @@ class TestOptionLockCdn extends WP_Auth0_Test_Case {
 		$this->assertEquals( '__old_cdn_url__', $validated['cdn_url'] );
 
 		self::$opts->set( 'cdn_url', null );
-		$validated = self::$admin->basic_validation(
+		$validated = $admin->input_validator(
 			[
 				'custom_cdn_url' => true,
 				'cdn_url'        => '',

--- a/tests/testOptionLoginRedirect.php
+++ b/tests/testOptionLoginRedirect.php
@@ -21,13 +21,6 @@ class TestOptionLoginRedirect extends WP_Auth0_Test_Case {
 	public static $admin;
 
 	/**
-	 * Empty input value.
-	 *
-	 * @var array
-	 */
-	public static $empty_input = [ 'default_login_redirection' => '' ];
-
-	/**
 	 * Run before the test suite starts.
 	 */
 	public static function setUpBeforeClass() {
@@ -41,100 +34,97 @@ class TestOptionLoginRedirect extends WP_Auth0_Test_Case {
 	 */
 	public function testThatNoValidationRunsIfNoChange() {
 		$invalid_url = 'https://auth0.com';
-		$input       = [ 'default_login_redirection' => $invalid_url ];
-		$old_input   = [ 'default_login_redirection' => $invalid_url ];
 
-		$valid_input = self::$admin->loginredirection_validation( $old_input, $input );
-		$this->assertEquals( $invalid_url, $valid_input['default_login_redirection'] );
+		$valid_input = self::$admin->validate_login_redirect( $invalid_url, $invalid_url );
+		$this->assertEquals( $invalid_url, $valid_input );
 	}
 
 	/**
 	 * Test that the default is set when the input is empty.
 	 */
 	public function testThatDefaultIsUsedIfNewValueIsEmpty() {
-		$old_input = [ 'default_login_redirection' => home_url() . '/path' ];
+		self::$opts->set( 'default_login_redirection', home_url() . '/path' );
 
-		$valid_input = self::$admin->loginredirection_validation( $old_input, self::$empty_input );
-		$this->assertEquals( home_url(), $valid_input['default_login_redirection'] );
+		$valid_input = self::$admin->validate_login_redirect( '' );
+		$this->assertEquals( home_url(), $valid_input );
 	}
 
 	/**
 	 * Test that the default is set if new URL is another site.
 	 */
 	public function testThatDefaultIsUsedIfNewUrlIsInvalid() {
-		$invalid_url = 'https://auth0.com';
-		$input       = [ 'default_login_redirection' => $invalid_url ];
-		$old_input   = [ 'default_login_redirection' => home_url() . '/path' ];
+		self::$opts->set( 'default_login_redirection', home_url() . '/path' );
 
-		$valid_input = self::$admin->loginredirection_validation( $old_input, $input );
-		$this->assertEquals( $old_input['default_login_redirection'], $valid_input['default_login_redirection'] );
+		$valid_input = self::$admin->validate_login_redirect( 'https://auth0.com' );
+		$this->assertEquals( home_url() . '/path', $valid_input );
+	}
 
-		$valid_input = self::$admin->loginredirection_validation( self::$empty_input, $input );
-		$this->assertEquals( home_url(), $valid_input['default_login_redirection'] );
+	/**
+	 * Test that the existing is used if new URL is another site.
+	 */
+	public function testThatDefaultIsUsedIfNewUrlIsInvalidAndNoSavedValue() {
+		self::$opts->set( 'default_login_redirection', null );
+
+		$valid_input = self::$admin->validate_login_redirect( 'https://auth0.com' );
+		$this->assertEquals( home_url(), $valid_input );
 	}
 
 	/**
 	 * Test that a URL with the same host as home_url will be saved.
 	 */
 	public function testThatNewUrlWithSameHostIsValid() {
-		$input = [ 'default_login_redirection' => home_url() . '/path' ];
+		$valid_input = self::$admin->validate_login_redirect( home_url( 'path' ) );
 
-		$valid_input = self::$admin->loginredirection_validation( self::$empty_input, $input );
-		$this->assertEquals( $input['default_login_redirection'], $valid_input['default_login_redirection'] );
+		$this->assertEquals( home_url( 'path' ), $valid_input );
 	}
 
 	/**
 	 * Test that a URL with a different scheme is valid.
 	 */
 	public function testThatNewUrlWithDifferentSchemeIsValid() {
-		$input = [ 'default_login_redirection' => 'http://www.example.org' ];
 		update_option( 'home_url', 'https://www.example.org' );
 
-		$valid_input = self::$admin->loginredirection_validation( self::$empty_input, $input );
-		$this->assertEquals( $input['default_login_redirection'], $valid_input['default_login_redirection'] );
+		$valid_input = self::$admin->validate_login_redirect( 'http://www.example.org' );
+		$this->assertEquals( 'http://www.example.org', $valid_input );
 	}
 
 	/**
 	 * Test that a subdomain of a main site is valid.
 	 */
 	public function testThatSubdomainIsValid() {
-		$input = [ 'default_login_redirection' => 'https://sub.sub.example.org' ];
 		update_option( 'home_url', 'https://www.example.org' );
 
-		$valid_input = self::$admin->loginredirection_validation( self::$empty_input, $input );
-		$this->assertEquals( $input['default_login_redirection'], $valid_input['default_login_redirection'] );
+		$valid_input = self::$admin->validate_login_redirect( 'https://sub.sub.example.org' );
+		$this->assertEquals( 'https://sub.sub.example.org', $valid_input );
 	}
 
 	/**
 	 * Test that a main site of a subdomain is valid.
 	 */
 	public function testThatParentDomainIsValid() {
-		$input = [ 'default_login_redirection' => 'https://example.org' ];
 		update_option( 'home_url', 'https://www.example.org' );
 
-		$valid_input = self::$admin->loginredirection_validation( self::$empty_input, $input );
-		$this->assertEquals( $input['default_login_redirection'], $valid_input['default_login_redirection'] );
+		$valid_input = self::$admin->validate_login_redirect( 'https://example.org' );
+		$this->assertEquals( 'https://example.org', $valid_input );
 	}
 
 	/**
 	 * Test that sibling subdomains are valid.
 	 */
 	public function testThatSiblingSubdomainIsValid() {
-		$input = [ 'default_login_redirection' => 'https://sub.example.org' ];
 		update_option( 'home_url', 'https://www.example.org' );
 
-		$valid_input = self::$admin->loginredirection_validation( self::$empty_input, $input );
-		$this->assertEquals( $input['default_login_redirection'], $valid_input['default_login_redirection'] );
+		$valid_input = self::$admin->validate_login_redirect( 'https://sub.example.org' );
+		$this->assertEquals( 'https://sub.example.org', $valid_input );
 	}
 
 	/**
 	 * Test that other ports of the main site domain are valid.
 	 */
 	public function testThatDifferentPortIsValid() {
-		$input = [ 'default_login_redirection' => 'http://www.example.org:8080' ];
 		update_option( 'home_url', 'https://www.example.org' );
 
-		$valid_input = self::$admin->loginredirection_validation( self::$empty_input, $input );
-		$this->assertEquals( $input['default_login_redirection'], $valid_input['default_login_redirection'] );
+		$valid_input = self::$admin->validate_login_redirect( 'http://www.example.org:8080' );
+		$this->assertEquals( 'http://www.example.org:8080', $valid_input );
 	}
 }

--- a/tests/testOptionMigrationIps.php
+++ b/tests/testOptionMigrationIps.php
@@ -19,9 +19,9 @@ class TestOptionMigrationIps extends WP_Auth0_Test_Case {
 	use UsersHelper;
 
 	/**
-	 * Instance of WP_Auth0_Admin_Advanced.
+	 * Instance of WP_Auth0_Admin.
 	 *
-	 * @var WP_Auth0_Admin_Advanced
+	 * @var WP_Auth0_Admin
 	 */
 	public static $admin;
 
@@ -38,7 +38,7 @@ class TestOptionMigrationIps extends WP_Auth0_Test_Case {
 	public function setUp() {
 		parent::setUp();
 		$router         = new WP_Auth0_Routes( self::$opts );
-		self::$admin    = new WP_Auth0_Admin_Advanced( self::$opts, $router );
+		self::$admin    = new WP_Auth0_Admin( self::$opts, $router );
 		self::$ip_check = new WP_Auth0_Ip_Check();
 	}
 
@@ -49,10 +49,12 @@ class TestOptionMigrationIps extends WP_Auth0_Test_Case {
 			'label_for' => 'wpa0_migration_ws_ips',
 			'opt_name'  => 'migration_ips',
 		];
+		$router     = new WP_Auth0_Routes( self::$opts );
+		$admin      = new WP_Auth0_Admin_Advanced( self::$opts, $router );
 
 		// Get the field HTML.
 		ob_start();
-		self::$admin->render_migration_ws_ips( $field_args );
+		$admin->render_migration_ws_ips( $field_args );
 		$field_html = ob_get_clean();
 
 		$textarea = $this->getDomListFromTagName( $field_html, 'textarea' );
@@ -74,22 +76,22 @@ class TestOptionMigrationIps extends WP_Auth0_Test_Case {
 
 	public function testThatEmptyIpsAreValidatedToAnEmptyString() {
 		$input     = [ 'migration_ips' => 0 ];
-		$validated = self::$admin->migration_ips_validation( $input );
+		$validated = self::$admin->input_validator( $input );
 		$this->assertEquals( '', $validated['migration_ips'] );
 
 		$input     = [ 'migration_ips' => false ];
-		$validated = self::$admin->migration_ips_validation( $input );
+		$validated = self::$admin->input_validator( $input );
 		$this->assertEquals( '', $validated['migration_ips'] );
 
 		$input     = [ 'migration_ips' => null ];
-		$validated = self::$admin->migration_ips_validation( $input );
+		$validated = self::$admin->input_validator( $input );
 		$this->assertEquals( '', $validated['migration_ips'] );
 	}
 
 	public function testThatDuplicateIpsAreRemovedDuringValidation() {
 		$input = [ 'migration_ips' => '1.2.3.4, 2.3.4.5,1.2.3.4,3.4.5.6, 2.3.4.5' ];
 
-		$validated = self::$admin->migration_ips_validation( $input );
+		$validated = self::$admin->input_validator( $input );
 		$this->assertEquals( '1.2.3.4, 2.3.4.5, 3.4.5.6', $validated['migration_ips'] );
 	}
 
@@ -101,21 +103,21 @@ class TestOptionMigrationIps extends WP_Auth0_Test_Case {
 			'domain'        => 'test.eu.auth0.com',
 		];
 
-		$validated = self::$admin->migration_ips_validation( $input );
+		$validated = self::$admin->input_validator( $input );
 		$this->assertEquals( '4.5.6.7, 5.6.7.8', $validated['migration_ips'] );
 	}
 
 	public function testThatUnsafeValuesAreRemovedDuringValidation() {
 		$input = [ 'migration_ips' => '6.7.8.9,<script>alert("Hello")</script>,7.8.9.10' ];
 
-		$validated = self::$admin->migration_ips_validation( $input );
+		$validated = self::$admin->input_validator( $input );
 		$this->assertEquals( '6.7.8.9, 7.8.9.10', $validated['migration_ips'] );
 	}
 
 	public function testThatEmptyValuesAreRemovedDuringValidation() {
 		$input = [ 'migration_ips' => '8.9.10.11, , 9.10.11.12, 0' ];
 
-		$validated = self::$admin->migration_ips_validation( $input );
+		$validated = self::$admin->input_validator( $input );
 		$this->assertEquals( '8.9.10.11, 9.10.11.12', $validated['migration_ips'] );
 	}
 }

--- a/tests/testOptionMigrationIps.php
+++ b/tests/testOptionMigrationIps.php
@@ -74,22 +74,22 @@ class TestOptionMigrationIps extends WP_Auth0_Test_Case {
 
 	public function testThatEmptyIpsAreValidatedToAnEmptyString() {
 		$input     = [ 'migration_ips' => 0 ];
-		$validated = self::$admin->migration_ips_validation( [], $input );
+		$validated = self::$admin->migration_ips_validation( $input );
 		$this->assertEquals( '', $validated['migration_ips'] );
 
 		$input     = [ 'migration_ips' => false ];
-		$validated = self::$admin->migration_ips_validation( [], $input );
+		$validated = self::$admin->migration_ips_validation( $input );
 		$this->assertEquals( '', $validated['migration_ips'] );
 
 		$input     = [ 'migration_ips' => null ];
-		$validated = self::$admin->migration_ips_validation( [], $input );
+		$validated = self::$admin->migration_ips_validation( $input );
 		$this->assertEquals( '', $validated['migration_ips'] );
 	}
 
 	public function testThatDuplicateIpsAreRemovedDuringValidation() {
 		$input = [ 'migration_ips' => '1.2.3.4, 2.3.4.5,1.2.3.4,3.4.5.6, 2.3.4.5' ];
 
-		$validated = self::$admin->migration_ips_validation( [], $input );
+		$validated = self::$admin->migration_ips_validation( $input );
 		$this->assertEquals( '1.2.3.4, 2.3.4.5, 3.4.5.6', $validated['migration_ips'] );
 	}
 
@@ -101,21 +101,21 @@ class TestOptionMigrationIps extends WP_Auth0_Test_Case {
 			'domain'        => 'test.eu.auth0.com',
 		];
 
-		$validated = self::$admin->migration_ips_validation( [], $input );
+		$validated = self::$admin->migration_ips_validation( $input );
 		$this->assertEquals( '4.5.6.7, 5.6.7.8', $validated['migration_ips'] );
 	}
 
 	public function testThatUnsafeValuesAreRemovedDuringValidation() {
 		$input = [ 'migration_ips' => '6.7.8.9,<script>alert("Hello")</script>,7.8.9.10' ];
 
-		$validated = self::$admin->migration_ips_validation( [], $input );
+		$validated = self::$admin->migration_ips_validation( $input );
 		$this->assertEquals( '6.7.8.9, 7.8.9.10', $validated['migration_ips'] );
 	}
 
 	public function testThatEmptyValuesAreRemovedDuringValidation() {
 		$input = [ 'migration_ips' => '8.9.10.11, , 9.10.11.12, 0' ];
 
-		$validated = self::$admin->migration_ips_validation( [], $input );
+		$validated = self::$admin->migration_ips_validation( $input );
 		$this->assertEquals( '8.9.10.11, 9.10.11.12', $validated['migration_ips'] );
 	}
 }

--- a/tests/testOptionMigrationWs.php
+++ b/tests/testOptionMigrationWs.php
@@ -21,9 +21,9 @@ class TestOptionMigrationWs extends WP_Auth0_Test_Case {
 	use UsersHelper;
 
 	/**
-	 * Instance of WP_Auth0_Admin_Advanced.
+	 * Instance of WP_Auth0_Admin.
 	 *
-	 * @var WP_Auth0_Admin_Advanced
+	 * @var WP_Auth0_Admin
 	 */
 	public static $admin;
 
@@ -33,7 +33,7 @@ class TestOptionMigrationWs extends WP_Auth0_Test_Case {
 	public function setUp() {
 		parent::setUp();
 		$router      = new WP_Auth0_Routes( self::$opts );
-		self::$admin = new WP_Auth0_Admin_Advanced( self::$opts, $router );
+		self::$admin = new WP_Auth0_Admin( self::$opts, $router );
 	}
 
 	/**
@@ -44,10 +44,12 @@ class TestOptionMigrationWs extends WP_Auth0_Test_Case {
 			'label_for' => 'wpa0_migration_ws',
 			'opt_name'  => 'migration_ws',
 		];
+		$router     = new WP_Auth0_Routes( self::$opts );
+		$admin      = new WP_Auth0_Admin_Advanced( self::$opts, $router );
 
 		// Get the field HTML.
 		ob_start();
-		self::$admin->render_migration_ws( $field_args );
+		$admin->render_migration_ws( $field_args );
 		$field_html = ob_get_clean();
 
 		$input = $this->getDomListFromTagName( $field_html, 'input' );
@@ -68,12 +70,14 @@ class TestOptionMigrationWs extends WP_Auth0_Test_Case {
 			'label_for' => 'wpa0_migration_ws',
 			'opt_name'  => 'migration_ws',
 		];
+		$router     = new WP_Auth0_Routes( self::$opts );
+		$admin      = new WP_Auth0_Admin_Advanced( self::$opts, $router );
 
 		$this->assertFalse( self::$opts->get( $field_args['opt_name'] ) );
 
 		// Get the field HTML.
 		ob_start();
-		self::$admin->render_migration_ws( $field_args );
+		$admin->render_migration_ws( $field_args );
 		$field_html = ob_get_clean();
 
 		$this->assertContains( 'User migration endpoints deactivated', $field_html );
@@ -92,9 +96,12 @@ class TestOptionMigrationWs extends WP_Auth0_Test_Case {
 
 		self::$opts->set( $field_args['opt_name'], 1 );
 
+		$router = new WP_Auth0_Routes( self::$opts );
+		$admin  = new WP_Auth0_Admin_Advanced( self::$opts, $router );
+
 		// Get the field HTML.
 		ob_start();
-		self::$admin->render_migration_ws( $field_args );
+		$admin->render_migration_ws( $field_args );
 		$field_html = ob_get_clean();
 
 		$this->assertContains( 'User migration endpoints activated', $field_html );
@@ -128,7 +135,7 @@ class TestOptionMigrationWs extends WP_Auth0_Test_Case {
 		$input     = [
 			'migration_token_id' => 'existing_token_id',
 		];
-		$validated = self::$admin->migration_ws_validation( $input );
+		$validated = self::$admin->input_validator( $input );
 
 		$this->assertArrayHasKey( 'migration_ws', $validated );
 		$this->assertEmpty( $validated['migration_ws'] );
@@ -146,7 +153,7 @@ class TestOptionMigrationWs extends WP_Auth0_Test_Case {
 			'client_secret' => '__test_client_secret__',
 		];
 
-		$validated = self::$admin->migration_ws_validation( $input );
+		$validated = self::$admin->input_validator( $input );
 
 		$this->assertEquals( 'new_token', $validated['migration_token'] );
 		$this->assertNull( $validated['migration_token_id'] );
@@ -165,7 +172,7 @@ class TestOptionMigrationWs extends WP_Auth0_Test_Case {
 			'client_secret' => $client_secret,
 		];
 
-		$validated = self::$admin->migration_ws_validation( $input );
+		$validated = self::$admin->input_validator( $input );
 
 		$this->assertEquals( $input['migration_ws'], $validated['migration_ws'] );
 		$this->assertEquals( $migration_token, $validated['migration_token'] );
@@ -178,7 +185,7 @@ class TestOptionMigrationWs extends WP_Auth0_Test_Case {
 	public function testThatChangingMigrationToOnGeneratesNewToken() {
 		$input = [ 'migration_ws' => '1' ];
 
-		$validated = self::$admin->migration_ws_validation( $input );
+		$validated = self::$admin->input_validator( $input );
 
 		$this->assertGreaterThan( 64, strlen( $validated['migration_token'] ) );
 		$this->assertNull( $validated['migration_token_id'] );

--- a/tests/testOptionMigrationWs.php
+++ b/tests/testOptionMigrationWs.php
@@ -128,7 +128,7 @@ class TestOptionMigrationWs extends WP_Auth0_Test_Case {
 		$input     = [
 			'migration_token_id' => 'existing_token_id',
 		];
-		$validated = self::$admin->migration_ws_validation( [], $input );
+		$validated = self::$admin->migration_ws_validation( $input );
 
 		$this->assertArrayHasKey( 'migration_ws', $validated );
 		$this->assertEmpty( $validated['migration_ws'] );
@@ -146,7 +146,7 @@ class TestOptionMigrationWs extends WP_Auth0_Test_Case {
 			'client_secret' => '__test_client_secret__',
 		];
 
-		$validated = self::$admin->migration_ws_validation( [], $input );
+		$validated = self::$admin->migration_ws_validation( $input );
 
 		$this->assertEquals( 'new_token', $validated['migration_token'] );
 		$this->assertNull( $validated['migration_token_id'] );
@@ -165,7 +165,7 @@ class TestOptionMigrationWs extends WP_Auth0_Test_Case {
 			'client_secret' => $client_secret,
 		];
 
-		$validated = self::$admin->migration_ws_validation( [], $input );
+		$validated = self::$admin->migration_ws_validation( $input );
 
 		$this->assertEquals( $input['migration_ws'], $validated['migration_ws'] );
 		$this->assertEquals( $migration_token, $validated['migration_token'] );
@@ -178,7 +178,7 @@ class TestOptionMigrationWs extends WP_Auth0_Test_Case {
 	public function testThatChangingMigrationToOnGeneratesNewToken() {
 		$input = [ 'migration_ws' => '1' ];
 
-		$validated = self::$admin->migration_ws_validation( [], $input );
+		$validated = self::$admin->migration_ws_validation( $input );
 
 		$this->assertGreaterThan( 64, strlen( $validated['migration_token'] ) );
 		$this->assertNull( $validated['migration_token_id'] );
@@ -202,7 +202,7 @@ class TestOptionMigrationWs extends WP_Auth0_Test_Case {
 		$router = new WP_Auth0_Routes( $opts );
 		$admin  = new WP_Auth0_Admin_Advanced( $opts, $router );
 
-		$validated = $admin->migration_ws_validation( [], $input );
+		$validated = $admin->migration_ws_validation( $input );
 
 		$this->assertNull( $validated['migration_token_id'] );
 		$this->assertEquals( $input['migration_ws'], $validated['migration_ws'] );

--- a/tests/testOptionSlo.php
+++ b/tests/testOptionSlo.php
@@ -74,22 +74,22 @@ class TestOptionSlo extends WP_Auth0_Test_Case {
 	 * See testThatSloIsTurnedOffIfSsoIsOff for tests regarding that behavior.
 	 */
 	public function testThatSloIsValidatedOnSave() {
-		$validated = self::$admin->basic_validation( [], [ 'singlelogout' => false ] );
+		$validated = self::$admin->basic_validation( [ 'singlelogout' => false ] );
 		$this->assertEquals( false, $validated['singlelogout'] );
 
-		$validated = self::$admin->basic_validation( [], [ 'singlelogout' => 0 ] );
+		$validated = self::$admin->basic_validation( [ 'singlelogout' => 0 ] );
 		$this->assertEquals( false, $validated['singlelogout'] );
 
-		$validated = self::$admin->basic_validation( [], [ 'singlelogout' => 1 ] );
+		$validated = self::$admin->basic_validation( [ 'singlelogout' => 1 ] );
 		$this->assertEquals( true, $validated['singlelogout'] );
 
-		$validated = self::$admin->basic_validation( [], [ 'singlelogout' => '1' ] );
+		$validated = self::$admin->basic_validation( [ 'singlelogout' => '1' ] );
 		$this->assertEquals( true, $validated['singlelogout'] );
 
-		$validated = self::$admin->basic_validation( [], [] );
+		$validated = self::$admin->basic_validation( [] );
 		$this->assertEquals( false, $validated['singlelogout'] );
 
-		$validated = self::$admin->basic_validation( [], [ 'singlelogout' => uniqid() ] );
+		$validated = self::$admin->basic_validation( [ 'singlelogout' => uniqid() ] );
 		$this->assertEquals( false, $validated['singlelogout'] );
 	}
 }

--- a/tests/testOptionSlo.php
+++ b/tests/testOptionSlo.php
@@ -16,9 +16,9 @@ class TestOptionSlo extends WP_Auth0_Test_Case {
 	use DomDocumentHelpers;
 
 	/**
-	 * WP_Auth0_Admin_Features instance.
+	 * WP_Auth0_Admin instance.
 	 *
-	 * @var WP_Auth0_Admin_Features
+	 * @var WP_Auth0_Admin
 	 */
 	public static $admin;
 
@@ -27,13 +27,14 @@ class TestOptionSlo extends WP_Auth0_Test_Case {
 	 */
 	public static function setUpBeforeClass() {
 		parent::setUpBeforeClass();
-		self::$admin = new WP_Auth0_Admin_Features( self::$opts );
+		self::$admin = new WP_Auth0_Admin( self::$opts, new WP_Auth0_Routes( self::$opts ) );
 	}
 
 	/**
 	 * Test the input HTML for the custom domain setting.
 	 */
 	public function testSloFieldOutput() {
+		$admin      = new WP_Auth0_Admin_Features( self::$opts );
 		$field_args = [
 			'label_for' => 'wpa0_singlelogout',
 			'opt_name'  => 'singlelogout',
@@ -41,7 +42,7 @@ class TestOptionSlo extends WP_Auth0_Test_Case {
 
 		// Get the field HTML.
 		ob_start();
-		self::$admin->render_singlelogout( $field_args );
+		$admin->render_singlelogout( $field_args );
 		$field_html = ob_get_clean();
 
 		// Check field HTML for required attributes.
@@ -74,22 +75,22 @@ class TestOptionSlo extends WP_Auth0_Test_Case {
 	 * See testThatSloIsTurnedOffIfSsoIsOff for tests regarding that behavior.
 	 */
 	public function testThatSloIsValidatedOnSave() {
-		$validated = self::$admin->basic_validation( [ 'singlelogout' => false ] );
+		$validated = self::$admin->input_validator( [ 'singlelogout' => false ] );
 		$this->assertEquals( false, $validated['singlelogout'] );
 
-		$validated = self::$admin->basic_validation( [ 'singlelogout' => 0 ] );
+		$validated = self::$admin->input_validator( [ 'singlelogout' => 0 ] );
 		$this->assertEquals( false, $validated['singlelogout'] );
 
-		$validated = self::$admin->basic_validation( [ 'singlelogout' => 1 ] );
+		$validated = self::$admin->input_validator( [ 'singlelogout' => 1 ] );
 		$this->assertEquals( true, $validated['singlelogout'] );
 
-		$validated = self::$admin->basic_validation( [ 'singlelogout' => '1' ] );
+		$validated = self::$admin->input_validator( [ 'singlelogout' => '1' ] );
 		$this->assertEquals( true, $validated['singlelogout'] );
 
-		$validated = self::$admin->basic_validation( [] );
+		$validated = self::$admin->input_validator( [] );
 		$this->assertEquals( false, $validated['singlelogout'] );
 
-		$validated = self::$admin->basic_validation( [ 'singlelogout' => uniqid() ] );
+		$validated = self::$admin->input_validator( [ 'singlelogout' => uniqid() ] );
 		$this->assertEquals( false, $validated['singlelogout'] );
 	}
 }

--- a/tests/testOptionWle.php
+++ b/tests/testOptionWle.php
@@ -132,22 +132,24 @@ class TestOptionWle extends WP_Auth0_Test_Case {
 	 * Test that wordpress_login_enabled is validated properly on save.
 	 */
 	public function testThatWleIsValiatedOnSave() {
-		$validated = self::$admin->basic_validation( [ 'wordpress_login_enabled' => 'link' ] );
+		$admin = new WP_Auth0_Admin( self::$opts, new WP_Auth0_Routes( self::$opts ) );
+
+		$validated = $admin->input_validator( [ 'wordpress_login_enabled' => 'link' ] );
 		$this->assertEquals( 'link', $validated['wordpress_login_enabled'] );
 
-		$validated = self::$admin->basic_validation( [ 'wordpress_login_enabled' => 'isset' ] );
+		$validated = $admin->input_validator( [ 'wordpress_login_enabled' => 'isset' ] );
 		$this->assertEquals( 'isset', $validated['wordpress_login_enabled'] );
 
-		$validated = self::$admin->basic_validation( [ 'wordpress_login_enabled' => 'code' ] );
+		$validated = $admin->input_validator( [ 'wordpress_login_enabled' => 'code' ] );
 		$this->assertEquals( 'code', $validated['wordpress_login_enabled'] );
 
-		$validated = self::$admin->basic_validation( [ 'wordpress_login_enabled' => 'no' ] );
+		$validated = $admin->input_validator( [ 'wordpress_login_enabled' => 'no' ] );
 		$this->assertEquals( 'no', $validated['wordpress_login_enabled'] );
 
-		$validated = self::$admin->basic_validation( [ 'wordpress_login_enabled' => uniqid() ] );
+		$validated = $admin->input_validator( [ 'wordpress_login_enabled' => uniqid() ] );
 		$this->assertEquals( 'link', $validated['wordpress_login_enabled'] );
 
-		$validated = self::$admin->basic_validation( [ 'wordpress_login_enabled' => false ] );
+		$validated = $admin->input_validator( [ 'wordpress_login_enabled' => false ] );
 		$this->assertEquals( 'link', $validated['wordpress_login_enabled'] );
 	}
 
@@ -155,17 +157,19 @@ class TestOptionWle extends WP_Auth0_Test_Case {
 	 * Test that wle_code is validated properly on save.
 	 */
 	public function testThatWleCodeIsKeptIfSavedGeneratedIfEmpty() {
+		$admin = new WP_Auth0_Admin( self::$opts, new WP_Auth0_Routes( self::$opts ) );
+
 		$wle_code = uniqid();
 		self::$opts->set( 'wle_code', $wle_code );
-		$validated = self::$admin->basic_validation( [ 'wordpress_login_enabled' => uniqid() ] );
+		$validated = $admin->input_validator( [ 'wordpress_login_enabled' => uniqid() ] );
 		$this->assertEquals( $wle_code, $validated['wle_code'] );
 
 		self::$opts->set( 'wle_code', null );
-		$validated = self::$admin->basic_validation( [ 'wordpress_login_enabled' => uniqid() ] );
+		$validated = $admin->input_validator( [ 'wordpress_login_enabled' => uniqid() ] );
 		$this->assertGreaterThan( 24, strlen( $validated['wle_code'] ) );
 
 		self::$opts->set( 'wle_code', '' );
-		$validated = self::$admin->basic_validation( [ 'wordpress_login_enabled' => uniqid() ] );
+		$validated = $admin->input_validator( [ 'wordpress_login_enabled' => uniqid() ] );
 		$this->assertGreaterThan( 24, strlen( $validated['wle_code'] ) );
 	}
 }

--- a/tests/testOptionWle.php
+++ b/tests/testOptionWle.php
@@ -132,22 +132,22 @@ class TestOptionWle extends WP_Auth0_Test_Case {
 	 * Test that wordpress_login_enabled is validated properly on save.
 	 */
 	public function testThatWleIsValiatedOnSave() {
-		$validated = self::$admin->basic_validation( [], [ 'wordpress_login_enabled' => 'link' ] );
+		$validated = self::$admin->basic_validation( [ 'wordpress_login_enabled' => 'link' ] );
 		$this->assertEquals( 'link', $validated['wordpress_login_enabled'] );
 
-		$validated = self::$admin->basic_validation( [], [ 'wordpress_login_enabled' => 'isset' ] );
+		$validated = self::$admin->basic_validation( [ 'wordpress_login_enabled' => 'isset' ] );
 		$this->assertEquals( 'isset', $validated['wordpress_login_enabled'] );
 
-		$validated = self::$admin->basic_validation( [], [ 'wordpress_login_enabled' => 'code' ] );
+		$validated = self::$admin->basic_validation( [ 'wordpress_login_enabled' => 'code' ] );
 		$this->assertEquals( 'code', $validated['wordpress_login_enabled'] );
 
-		$validated = self::$admin->basic_validation( [], [ 'wordpress_login_enabled' => 'no' ] );
+		$validated = self::$admin->basic_validation( [ 'wordpress_login_enabled' => 'no' ] );
 		$this->assertEquals( 'no', $validated['wordpress_login_enabled'] );
 
-		$validated = self::$admin->basic_validation( [], [ 'wordpress_login_enabled' => uniqid() ] );
+		$validated = self::$admin->basic_validation( [ 'wordpress_login_enabled' => uniqid() ] );
 		$this->assertEquals( 'link', $validated['wordpress_login_enabled'] );
 
-		$validated = self::$admin->basic_validation( [], [ 'wordpress_login_enabled' => false ] );
+		$validated = self::$admin->basic_validation( [ 'wordpress_login_enabled' => false ] );
 		$this->assertEquals( 'link', $validated['wordpress_login_enabled'] );
 	}
 
@@ -157,15 +157,15 @@ class TestOptionWle extends WP_Auth0_Test_Case {
 	public function testThatWleCodeIsKeptIfSavedGeneratedIfEmpty() {
 		$wle_code = uniqid();
 		self::$opts->set( 'wle_code', $wle_code );
-		$validated = self::$admin->basic_validation( [], [ 'wordpress_login_enabled' => uniqid() ] );
+		$validated = self::$admin->basic_validation( [ 'wordpress_login_enabled' => uniqid() ] );
 		$this->assertEquals( $wle_code, $validated['wle_code'] );
 
 		self::$opts->set( 'wle_code', null );
-		$validated = self::$admin->basic_validation( [], [ 'wordpress_login_enabled' => uniqid() ] );
+		$validated = self::$admin->basic_validation( [ 'wordpress_login_enabled' => uniqid() ] );
 		$this->assertGreaterThan( 24, strlen( $validated['wle_code'] ) );
 
 		self::$opts->set( 'wle_code', '' );
-		$validated = self::$admin->basic_validation( [], [ 'wordpress_login_enabled' => uniqid() ] );
+		$validated = self::$admin->basic_validation( [ 'wordpress_login_enabled' => uniqid() ] );
 		$this->assertGreaterThan( 24, strlen( $validated['wle_code'] ) );
 	}
 }

--- a/tests/testRequiredEmail.php
+++ b/tests/testRequiredEmail.php
@@ -73,22 +73,22 @@ class TestRequiredEmail extends WP_Auth0_Test_Case {
 	 * Test that the required email field is properly validated.
 	 */
 	public function testRequiredEmailValidation() {
-		$validated_opts = self::$admin->basic_validation( [], [ 'requires_verified_email' => '1' ] );
+		$validated_opts = self::$admin->basic_validation( [ 'requires_verified_email' => '1' ] );
 		$this->assertEquals( true, $validated_opts['requires_verified_email'] );
 
-		$validated_opts = self::$admin->basic_validation( [], [ 'requires_verified_email' => 1 ] );
+		$validated_opts = self::$admin->basic_validation( [ 'requires_verified_email' => 1 ] );
 		$this->assertEquals( true, $validated_opts['requires_verified_email'] );
 
-		$validated_opts = self::$admin->basic_validation( [], [ 'requires_verified_email' => true ] );
+		$validated_opts = self::$admin->basic_validation( [ 'requires_verified_email' => true ] );
 		$this->assertEquals( true, $validated_opts['requires_verified_email'] );
 
-		$validated_opts = self::$admin->basic_validation( [], [] );
+		$validated_opts = self::$admin->basic_validation( [] );
 		$this->assertEquals( false, $validated_opts['requires_verified_email'] );
 
-		$validated_opts = self::$admin->basic_validation( [], [ 'requires_verified_email' => 0 ] );
+		$validated_opts = self::$admin->basic_validation( [ 'requires_verified_email' => 0 ] );
 		$this->assertEquals( false, $validated_opts['requires_verified_email'] );
 
-		$validated_opts = self::$admin->basic_validation( [], [ 'requires_verified_email' => '' ] );
+		$validated_opts = self::$admin->basic_validation( [ 'requires_verified_email' => '' ] );
 		$this->assertEquals( false, $validated_opts['requires_verified_email'] );
 	}
 
@@ -136,19 +136,19 @@ class TestRequiredEmail extends WP_Auth0_Test_Case {
 	public function testSkipRequiredEmailValidation() {
 		$opt_name = 'skip_strategies';
 
-		$validated_opts = self::$admin->basic_validation( [], [ $opt_name => '' ] );
+		$validated_opts = self::$admin->basic_validation( [ $opt_name => '' ] );
 		$this->assertEquals( '', $validated_opts[ $opt_name ] );
 
-		$validated_opts = self::$admin->basic_validation( [], [ $opt_name => '  ' ] );
+		$validated_opts = self::$admin->basic_validation( [ $opt_name => '  ' ] );
 		$this->assertEquals( '', $validated_opts[ $opt_name ] );
 
-		$validated_opts = self::$admin->basic_validation( [], [ $opt_name => 'auth0' ] );
+		$validated_opts = self::$admin->basic_validation( [ $opt_name => 'auth0' ] );
 		$this->assertEquals( 'auth0', $validated_opts[ $opt_name ] );
 
-		$validated_opts = self::$admin->basic_validation( [], [ $opt_name => ' auth0 ' ] );
+		$validated_opts = self::$admin->basic_validation( [ $opt_name => ' auth0 ' ] );
 		$this->assertEquals( 'auth0', $validated_opts[ $opt_name ] );
 
-		$validated_opts = self::$admin->basic_validation( [], [ $opt_name => 'auth0,twitter' ] );
+		$validated_opts = self::$admin->basic_validation( [ $opt_name => 'auth0,twitter' ] );
 		$this->assertEquals( 'auth0,twitter', $validated_opts[ $opt_name ] );
 	}
 

--- a/tests/testRequiredEmail.php
+++ b/tests/testRequiredEmail.php
@@ -73,22 +73,24 @@ class TestRequiredEmail extends WP_Auth0_Test_Case {
 	 * Test that the required email field is properly validated.
 	 */
 	public function testRequiredEmailValidation() {
-		$validated_opts = self::$admin->basic_validation( [ 'requires_verified_email' => '1' ] );
+		$admin = new WP_Auth0_Admin( self::$opts, new WP_Auth0_Routes( self::$opts ) );
+
+		$validated_opts = $admin->input_validator( [ 'requires_verified_email' => '1' ] );
 		$this->assertEquals( true, $validated_opts['requires_verified_email'] );
 
-		$validated_opts = self::$admin->basic_validation( [ 'requires_verified_email' => 1 ] );
+		$validated_opts = $admin->input_validator( [ 'requires_verified_email' => 1 ] );
 		$this->assertEquals( true, $validated_opts['requires_verified_email'] );
 
-		$validated_opts = self::$admin->basic_validation( [ 'requires_verified_email' => true ] );
+		$validated_opts = $admin->input_validator( [ 'requires_verified_email' => true ] );
 		$this->assertEquals( true, $validated_opts['requires_verified_email'] );
 
-		$validated_opts = self::$admin->basic_validation( [] );
+		$validated_opts = $admin->input_validator( [] );
 		$this->assertEquals( false, $validated_opts['requires_verified_email'] );
 
-		$validated_opts = self::$admin->basic_validation( [ 'requires_verified_email' => 0 ] );
+		$validated_opts = $admin->input_validator( [ 'requires_verified_email' => 0 ] );
 		$this->assertEquals( false, $validated_opts['requires_verified_email'] );
 
-		$validated_opts = self::$admin->basic_validation( [ 'requires_verified_email' => '' ] );
+		$validated_opts = $admin->input_validator( [ 'requires_verified_email' => '' ] );
 		$this->assertEquals( false, $validated_opts['requires_verified_email'] );
 	}
 
@@ -135,20 +137,21 @@ class TestRequiredEmail extends WP_Auth0_Test_Case {
 	 */
 	public function testSkipRequiredEmailValidation() {
 		$opt_name = 'skip_strategies';
+		$admin    = new WP_Auth0_Admin( self::$opts, new WP_Auth0_Routes( self::$opts ) );
 
-		$validated_opts = self::$admin->basic_validation( [ $opt_name => '' ] );
+		$validated_opts = $admin->input_validator( [ $opt_name => '' ] );
 		$this->assertEquals( '', $validated_opts[ $opt_name ] );
 
-		$validated_opts = self::$admin->basic_validation( [ $opt_name => '  ' ] );
+		$validated_opts = $admin->input_validator( [ $opt_name => '  ' ] );
 		$this->assertEquals( '', $validated_opts[ $opt_name ] );
 
-		$validated_opts = self::$admin->basic_validation( [ $opt_name => 'auth0' ] );
+		$validated_opts = $admin->input_validator( [ $opt_name => 'auth0' ] );
 		$this->assertEquals( 'auth0', $validated_opts[ $opt_name ] );
 
-		$validated_opts = self::$admin->basic_validation( [ $opt_name => ' auth0 ' ] );
+		$validated_opts = $admin->input_validator( [ $opt_name => ' auth0 ' ] );
 		$this->assertEquals( 'auth0', $validated_opts[ $opt_name ] );
 
-		$validated_opts = self::$admin->basic_validation( [ $opt_name => 'auth0,twitter' ] );
+		$validated_opts = $admin->input_validator( [ $opt_name => 'auth0,twitter' ] );
 		$this->assertEquals( 'auth0,twitter', $validated_opts[ $opt_name ] );
 	}
 

--- a/tests/testWPAuth0Options.php
+++ b/tests/testWPAuth0Options.php
@@ -41,6 +41,7 @@ class TestWPAuth0Options extends WP_Auth0_Test_Case {
 	 */
 	public function testThatDefaultsWork() {
 		$opts = new WP_Auth0_Options();
+		$opts->reset();
 		foreach ( array_keys( $opts->get_options() ) as $opt_name ) {
 			$test_msg = 'Testing option: "' . $opt_name . '"';
 			$this->assertEquals( $opts->get_default( $opt_name ), $opts->get( $opt_name ), $test_msg );


### PR DESCRIPTION
### Description

- Add validation to imported settings JSON
- Change the following validation methods to accept only the new options array as a first parameter; existing saved options values are used as fallbacks:
   - `WP_Auth0_Admin_Advanced->basic_validation()`
   - `WP_Auth0_Admin_Advanced->migration_ws_validation()`
   - `WP_Auth0_Admin_Advanced->migration_ips_validation()`
   - `WP_Auth0_Admin_Appearance->basic_validation()`
   - `WP_Auth0_Admin_Basic->basic_validation()`
   - `WP_Auth0_Admin_Features->basic_validation()`
- Rename `WP_Auth0_Admin_Advanced::loginredirection_validation()` to `WP_Auth0_Admin_Advanced->validate_login_redirect()` and changed the signature to accept the new and previous values instead of arrays.

**Note to reviewers:** vast majority of the changes here are renaming and changing the method signatures. 

### Testing

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`
