### PR TITLE
Remove migration JWT JTI check

### DIFF
--- a/lib/WP_Auth0_DBManager.php
+++ b/lib/WP_Auth0_DBManager.php
@@ -175,6 +175,7 @@ class WP_Auth0_DBManager {
 			$options->remove( 'auth0_implicit_workflow' );
 			$options->remove( 'client_secret_b64_encoded' );
 			$options->remove( 'custom_signup_fields' );
+			$options->remove( 'migration_token_id' );
 		}
 
 		$options->update_all();

--- a/lib/WP_Auth0_Options.php
+++ b/lib/WP_Auth0_Options.php
@@ -367,7 +367,6 @@ class WP_Auth0_Options {
 			// System
 			'version'                   => 1,
 			'last_step'                 => 1,
-			'migration_token_id'        => null,
 
 			// Basic
 			'domain'                    => '',

--- a/lib/WP_Auth0_Routes.php
+++ b/lib/WP_Auth0_Routes.php
@@ -286,7 +286,7 @@ class WP_Auth0_Routes {
 			throw new Exception( __( 'Unauthorized: missing authorization header', 'wp-auth0' ), 401 );
 		}
 
-		if ( ! $this->valid_token( $authorization ) ) {
+		if ( $authorization !== $this->a0_options->get( 'migration_token' ) ) {
 			throw new Exception( __( 'Invalid token', 'wp-auth0' ), 401 );
 		}
 
@@ -321,33 +321,6 @@ class WP_Auth0_Routes {
 					'error'  => __( 'Forbidden', 'wp-auth0' ),
 				];
 				break;
-		}
-	}
-
-	/**
-	 * Check if a token or token JTI is the same as what is stored.
-	 *
-	 * @param string $authorization - Incoming migration token.
-	 *
-	 * @return bool
-	 */
-	private function valid_token( $authorization ) {
-		$token = $this->a0_options->get( 'migration_token' );
-		if ( $token === $authorization ) {
-			return true;
-		}
-
-		$client_secret = $this->a0_options->get( 'client_secret' );
-		if ( $this->a0_options->get( 'client_secret_base64_encoded' ) ) {
-			$client_secret = wp_auth0_url_base64_decode( $client_secret );
-		}
-
-		try {
-			$signature_verifier = new WP_Auth0_SymmetricVerifier( $client_secret );
-			$decoded            = $signature_verifier->verifyAndDecode( $authorization );
-			return $decoded->getClaim( 'jti' ) === $this->a0_options->get( 'migration_token_id' );
-		} catch ( Exception $e ) {
-			return false;
 		}
 	}
 }

--- a/lib/admin/WP_Auth0_Admin_Advanced.php
+++ b/lib/admin/WP_Auth0_Admin_Advanced.php
@@ -378,32 +378,13 @@ class WP_Auth0_Admin_Advanced extends WP_Auth0_Admin_Generic {
 		$input['migration_ws']    = $this->sanitize_switch_val( $input['migration_ws'] ?? null );
 		$input['migration_token'] = $this->options->get( 'migration_token' );
 
-		// Migration endpoints or turned off, nothing to do.
-		if ( ! $input['migration_ws'] ) {
-			return $input;
-		}
-
-		$input['migration_token_id'] = null;
-		$this->router->setup_rewrites();
-		flush_rewrite_rules();
-
-		// If we don't have a token yet, generate one.
 		if ( empty( $input['migration_token'] ) ) {
 			$input['migration_token'] = wp_auth0_generate_token();
-			return $input;
 		}
 
-		// If we do have a token, try to decode and store the JTI.
-		$secret = $input['client_secret'];
-
-		try {
-			$signature_verifier          = new WP_Auth0_SymmetricVerifier( $secret );
-			$token_decoded               = $signature_verifier->verifyAndDecode( $input['migration_token'] );
-			$input['migration_token_id'] = $token_decoded->getClaim( 'jti' );
-
-			// phpcs:ignore
-		} catch ( Exception $e ) {
-			// If the JWT cannot be decoded then we use the token as-is without storing the JTI.
+		if ( $input['migration_ws'] ) {
+			$this->router->setup_rewrites();
+			flush_rewrite_rules();
 		}
 
 		return $input;

--- a/tests/testOptionMigrationWs.php
+++ b/tests/testOptionMigrationWs.php
@@ -132,14 +132,10 @@ class TestOptionMigrationWs extends WP_Auth0_Test_Case {
 	 */
 	public function testThatChangingMigrationToOffKeepsTokenData() {
 		self::$opts->set( 'migration_token', 'existing_token' );
-		$input     = [
-			'migration_token_id' => 'existing_token_id',
-		];
-		$validated = self::$admin->input_validator( $input );
+		$validated = self::$admin->input_validator( [] );
 
 		$this->assertArrayHasKey( 'migration_ws', $validated );
 		$this->assertEmpty( $validated['migration_ws'] );
-		$this->assertEquals( $input['migration_token_id'], $validated['migration_token_id'] );
 		$this->assertEquals( 'existing_token', $validated['migration_token'] );
 	}
 
@@ -156,7 +152,6 @@ class TestOptionMigrationWs extends WP_Auth0_Test_Case {
 		$validated = self::$admin->input_validator( $input );
 
 		$this->assertEquals( 'new_token', $validated['migration_token'] );
-		$this->assertNull( $validated['migration_token_id'] );
 		$this->assertEquals( $input['migration_ws'], $validated['migration_ws'] );
 	}
 
@@ -176,7 +171,6 @@ class TestOptionMigrationWs extends WP_Auth0_Test_Case {
 
 		$this->assertEquals( $input['migration_ws'], $validated['migration_ws'] );
 		$this->assertEquals( $migration_token, $validated['migration_token'] );
-		$this->assertEquals( '__test_token_id__', $validated['migration_token_id'] );
 	}
 
 	/**
@@ -188,7 +182,6 @@ class TestOptionMigrationWs extends WP_Auth0_Test_Case {
 		$validated = self::$admin->input_validator( $input );
 
 		$this->assertGreaterThan( 64, strlen( $validated['migration_token'] ) );
-		$this->assertNull( $validated['migration_token_id'] );
 		$this->assertEquals( $input['migration_ws'], $validated['migration_ws'] );
 	}
 
@@ -211,7 +204,6 @@ class TestOptionMigrationWs extends WP_Auth0_Test_Case {
 
 		$validated = $admin->migration_ws_validation( $input );
 
-		$this->assertNull( $validated['migration_token_id'] );
 		$this->assertEquals( $input['migration_ws'], $validated['migration_ws'] );
 		$this->assertEquals( AUTH0_ENV_MIGRATION_TOKEN, $validated['migration_token'] );
 	}

--- a/tests/testRoutesGetUser.php
+++ b/tests/testRoutesGetUser.php
@@ -90,27 +90,6 @@ class TestRoutesGetUser extends WP_Auth0_Test_Case {
 	}
 
 	/**
-	 * If the token has the wrong JTI, the route should fail with an error.
-	 */
-	public function testThatGetUserRouteIsUnauthorizedIfWrongJti() {
-		$client_secret = '__test_client_secret__';
-		self::$opts->set( 'migration_ws', true );
-		self::$opts->set( 'client_secret', $client_secret );
-		self::$opts->set( 'migration_token_id', '__test_token_id__' );
-
-		$_POST['access_token'] = self::makeHsToken( [ 'jti' => uniqid() ], $client_secret );
-
-		$output = json_decode( wp_auth0_custom_requests( self::$wp, true ) );
-
-		$this->assertEquals( 401, $output->status );
-		$this->assertEquals( 'Invalid token', $output->error );
-
-		$log = self::$error_log->get();
-		$this->assertCount( 1, $log );
-		$this->assertEquals( $output->error, $log[0]['message'] );
-	}
-
-	/**
 	 * If there is no username POSTed, the route should fail with an error.
 	 */
 	public function testThatGetUserRouteIsBadRequestIfNoUsername() {

--- a/tests/testRoutesLogin.php
+++ b/tests/testRoutesLogin.php
@@ -94,50 +94,6 @@ class TestRoutesLogin extends WP_Auth0_Test_Case {
 	}
 
 	/**
-	 * If the token has the wrong JTI, the route should fail with an error.
-	 */
-	public function testThatLoginRouteIsUnauthorizedIfWrongJti() {
-		$client_secret = '__test_client_secret__';
-		self::$opts->set( 'migration_ws', true );
-		self::$opts->set( 'client_secret', $client_secret );
-		self::$opts->set( 'migration_token_id', '__test_token_id__' );
-
-		self::$wp->query_vars['a0_action'] = 'migration-ws-login';
-		$_POST['access_token']             = self::makeHsToken( [ 'jti' => uniqid() ], $client_secret );
-
-		$output = json_decode( wp_auth0_custom_requests( self::$wp, true ) );
-
-		$this->assertEquals( 401, $output->status );
-		$this->assertEquals( 'Invalid token', $output->error );
-
-		$log = self::$error_log->get();
-		$this->assertCount( 1, $log );
-		$this->assertEquals( $output->error, $log[0]['message'] );
-	}
-
-	/**
-	 * If the token has the wrong JTI, the route should fail with an error.
-	 */
-	public function testThatLoginRouteIsUnauthorizedIfMissingJti() {
-		$client_secret = '__test_client_secret__';
-		self::$opts->set( 'migration_ws', true );
-		self::$opts->set( 'client_secret', $client_secret );
-		self::$opts->set( 'migration_token_id', '__test_token_id__' );
-
-		self::$wp->query_vars['a0_action'] = 'migration-ws-login';
-		$_POST['access_token']             = self::makeHsToken( [ 'iss' => uniqid() ], $client_secret );
-
-		$output = json_decode( wp_auth0_custom_requests( self::$wp, true ) );
-
-		$this->assertEquals( 401, $output->status );
-		$this->assertEquals( 'Invalid token', $output->error );
-
-		$log = self::$error_log->get();
-		$this->assertCount( 1, $log );
-		$this->assertEquals( $output->error, $log[0]['message'] );
-	}
-
-	/**
 	 * If there is no username POSTed, the route should fail with an error.
 	 */
 	public function testThatLoginRouteIsBadRequestIfNoUsername() {

--- a/tests/testWPAuth0Options.php
+++ b/tests/testWPAuth0Options.php
@@ -20,7 +20,7 @@ class TestWPAuth0Options extends WP_Auth0_Test_Case {
 	/**
 	 * Total number of options.
 	 */
-	const DEFAULT_OPTIONS_COUNT = 37;
+	const DEFAULT_OPTIONS_COUNT = 36;
 
 	/**
 	 * Test the basic options functionality.


### PR DESCRIPTION
### Description

Remove JWT JTI check for migration routes. Token is checked against stored value so token can be opaque. This will only affect sites that generated their own migration token as a JWT and stored a different token in the migration route than in the WordPress site (which would be a really odd thing to do). 

### Testing

- [x] This change modifies test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`
