### PR TITLE
Allow Composer installations w/ wpackagist

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,9 +3,33 @@
   "description": "WordPress Plugin for Auth0",
   "homepage": "https://auth0.com/wordpress",
   "license": "MIT",
+  "type": "wordpress-plugin",
+  "keywords": [
+    "wordpress",
+    "wp",
+    "authentication",
+    "auth",
+    "auth0"
+  ],
+  "authors": [
+    {
+      "name": "Auth0",
+      "email": "support@auth0.com",
+      "homepage": "http://www.auth0.com/"
+    }
+  ],
+  "support": {
+    "forum": "https://community.auth0.com/tags/wordpress",
+    "source": "https://github.com/auth0/wp-auth0",
+    "issues": "https://github.com/auth0/wp-auth0/issues",
+    "docs": "https://auth0.com/docs/cms/wordpress"
+  },
   "require": {
     "php": "^7.0 | ^8.0",
-    "auth0/php-jwt": "^3.3.4"
+    "ext-json": "*",
+    "ext-openssl": "*",
+    "auth0/php-jwt": "3.3.4",
+    "composer/installers": "~1.0"
   },
   "require-dev": {
     "phpunit/phpunit": "^6.0",
@@ -14,22 +38,6 @@
     "wp-coding-standards/wpcs": "*",
     "phpstan/phpstan": "^0.12.64",
     "szepeviktor/phpstan-wordpress": "^0.7.2"
-  },
-  "authors": [
-    {
-      "name": "Auth0",
-      "email": "support@auth0.com"
-    },
-    {
-      "name": "Josh Cunningham",
-      "email": "josh@joshcanhelp.com"
-    }
-  ],
-  "support": {
-    "forum": "https://community.auth0.com/tags/wordpress",
-    "source": "https://github.com/auth0/wp-auth0",
-    "issues": "https://github.com/auth0/wp-auth0/issues",
-    "docs": "https://auth0.com/docs/cms/wordpress"
   },
   "scripts": {
     "test": "@php ./vendor/bin/phpunit --coverage-text",

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
     "php": "^7.0 | ^8.0",
     "ext-json": "*",
     "ext-openssl": "*",
-    "auth0/php-jwt": "3.3.4",
+    "auth0/php-jwt": "^3.3.4",
     "composer/installers": "~1.0"
   },
   "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     {
       "name": "Auth0",
       "email": "support@auth0.com",
-      "homepage": "http://www.auth0.com/"
+      "homepage": "https://auth0.com/"
     }
   ],
   "support": {


### PR DESCRIPTION
This PR includes minor changes to our composer.json that;

- Allows installations via [wpackagist](https://wpackagist.org/)
- Updates our authors manifest to match our other PHP libraries
- Adds keywords to improve package discovery
- Restructures order of composer manifest to match our other PHP libraries

There are no functional or necessary test changes in this PR.