### PR TITLE
Raise priority of authentication processing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,7 +46,7 @@ commands:
           name: Wait for DB
           command: |
             dockerize -wait tcp://127.0.0.1:3306 -timeout 120s
-            bash bin/install-wp-tests.sh wordpress_test root '' 127.0.0.1 latest
+            bash bin/install-wp-tests.sh wordpress_test root '' 127.0.0.1 5.4
       - run: composer test-ci
 
 jobs:

--- a/WP_Auth0.php
+++ b/WP_Auth0.php
@@ -634,7 +634,7 @@ function wp_auth0_process_auth_callback() {
 	$login_manager = new WP_Auth0_LoginManager( $users_repo, WP_Auth0_Options::Instance() );
 	return $login_manager->init_auth0();
 }
-add_action( 'template_redirect', 'wp_auth0_process_auth_callback' );
+add_action( 'template_redirect', 'wp_auth0_process_auth_callback', 1 );
 
 function wp_auth0_login_ulp_redirect() {
 	$users_repo    = new WP_Auth0_UsersRepo( WP_Auth0_Options::Instance() );

--- a/readme.txt
+++ b/readme.txt
@@ -1,6 +1,6 @@
 === Login by Auth0 ===
 Tags: OIDC, OpenID Connect, Single Sign On, SSO, SAML, Passwordless, OAuth2, Auth0
-Tested up to: 5.3.2
+Tested up to: 5.4.2
 Requires at least: 4.9
 Requires PHP: 7.0
 License: GPLv2


### PR DESCRIPTION
Raise authentication processing priority from default `10` to `1` (lower === earlier). 

Fixes ESD-8010