### PR TITLE
PHPStan Level 2 fixes

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -130,9 +130,9 @@ function wp_auth0_can_show_wp_login_form() {
 }
 
 /**
- * @param $input
+ * @param string $input
  *
- * @return mixed
+ * @return string
  *
  * @see https://github.com/firebase/php-jwt/blob/v5.0.0/src/JWT.php#L337
  */
@@ -141,7 +141,7 @@ function wp_auth0_url_base64_encode( $input ) {
 }
 
 /**
- * @param $input
+ * @param string $input
  *
  * @return bool|string
  *

--- a/lib/WP_Auth0_Embed_Widget.php
+++ b/lib/WP_Auth0_Embed_Widget.php
@@ -31,6 +31,7 @@ class WP_Auth0_Embed_Widget extends WP_Widget {
 		wp_enqueue_script( 'wpa0_admin' );
 		wp_enqueue_style( 'media' );
 		require WPA0_PLUGIN_DIR . 'templates/a0-widget-setup-form.php';
+		return 'form';
 	}
 
 	public function widget( $args, $instance ) {

--- a/lib/WP_Auth0_LoginManager.php
+++ b/lib/WP_Auth0_LoginManager.php
@@ -31,10 +31,10 @@ class WP_Auth0_LoginManager {
 	/**
 	 * WP_Auth0_LoginManager constructor.
 	 *
-	 * @param WP_Auth0_UsersRepo    $users_repo - see member variable doc comment.
-	 * @param WP_Auth0_Options|null $a0_options - see member variable doc comment.
+	 * @param WP_Auth0_UsersRepo $users_repo - see member variable doc comment.
+	 * @param WP_Auth0_Options   $a0_options - see member variable doc comment.
 	 */
-	public function __construct( WP_Auth0_UsersRepo $users_repo, ?WP_Auth0_Options $a0_options ) {
+	public function __construct( WP_Auth0_UsersRepo $users_repo, WP_Auth0_Options $a0_options ) {
 		$this->users_repo = $users_repo;
 		$this->a0_options = $a0_options;
 	}

--- a/lib/WP_Auth0_LoginManager.php
+++ b/lib/WP_Auth0_LoginManager.php
@@ -34,7 +34,7 @@ class WP_Auth0_LoginManager {
 	 * @param WP_Auth0_UsersRepo    $users_repo - see member variable doc comment.
 	 * @param WP_Auth0_Options|null $a0_options - see member variable doc comment.
 	 */
-	public function __construct( WP_Auth0_UsersRepo $users_repo, WP_Auth0_Options $a0_options ) {
+	public function __construct( WP_Auth0_UsersRepo $users_repo, ?WP_Auth0_Options $a0_options ) {
 		$this->users_repo = $users_repo;
 		$this->a0_options = $a0_options;
 	}
@@ -310,7 +310,7 @@ class WP_Auth0_LoginManager {
 			try {
 
 				$creator = new WP_Auth0_UsersRepo( $this->a0_options );
-				$user_id = $creator->create( $userinfo, $id_token, $access_token );
+				$user_id = $creator->create( $userinfo, $id_token );
 				$user    = get_user_by( 'id', $user_id );
 				$this->do_login( $user, $userinfo, true, $id_token, $access_token, $refresh_token );
 			} catch ( WP_Auth0_CouldNotCreateUserException $e ) {
@@ -569,7 +569,7 @@ class WP_Auth0_LoginManager {
 	}
 
 	/**
-	 * @param $id_token
+	 * @param string $id_token
 	 * @return object
 	 * @throws WP_Auth0_InvalidIdTokenException
 	 */

--- a/lib/WP_Auth0_UsersRepo.php
+++ b/lib/WP_Auth0_UsersRepo.php
@@ -161,8 +161,8 @@ class WP_Auth0_UsersRepo {
 	/**
 	 * Get a user's Auth0 meta data.
 	 *
-	 * @param integer  $user_id - WordPress user ID.
-	 * @param string - $key - Usermeta key to get.
+	 * @param integer $user_id - WordPress user ID.
+	 * @param string  $key - Usermeta key to get.
 	 *
 	 * @return mixed
 	 *

--- a/lib/WP_Auth0_WooCommerceOverrides.php
+++ b/lib/WP_Auth0_WooCommerceOverrides.php
@@ -13,13 +13,6 @@
 class WP_Auth0_WooCommerceOverrides {
 
 	/**
-	 * Injected WP_Auth0 instance.
-	 *
-	 * @var WP_Auth0
-	 */
-	protected $plugin;
-
-	/**
 	 * Injected WP_Auth0_Options instance.
 	 *
 	 * @var WP_Auth0_Options
@@ -76,7 +69,7 @@ class WP_Auth0_WooCommerceOverrides {
 	/**
 	 * Handle Auth0 login on the account form if the plugin is ready.
 	 *
-	 * @param $html string $html - Original HTML passed to filter.
+	 * @param string $html - Original HTML passed to filter.
 	 *
 	 * @return mixed
 	 */

--- a/lib/token-verifier/WP_Auth0_AsymmetricVerifier.php
+++ b/lib/token-verifier/WP_Auth0_AsymmetricVerifier.php
@@ -21,7 +21,7 @@ final class WP_Auth0_AsymmetricVerifier extends WP_Auth0_SignatureVerifier {
 	/**
 	 * JWKS array with kid as keys, PEM cert as values.
 	 *
-	 * @var array
+	 * @var WP_Auth0_JwksFetcher
 	 */
 	private $jwks;
 

--- a/lib/token-verifier/WP_Auth0_SignatureVerifier.php
+++ b/lib/token-verifier/WP_Auth0_SignatureVerifier.php
@@ -28,7 +28,7 @@ abstract class WP_Auth0_SignatureVerifier {
 	/**
 	 * Token parser.
 	 *
-	 * @var Token
+	 * @var Parser
 	 */
 	private $parser;
 


### PR DESCRIPTION
By submitting a PR to this repository, I agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md).

### Description

@joshcanhelp Started static analysis by @phpstan

### References

https://packagist.org/packages/szepeviktor/phpstan-wordpress

### Testing

Please consider using PHPStan on at least Level 4.

`phpstan.neon.dist`

```yaml
#$ composer require --dev szepeviktor/phpstan-wordpress
#$ vendor/bin/phpstan analyze -l 3

includes:
    - vendor/szepeviktor/phpstan-wordpress/extension.neon
parameters:
    level: max
    inferPrivatePropertyTypeFromConstructor: true
    autoload_files:
        - functions.php
        # FIXME Must comment out require_once twice!!!
        - WP_Auth0.php
    paths:
        - functions.php
        - lib/
    ignoreErrors:
        # Uses func_get_args()
        - '#^Function apply_filters(_ref_array)? invoked with [34567] parameters, 2 required\.$#'
```

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`
