### PR TITLE
Pass shortcode atts to the handler

### DIFF
--- a/WP_Auth0.php
+++ b/WP_Auth0.php
@@ -58,7 +58,7 @@ function wp_auth0_init() {
 }
 add_action( 'init', 'wp_auth0_init' );
 
-function wp_auth0_shortcode() {
+function wp_auth0_shortcode( $atts ) {
 	if ( empty( $atts ) ) {
 		$atts = [];
 	}


### PR DESCRIPTION
### Description

In 4.0.0 the "[auth0]" shortcode no longer accepts parameters (i.e "redirect_to"), this looks like it was an accidental bug introduced during a rewrite.

### Testing

Verified locally that the redirect_to shortcode now works. Also compared to v3.11 to be sure that this used to be supported.