### PR TITLE
Pass user info to auth0_before_login action

### DIFF
--- a/examples/auth0_before_login.php
+++ b/examples/auth0_before_login.php
@@ -7,9 +7,11 @@
  * @see WP_Auth0_LoginManager::do_login()
  *
  * @param WP_User $user - WordPress user object.
+ * @param stdClass $userinfo - user information object from Auth0
  */
-function example_auth0_before_login( $user ) {
+function example_auth0_before_login( $user, $userinfo ) {
 	echo '<strong>WP user</strong>:<br><pre>' . print_r( $user, true ) . '</pre><hr>';
+	echo '<strong>Auth0 user info</strong>:<br><pre>' . print_r( $userinfo, true ) . '</pre><hr>';
 	wp_die( 'Login process started!' );
 }
- add_action( 'auth0_before_login', 'example_auth0_before_login', 10, 1 );
+ add_action( 'auth0_before_login', 'example_auth0_before_login', 10, 2 );

--- a/lib/WP_Auth0_LoginManager.php
+++ b/lib/WP_Auth0_LoginManager.php
@@ -348,7 +348,7 @@ class WP_Auth0_LoginManager {
 		$remember_users_session = $this->a0_options->get( 'remember_users_session' );
 
 		try {
-			do_action( 'auth0_before_login', $user );
+			do_action( 'auth0_before_login', $user, $userinfo );
 		} catch ( Exception $e ) {
 			throw new WP_Auth0_BeforeLoginException( $e->getMessage() );
 		}


### PR DESCRIPTION
There are situations in which we want to check whether the user is authorized to access a wordpress website based on the info passed by Auth0 (contained in app_metadata or user_metadata)

This PR aim is for this info to be available in the auth0_before_login action

#### Why not use auth0_user_login?

Because at that point the user is already logged in. 
Letting the user login and then rejecting him is not ideal, especially if we want to show a custom error page