### PR TITLE
Fix custom domain not being used in JWKS

### DIFF
--- a/lib/token-verifier/WP_Auth0_JwksFetcher.php
+++ b/lib/token-verifier/WP_Auth0_JwksFetcher.php
@@ -92,6 +92,6 @@ class WP_Auth0_JwksFetcher {
 	 * @return array
 	 */
 	protected function requestJwks() : array {
-		return ( new WP_Auth0_Api_Get_Jwks( $this->options ) )->call();
+		return ( new WP_Auth0_Api_Get_Jwks( $this->options, $this->options->get_auth_domain() ) )->call();
 	}
 }

--- a/tests/testJwksFetcher.php
+++ b/tests/testJwksFetcher.php
@@ -107,4 +107,37 @@ class TestJwksFetcher extends WP_Auth0_Test_Case {
 		$jwks = new WP_Auth0_JwksFetcher();
 		$this->assertNull( $jwks->getKey( '__not_found_kid__' ) );
 	}
+
+	public function testThatJwksFetcherUsesDefaultDomain() {
+		$this->startHttpHalting();
+
+		self::$opts->set('domain', 'test.auth0.com');
+		$jwks = new WP_Auth0_JwksFetcher();
+
+		try {
+			$jwks->getKeys( false );
+			$http_data = ['No exception caught'];
+		} catch (Exception $e) {
+			$http_data = unserialize( $e->getMessage() );
+		}
+
+		$this->assertEquals('https://test.auth0.com/.well-known/jwks.json', $http_data['url']);
+	}
+
+	public function testThatJwksFetcherUsesCustomDomain() {
+		$this->startHttpHalting();
+
+		self::$opts->set('domain', 'test.auth0.com');
+		self::$opts->set('custom_domain', 'custom.auth0.com');
+		$jwks = new WP_Auth0_JwksFetcher();
+
+		try {
+			$jwks->getKeys( false );
+			$http_data = ['No exception caught'];
+		} catch (Exception $e) {
+			$http_data = unserialize( $e->getMessage() );
+		}
+
+		$this->assertEquals('https://custom.auth0.com/.well-known/jwks.json', $http_data['url']);
+	}
 }


### PR DESCRIPTION
### Description

Use the custom domain for the JWKS instead of the main domain. 

### References

Closes #790

### Testing

- [x] This change adds test coverage for new/changed/fixed functionality
