### PR TITLE
Support installation via Packagist

### DIFF
--- a/WP_Auth0.php
+++ b/WP_Auth0.php
@@ -32,7 +32,7 @@ define( 'WPA0_JWKS_CACHE_TRANSIENT_NAME', 'WP_Auth0_JWKS_cache' );
 define( 'WPA0_LANG', 'wp-auth0' ); // deprecated; do not use for translations
 
 if ( is_readable( __DIR__ . '/vendor/autoload.php' ) ) {
-    require_once __DIR__ . '/vendor/autoload.php';
+	require_once __DIR__ . '/vendor/autoload.php';
 }
 
 /*

--- a/WP_Auth0.php
+++ b/WP_Auth0.php
@@ -31,7 +31,9 @@ define( 'WPA0_JWKS_CACHE_TRANSIENT_NAME', 'WP_Auth0_JWKS_cache' );
 
 define( 'WPA0_LANG', 'wp-auth0' ); // deprecated; do not use for translations
 
-require_once __DIR__ . '/vendor/autoload.php';
+if ( is_readable( __DIR__ . '/vendor/autoload.php' ) ) {
+    require_once __DIR__ . '/vendor/autoload.php';
+}
 
 /*
  * Startup


### PR DESCRIPTION

### Description

Enables publishing this plugin to Packagist. Packagist installs will use the project `vendor` directory rather than requiring the plugin to bundle it.

### References

- Issue #823 

### Testing

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`
