### PR TITLE
[SDK-2376] Add Organizations support

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,10 +64,10 @@ Note that Organizations is currently only available to customers on our Enterpri
 Adding Organization support to your WordPress installation is simple. Configure WordPress and the Auth0 plugin as normally instructed, and then follow these additional steps:
 
 1. Open your [Auth0 dashboard](https://manage.auth0.com/dashboard).
-2. In your Application settings, ensure your 'Application Login URI' points to your WordPress blog's URL.
+2. In your Application settings, ensure your 'Application Login URI' points to your WordPress installation's URL.
 3. Create a new Organization.
 4. Copy the ID of your new organization, beginning with 'org\_'.
-5. Open the Auth0 WordPress plugin settings page within your WordPress .installation, and navigate to the Basic tab.
+5. Open the Auth0 WordPress plugin settings page within your WordPress installation, and navigate to the Basic tab.
 6. Paste the Organization ID into the 'Organization' field.
 7. Save your changes.
 

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ If you have existing users of your WordPress blog and Auth0, you should add thos
 
 With an organization configured, users logging into your WordPress installation will see your Universal Login Page customized for the Organization. You can further customize it's appearance from the Auth0 dashboard.
 
-Organizations also support invitations. To use this feature, navigate to the Organization on your Auth0 dashboard, click the Invitations tab, and 'invite member.' When the user clicks their invitation link, they'll be redirected to your WordPress installation, and then prompted to create their account or sign in.
+Organizations also support invitations. To use this feature, navigate to the Invitations tab for the corresponding Organization on your Auth0 dashboard and click 'invite member.' When the user clicks their invitation link, they'll be redirected to your WordPress installation, and then prompted to create their account or sign in.
 
 ## Contribution
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![Login by Auth0](https://ps.w.org/auth0/assets/banner-772x250.png)
 
-This plugin replaces standard WordPress login forms with one powered by Auth0 that enables social, passwordless, and enterprise connection login as well as additional security, multifactor auth, and user statistics. Please see the [WP.org plugin page](https://wordpress.org/plugins/auth0/) for more details on functionality. 
+This plugin replaces standard WordPress login forms with one powered by Auth0 that enables social, passwordless, and enterprise connection login as well as additional security, multifactor auth, and user statistics. Please see the [WP.org plugin page](https://wordpress.org/plugins/auth0/) for more details on functionality.
 
 **Important note:** The `master` branch is now the latest reviewed and tested functionality for version 4.0.0 and may contain breaking changes. Please see the [4.0.0 milestone, closed tab](https://github.com/auth0/wp-auth0/milestone/15?closed=1) for a list of merged changes. The latest [WP.org](https://wordpress.org/plugins/auth0/) release can be found in the [`wordpress-org-plugin`](https://github.com/auth0/wp-auth0/tree/wordpress-org-plugin) branch.
 
@@ -16,6 +16,7 @@ This plugin replaces standard WordPress login forms with one powered by Auth0 th
 - [Documentation](#documentation)
 - [Installation](#installation)
 - [Getting Started](#getting-started)
+  - [Organizations (Closed Beta)](#organizations-closed-beta)
 - [Contribution](#contribution)
 - [Support + Feedback](#support--feedback)
 - [Vulnerability Reporting](#vulnerability-reporting)
@@ -24,10 +25,10 @@ This plugin replaces standard WordPress login forms with one powered by Auth0 th
 
 ## Documentation
 
-* [Installation](https://auth0.com/docs/cms/wordpress/installation)
-* [Configuration](https://auth0.com/docs/cms/wordpress/configuration)
-* [Troubleshooting](https://auth0.com/docs/cms/wordpress/troubleshoot)
-* [Extending](https://auth0.com/docs/cms/wordpress/extending)
+- [Installation](https://auth0.com/docs/cms/wordpress/installation)
+- [Configuration](https://auth0.com/docs/cms/wordpress/configuration)
+- [Troubleshooting](https://auth0.com/docs/cms/wordpress/troubleshoot)
+- [Extending](https://auth0.com/docs/cms/wordpress/extending)
 
 ## Installation
 
@@ -44,6 +45,38 @@ Please see the [configuration docs](https://auth0.com/docs/cms/wordpress/configu
 
 We recommend testing on a staging/development site first using a separate Auth0 Application before putting the plugin live on your production site. See the **[Support](#support--feedback)** section below if you have any questions or issues during setup.
 
+### Organizations (Closed Beta)
+
+Organizations is a set of features that provide better support for developers who build and maintain SaaS and Business-to-Business (B2B) applications.
+
+Using Organizations, you can:
+
+- Represent teams, business customers, partner companies, or any logical grouping of users that should have different ways of accessing your applications, as organizations.
+- Manage their membership in a variety of ways, including user invitation.
+- Configure branded, federated login flows for each organization.
+- Implement role-based access control, such that users can have different roles when authenticating in the context of different organizations.
+- Build administration capabilities into your products, using Organizations APIs, so that those businesses can manage their own organizations.
+
+Note that Organizations is currently only available to customers on our Enterprise and Startup subscription plans.
+
+#### Configure WordPress to use an Organization
+
+Adding Organization support to your WordPress installation is simple. Configure WordPress and the Auth0 plugin as normally instructed, and then follow these additional steps:
+
+1. Open your [Auth0 dashboard](https://manage.auth0.com/dashboard).
+2. In your Application settings, ensure your 'Application Login URI' points to your WordPress blog's URL.
+3. Create a new Organization.
+4. Copy the ID of your new organization, beginning with 'org\_'.
+5. Open the Auth0 WordPress plugin settings page within your WordPress .installation, and navigate to the Basic tab.
+6. Paste the Organization ID into the 'Organization' field.
+7. Save your changes.
+
+If you have existing users of your WordPress blog and Auth0, you should add those users to your new Organization using the Auth0 dashboard. Ensure 'membership on authentication' is enabled for the Organization's Connection to automatically add them upon signing in.
+
+With an organization configured, users logging into your WordPress installation will see your Universal Login Page customized for the Organization. You can further customize it's appearance from the Auth0 dashboard.
+
+Organizations also support invitations. To use this feature, navigate to the Organization on your Auth0 dashboard, click the Invitations tab, and 'invite member.' When the user clicks their invitation link, they'll be redirected to your WordPress installation, and then prompted to create their account or sign in.
+
 ## Contribution
 
 We appreciate feedback and contribution to this plugin! Before you get started, please see the following:
@@ -51,7 +84,7 @@ We appreciate feedback and contribution to this plugin! Before you get started, 
 - [Auth0's general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
 - [Auth0's code of conduct guidelines](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
 - [This repo's contribution guidelines](CONTRIBUTION.md)
- 
+
 ## Support + Feedback
 
 Include information on how to get support. Consider adding:

--- a/WP_Auth0.php
+++ b/WP_Auth0.php
@@ -167,7 +167,7 @@ function wp_auth0_register_widget() {
 add_action( 'widgets_init', 'wp_auth0_register_widget' );
 
 function wp_auth0_register_query_vars( $qvars ) {
-	return array_merge( $qvars, [ 'error', 'error_description', 'a0_action', 'auth0', 'state', 'code' ] );
+	return array_merge( $qvars, [ 'error', 'error_description', 'a0_action', 'auth0', 'state', 'code', 'invitation', 'organization', 'organization_name' ] );
 }
 add_filter( 'query_vars', 'wp_auth0_register_query_vars' );
 

--- a/lib/WP_Auth0_LoginManager.php
+++ b/lib/WP_Auth0_LoginManager.php
@@ -83,6 +83,7 @@ class WP_Auth0_LoginManager {
 		WP_Auth0_Nonce_Handler::get_instance()->set_cookie( $auth_params['nonce'] );
 
 		$auth_url = self::build_authorize_url( $auth_params );
+
 		wp_safe_redirect( $auth_url );
 		exit;
 
@@ -100,8 +101,27 @@ class WP_Auth0_LoginManager {
 
 		set_query_var( 'auth0_login_successful', false );
 
-		// Not an Auth0 login process or settings are not configured to allow logins.
+		$invitation   = $this->query_vars( 'invitation' );
+		$organization = $this->query_vars( 'organization' );
+
+		if ( $invitation && $organization ) {
+			$connection  = apply_filters( 'auth0_get_auto_login_connection', $this->a0_options->get( 'auto_login_method' ) );
+			$auth_params = self::get_authorize_params( $connection );
+
+			WP_Auth0_State_Handler::get_instance()->set_cookie( $auth_params['state'] );
+			WP_Auth0_Nonce_Handler::get_instance()->set_cookie( $auth_params['nonce'] );
+
+			$auth_params['invitation'] = $invitation;
+
+			$auth_url = self::build_authorize_url( $auth_params );
+
+			wp_safe_redirect( $auth_url );
+			exit;
+		}
+
 		$cb_type = $this->query_vars( 'auth0' );
+
+		// Not an Auth0 login process or settings are not configured to allow logins.
 		if ( ! $cb_type || ! wp_auth0_is_ready() ) {
 			return false;
 		}
@@ -433,6 +453,7 @@ class WP_Auth0_LoginManager {
 		$params = [
 			'connection'    => $connection,
 			'client_id'     => $opts->get( 'client_id' ),
+			'organization'  => $opts->get( 'organization' ),
 			'scope'         => self::get_userinfo_scope( 'authorize_url' ),
 			'nonce'         => WP_Auth0_Nonce_Handler::get_instance()->get_unique(),
 			'max_age'       => absint( apply_filters( 'auth0_jwt_max_age', null ) ),

--- a/lib/WP_Auth0_LoginManager.php
+++ b/lib/WP_Auth0_LoginManager.php
@@ -610,6 +610,7 @@ class WP_Auth0_LoginManager {
 			'nonce'   => WP_Auth0_Nonce_Handler::get_instance()->get_once(),
 			'leeway'  => absint( apply_filters( 'auth0_jwt_leeway', null ) ),
 			'max_age' => absint( apply_filters( 'auth0_jwt_max_age', null ) ),
+			'org_id'  => apply_filters( 'auth0_jwt_org_id', $this->a0_options->get_auth_organization() ),
 		];
 
 		$idTokenVerifier = new WP_Auth0_IdTokenVerifier( $expectedIss, $this->a0_options->get( 'client_id' ), $sigVerifier );

--- a/lib/WP_Auth0_Options.php
+++ b/lib/WP_Auth0_Options.php
@@ -377,6 +377,7 @@ class WP_Auth0_Options {
 			'custom_domain'             => '',
 			'client_id'                 => '',
 			'client_secret'             => '',
+			'organization'              => '',
 			'client_signing_algorithm'  => WP_Auth0_Api_Client::DEFAULT_CLIENT_ALG,
 			'cache_expiration'          => 1440,
 			'wordpress_login_enabled'   => 'link',

--- a/lib/WP_Auth0_Options.php
+++ b/lib/WP_Auth0_Options.php
@@ -310,6 +310,15 @@ class WP_Auth0_Options {
 	}
 
 	/**
+	 * Get the authentication organization.
+	 *
+	 * @return string
+	 */
+	public function get_auth_organization() {
+		return $this->get( 'organization', '' );
+	}
+
+	/**
 	 * Get lock_connections as an array of strings
 	 *
 	 * @return array

--- a/lib/admin/WP_Auth0_Admin_Basic.php
+++ b/lib/admin/WP_Auth0_Admin_Basic.php
@@ -49,6 +49,12 @@ class WP_Auth0_Admin_Basic extends WP_Auth0_Admin_Generic {
 				'function' => 'render_client_secret',
 			],
 			[
+				'name'     => __( 'Organization', 'wp-auth0' ),
+				'opt'      => 'organization',
+				'id'       => 'wpa0_organization',
+				'function' => 'render_organization',
+			],
+			[
 				'name'     => __( 'JWT Signature Algorithm', 'wp-auth0' ),
 				'opt'      => 'client_signing_algorithm',
 				'id'       => 'wpa0_client_signing_algorithm',
@@ -148,6 +154,24 @@ class WP_Auth0_Admin_Basic extends WP_Auth0_Admin_Generic {
 		$this->render_text_field( $args['label_for'], $args['opt_name'], 'password', '', $style );
 		$this->render_field_description(
 			__( 'Client Secret, found in your Application settings in the ', 'wp-auth0' ) .
+			$this->get_dashboard_link( 'applications' )
+		);
+	}
+
+	/**
+	 * Render form field and description for the `organization` option.
+	 * IMPORTANT: Internal callback use only, do not call this function directly!
+	 *
+	 * @param array $args - callback args passed in from add_settings_field().
+	 *
+	 * @see WP_Auth0_Admin_Generic::init_option_section()
+	 * @see add_settings_field()
+	 */
+	public function render_organization( $args = [] ) {
+
+		$this->render_text_field( $args['label_for'], $args['opt_name'], 'text', '' );
+		$this->render_field_description(
+			__( 'Optional. Organization Id, found in your Organizations settings in the ', 'wp-auth0' ) .
 			$this->get_dashboard_link( 'applications' )
 		);
 	}
@@ -319,6 +343,8 @@ class WP_Auth0_Admin_Basic extends WP_Auth0_Admin_Generic {
 		if ( empty( $input['client_secret'] ) ) {
 			$this->add_validation_error( __( 'You need to specify a Client Secret', 'wp-auth0' ) );
 		}
+
+		$input['organization'] = $this->sanitize_text_val( $input['organization'] ?? null );
 
 		$id_token_alg = $input['client_signing_algorithm'] ?? null;
 		if ( ! in_array( $id_token_alg, self::ALLOWED_ID_TOKEN_ALGS ) ) {

--- a/lib/api/WP_Auth0_Api_Abstract.php
+++ b/lib/api/WP_Auth0_Api_Abstract.php
@@ -116,6 +116,7 @@ abstract class WP_Auth0_Api_Abstract {
 		$this->domain        = $domain ?: $this->options->get( 'domain' );
 		$this->client_id     = $this->options->get( 'client_id' );
 		$this->client_secret = $this->options->get( 'client_secret' );
+		$this->organization  = $this->options->get( 'organization' );
 
 		// Headers sent with every request.
 		$this->headers = static::get_info_headers();

--- a/lib/api/WP_Auth0_Api_Abstract.php
+++ b/lib/api/WP_Auth0_Api_Abstract.php
@@ -46,6 +46,14 @@ abstract class WP_Auth0_Api_Abstract {
 	 */
 	protected $client_secret;
 
+
+	/**
+	 * Organization Id from plugin settings.
+	 *
+	 * @var string
+	 */
+	protected $organization;
+
 	/**
 	 * WP_Auth0_Api_Client_Credentials instance.
 	 *
@@ -232,6 +240,16 @@ abstract class WP_Auth0_Api_Abstract {
 	 */
 	protected function send_client_secret() {
 		$this->body['client_secret'] = $this->client_secret;
+		return $this;
+	}
+
+	/**
+	 * Include the Organization in the body array.
+	 *
+	 * @return $this
+	 */
+	protected function send_organization() {
+		$this->body['organization'] = $this->organization;
 		return $this;
 	}
 

--- a/lib/token-verifier/WP_Auth0_IdTokenVerifier.php
+++ b/lib/token-verifier/WP_Auth0_IdTokenVerifier.php
@@ -91,11 +91,16 @@ final class WP_Auth0_IdTokenVerifier {
 
 		$verifiedToken = $this->verifier->verifyAndDecode( $token );
 
+		$claims = [];
+		foreach ( $verifiedToken->getClaims() as $claim => $value ) {
+			$claims[ $claim ] = $value->getValue();
+		}
+
 		/*
 		 * Issuer checks
 		 */
 
-		$tokenIss = $verifiedToken->getClaim( 'iss', false );
+		$tokenIss = $claims['iss'] ?? false;
 		if ( ! $tokenIss || ! is_string( $tokenIss ) ) {
 			throw new WP_Auth0_InvalidIdTokenException( 'Issuer (iss) claim must be a string present in the ID token' );
 		}
@@ -114,7 +119,7 @@ final class WP_Auth0_IdTokenVerifier {
 		 * Subject check
 		 */
 
-		$tokenSub = $verifiedToken->getClaim( 'sub', false );
+		$tokenSub = $claims['sub'] ?? false;
 		if ( ! $tokenSub || ! is_string( $tokenSub ) ) {
 			throw new WP_Auth0_InvalidIdTokenException( 'Subject (sub) claim must be a string present in the ID token' );
 		}
@@ -123,7 +128,7 @@ final class WP_Auth0_IdTokenVerifier {
 		 * Audience checks
 		 */
 
-		$tokenAud = $verifiedToken->getClaim( 'aud', false );
+		$tokenAud = $claims['aud'] ?? false;
 		if ( ! $tokenAud || ( ! is_string( $tokenAud ) && ! is_array( $tokenAud ) ) ) {
 			throw new WP_Auth0_InvalidIdTokenException(
 				'Audience (aud) claim must be a string or array of strings present in the ID token'
@@ -155,7 +160,7 @@ final class WP_Auth0_IdTokenVerifier {
 		$now    = $options['time'] ?? time();
 		$leeway = $options['leeway'] ?? $this->leeway;
 
-		$tokenExp = $verifiedToken->getClaim( 'exp', false );
+		$tokenExp = $claims['exp'] ?? false;
 		if ( ! $tokenExp || ! is_int( $tokenExp ) ) {
 			throw new WP_Auth0_InvalidIdTokenException( 'Expiration Time (exp) claim must be a number present in the ID token' );
 		}
@@ -171,7 +176,7 @@ final class WP_Auth0_IdTokenVerifier {
 			);
 		}
 
-		$tokenIat = $verifiedToken->getClaim( 'iat', false );
+		$tokenIat = $claims['iat'] ?? false;
 		if ( ! $tokenIat || ! is_int( $tokenIat ) ) {
 			throw new WP_Auth0_InvalidIdTokenException( 'Issued At (iat) claim must be a number present in the ID token' );
 		}
@@ -181,7 +186,7 @@ final class WP_Auth0_IdTokenVerifier {
 		 */
 
 		if ( ! empty( $options['nonce'] ) ) {
-			$tokenNonce = $verifiedToken->getClaim( 'nonce', false );
+			$tokenNonce = $claims['nonce'] ?? false;
 			if ( ! $tokenNonce || ! is_string( $tokenNonce ) ) {
 				throw new WP_Auth0_InvalidIdTokenException( 'Nonce (nonce) claim must be a string present in the ID token' );
 			}
@@ -202,7 +207,7 @@ final class WP_Auth0_IdTokenVerifier {
 		 */
 
 		if ( is_array( $tokenAud ) && count( $tokenAud ) > 1 ) {
-			$tokenAzp = $verifiedToken->getClaim( 'azp', false );
+			$tokenAzp = $claims['azp'] ?? false;
 			if ( ! $tokenAzp || ! is_string( $tokenAzp ) ) {
 				throw new WP_Auth0_InvalidIdTokenException(
 					'Authorized Party (azp) claim must be a string present in the ID token when Audience (aud) claim has multiple values'
@@ -227,18 +232,16 @@ final class WP_Auth0_IdTokenVerifier {
 		$expectedOrganization = $options['org_id'] ?? null;
 
 		if ( null !== $expectedOrganization && '' !== $expectedOrganization ) {
-			if ( ! $verifiedToken->hasClaim( 'org_id' ) ) {
+			if ( ! isset( $claims['org_id'] ) || ! is_string( $claims['org_id'] ) ) {
 				throw new WP_Auth0_InvalidIdTokenException( 'Organization Id (org_id) claim must be a string present in the ID token' );
 			}
 
-			$tokenOrganization = $verifiedToken->getClaim( 'org_id' );
-
-			if ( $tokenOrganization !== $expectedOrganization ) {
+			if ( $claims['org_id'] !== $expectedOrganization ) {
 				throw new WP_Auth0_InvalidIdTokenException(
 					sprintf(
 						'Organization Id (org_id) claim value mismatch in the ID token; expected "%s", found "%s"',
 						$expectedOrganization,
-						$tokenOrganization
+						$claims['org_id']
 					)
 				);
 			}
@@ -249,7 +252,7 @@ final class WP_Auth0_IdTokenVerifier {
 		 */
 
 		if ( ! empty( $options['max_age'] ) ) {
-			$tokenAuthTime = $verifiedToken->getClaim( 'auth_time', false );
+			$tokenAuthTime = $claims['auth_time'] ?? false;
 			if ( ! $tokenAuthTime || ! is_int( $tokenAuthTime ) ) {
 				throw new WP_Auth0_InvalidIdTokenException(
 					'Authentication Time (auth_time) claim must be a number present in the ID token when Max Age (max_age) is specified'
@@ -269,11 +272,6 @@ final class WP_Auth0_IdTokenVerifier {
 			}
 		}
 
-		$profile = [];
-		foreach ( $verifiedToken->getClaims() as $claim => $value ) {
-			$profile[ $claim ] = $value->getValue();
-		}
-
-		return $profile;
+		return $claims;
 	}
 }

--- a/lib/token-verifier/WP_Auth0_IdTokenVerifier.php
+++ b/lib/token-verifier/WP_Auth0_IdTokenVerifier.php
@@ -226,7 +226,7 @@ final class WP_Auth0_IdTokenVerifier {
 
 		$expectedOrganization = $options['org_id'] ?? null;
 
-		if (null !== $expectedOrganization) {
+		if (null !== $expectedOrganization && '' !== $expectedOrganization) {
 				if (! $verifiedToken->hasClaim('org_id')) {
 						throw new WP_Auth0_InvalidIdTokenException('Organization Id (org_id) claim must be a string present in the ID token');
 				}

--- a/lib/token-verifier/WP_Auth0_IdTokenVerifier.php
+++ b/lib/token-verifier/WP_Auth0_IdTokenVerifier.php
@@ -226,20 +226,22 @@ final class WP_Auth0_IdTokenVerifier {
 
 		$expectedOrganization = $options['org_id'] ?? null;
 
-		if (null !== $expectedOrganization && '' !== $expectedOrganization) {
-				if (! $verifiedToken->hasClaim('org_id')) {
-						throw new WP_Auth0_InvalidIdTokenException('Organization Id (org_id) claim must be a string present in the ID token');
-				}
+		if ( null !== $expectedOrganization && '' !== $expectedOrganization ) {
+			if ( ! $verifiedToken->hasClaim( 'org_id' ) ) {
+				throw new WP_Auth0_InvalidIdTokenException( 'Organization Id (org_id) claim must be a string present in the ID token' );
+			}
 
-				$tokenOrganization = $verifiedToken->getClaim('org_id');
+			$tokenOrganization = $verifiedToken->getClaim( 'org_id' );
 
-				if ($tokenOrganization !== $expectedOrganization) {
-						throw new WP_Auth0_InvalidIdTokenException( sprintf(
-								'Organization Id (org_id) claim value mismatch in the ID token; expected "%s", found "%s"',
-								$expectedOrganization,
-								$tokenOrganization
-						) );
-				}
+			if ( $tokenOrganization !== $expectedOrganization ) {
+				throw new WP_Auth0_InvalidIdTokenException(
+					sprintf(
+						'Organization Id (org_id) claim value mismatch in the ID token; expected "%s", found "%s"',
+						$expectedOrganization,
+						$tokenOrganization
+					)
+				);
+			}
 		}
 
 		/*

--- a/lib/token-verifier/WP_Auth0_IdTokenVerifier.php
+++ b/lib/token-verifier/WP_Auth0_IdTokenVerifier.php
@@ -221,6 +221,28 @@ final class WP_Auth0_IdTokenVerifier {
 		}
 
 		/*
+		 * Organization check
+		 */
+
+		$expectedOrganization = $options['org_id'] ?? null;
+
+		if (null !== $expectedOrganization) {
+				if (! $verifiedToken->hasClaim('org_id')) {
+						throw new WP_Auth0_InvalidIdTokenException('Organization Id (org_id) claim must be a string present in the ID token');
+				}
+
+				$tokenOrganization = $verifiedToken->getClaim('org_id');
+
+				if ($tokenOrganization !== $expectedOrganization) {
+						throw new WP_Auth0_InvalidIdTokenException( sprintf(
+								'Organization Id (org_id) claim value mismatch in the ID token; expected "%s", found "%s"',
+								$expectedOrganization,
+								$tokenOrganization
+						) );
+				}
+		}
+
+		/*
 		 * Authentication time check
 		 */
 

--- a/tests/testApiAbstract.php
+++ b/tests/testApiAbstract.php
@@ -120,6 +120,7 @@ class TestApiAbstract extends WP_Auth0_Test_Case {
 		self::$opts->set( 'domain', self::TEST_DOMAIN );
 		self::$opts->set( 'client_id', '__test_client_id__' );
 		self::$opts->set( 'client_secret', '__test_client_secret__' );
+		self::$opts->set( 'organization', '__test_organization__' );
 
 		$api_abstract = new Test_WP_Auth0_Api_Abstract( self::$opts );
 
@@ -147,13 +148,19 @@ class TestApiAbstract extends WP_Auth0_Test_Case {
 		$api_abstract = $send_client_secret->invoke( $api_abstract );
 		$this->assertEquals( '__test_client_secret__', $api_abstract->get_request( 'body' )['client_secret'] );
 
-		// 4. Test an arbitrary body value.
+		// 4. Test that the organization is set.
+		$send_organization = $mock_abstract->getMethod( 'send_organization' );
+		$send_organization->setAccessible( true );
+		$api_abstract = $send_organization->invoke( $api_abstract );
+		$this->assertEquals( '__test_organization__', $api_abstract->get_request( 'body' )['organization'] );
+
+		// 5. Test an arbitrary body value.
 		$add_body = $mock_abstract->getMethod( 'add_body' );
 		$add_body->setAccessible( true );
 		$api_abstract = $add_body->invoke( $api_abstract, '__test_key__', '__test_val__' );
 		$this->assertEquals( '__test_val__', $api_abstract->get_request( 'body' )['__test_key__'] );
 
-		// 5. Make sure all keys set previously are sent with the request.
+		// 6. Make sure all keys set previously are sent with the request.
 		$decoded_res = [];
 		try {
 			$api_abstract->set_http_method( 'get' )->call();
@@ -163,6 +170,7 @@ class TestApiAbstract extends WP_Auth0_Test_Case {
 		$this->assertEquals( 'https://' . self::TEST_DOMAIN . '/api/v2/', $decoded_res['body']['audience'] );
 		$this->assertEquals( '__test_client_id__', $decoded_res['body']['client_id'] );
 		$this->assertEquals( '__test_client_secret__', $decoded_res['body']['client_secret'] );
+		$this->assertEquals( '__test_organization__', $decoded_res['body']['organization'] );
 		$this->assertEquals( '__test_val__', $decoded_res['body']['__test_key__'] );
 	}
 

--- a/tests/testIdTokenVerifier.php
+++ b/tests/testIdTokenVerifier.php
@@ -6,10 +6,10 @@ use WP_Auth0_InvalidIdTokenException as InvalidTokenException;
 use Lcobucci\JWT\Builder;
 
 /**
-* Class IdTokenVerifierTest.
+* Class TestIdTokenVerifierTest.
 * Test the WP_Auth0_Api_Get_User class.
 */
-class IdTokenVerifierTest extends WP_Auth0_Test_Case
+class TestIdTokenVerifierTest extends WP_Auth0_Test_Case
 {
   public function testThatEmptyTokenFails()
   {

--- a/tests/testIdTokenVerifier.php
+++ b/tests/testIdTokenVerifier.php
@@ -1,0 +1,501 @@
+<?php
+use WP_Auth0_IdTokenVerifier as IdTokenVerifier;
+use WP_Auth0_SymmetricVerifier as SymmetricVerifier;
+use WP_Auth0_InvalidIdTokenException as InvalidTokenException;
+
+use Lcobucci\JWT\Builder;
+
+/**
+* Class IdTokenVerifierTest.
+* Test the WP_Auth0_Api_Get_User class.
+*/
+class IdTokenVerifierTest extends WP_Auth0_Test_Case
+{
+  public function testThatEmptyTokenFails()
+  {
+    $verifier  = new IdTokenVerifier( '__test_iss__', '__test_aud__', new SymmetricVerifier( uniqid() ) );
+    $error_msg = 'No exception caught';
+
+    try {
+      $verifier->verify('');
+    } catch (InvalidTokenException $e) {
+      $error_msg = $e->getMessage();
+    }
+
+    $this->assertEquals('ID token is required but missing', $error_msg);
+  }
+
+  public function testThatTokenMissingIssuerFails()
+  {
+    $verifier  = new IdTokenVerifier('__test_iss__', '__test_aud__', new SymmetricVerifier('__test_secret__'));
+    $token     = SymmetricVerifierTest::getToken();
+    $error_msg = 'No exception caught';
+
+    try {
+      $verifier->verify($token);
+    } catch (InvalidTokenException $e) {
+      $error_msg = $e->getMessage();
+    }
+
+    $this->assertEquals('Issuer (iss) claim must be a string present in the ID token', $error_msg);
+  }
+
+  public function testThatTokenWithNonStringIssuerFails()
+  {
+    $verifier  = new IdTokenVerifier('__test_iss__', '__test_aud__', new SymmetricVerifier('__test_secret__'));
+    $builder   = (new Builder())->withClaim('iss', 123);
+    $token     = SymmetricVerifierTest::getToken('__test_secret__', $builder);
+    $error_msg = 'No exception caught';
+
+    try {
+      $verifier->verify($token);
+    } catch (InvalidTokenException $e) {
+      $error_msg = $e->getMessage();
+    }
+
+    $this->assertEquals('Issuer (iss) claim must be a string present in the ID token', $error_msg);
+  }
+
+  public function testThatTokenWithInvalidIssuerFails()
+  {
+    $verifier  = new IdTokenVerifier('__test_iss__', '__test_aud__', new SymmetricVerifier('__test_secret__'));
+    $builder   = (new Builder())->issuedBy('__invalid_issuer__');
+    $token     = SymmetricVerifierTest::getToken('__test_secret__', $builder);
+    $error_msg = 'No exception caught';
+
+    try {
+      $verifier->verify($token);
+    } catch (InvalidTokenException $e) {
+      $error_msg = $e->getMessage();
+    }
+
+    $this->assertEquals(
+      'Issuer (iss) claim mismatch in the ID token; expected "__test_iss__", found "__invalid_issuer__"',
+      $error_msg
+    );
+  }
+
+  public function testThatTokenWithMissingSubFails()
+  {
+    $verifier  = new IdTokenVerifier('__test_iss__', '__test_aud__', new SymmetricVerifier('__test_secret__'));
+    $builder   = (new Builder())
+    ->issuedBy('__test_iss__')
+    ->permittedFor('__test_aud__')
+    ->withClaim('exp', time() + 1000);
+    $token     = SymmetricVerifierTest::getToken('__test_secret__', $builder);
+    $error_msg = 'No exception caught';
+
+    try {
+      $verifier->verify($token);
+    } catch (InvalidTokenException $e) {
+      $error_msg = $e->getMessage();
+    }
+
+    $this->assertEquals('Subject (sub) claim must be a string present in the ID token', $error_msg);
+  }
+
+  public function testThatTokenWithNonStringSubFails()
+  {
+    $verifier  = new IdTokenVerifier('__test_iss__', '__test_aud__', new SymmetricVerifier('__test_secret__'));
+    $builder   = SymmetricVerifierTest::getTokenBuilder()
+    ->withClaim('sub', 123)
+    ->issuedBy('__test_iss__')
+    ->permittedFor('__test_aud__')
+    ->withClaim('exp', time() + 1000);
+    $token     = SymmetricVerifierTest::getToken('__test_secret__', $builder);
+    $error_msg = 'No exception caught';
+
+    try {
+      $verifier->verify($token);
+    } catch (InvalidTokenException $e) {
+      $error_msg = $e->getMessage();
+    }
+
+    $this->assertEquals('Subject (sub) claim must be a string present in the ID token', $error_msg);
+  }
+
+  public function testThatTokenWithMissingAudFails()
+  {
+    $verifier  = new IdTokenVerifier('__test_iss__', '__test_aud__', new SymmetricVerifier('__test_secret__'));
+    $builder   = SymmetricVerifierTest::getTokenBuilder()->issuedBy('__test_iss__');
+    $token     = SymmetricVerifierTest::getToken('__test_secret__', $builder);
+    $error_msg = 'No exception caught';
+
+    try {
+      $verifier->verify($token);
+    } catch (InvalidTokenException $e) {
+      $error_msg = $e->getMessage();
+    }
+
+    $this->assertEquals(
+      'Audience (aud) claim must be a string or array of strings present in the ID token',
+      $error_msg
+    );
+  }
+
+  public function testThatTokenWithNonStringOrArrayAudFails()
+  {
+    $verifier  = new IdTokenVerifier('__test_iss__', uniqid(), new SymmetricVerifier('__test_secret__'));
+    $builder   = SymmetricVerifierTest::getTokenBuilder()->issuedBy('__test_iss__')->withClaim('aud', 123);
+    $token     = SymmetricVerifierTest::getToken('__test_secret__', $builder);
+    $error_msg = 'No exception caught';
+
+    try {
+      $verifier->verify($token);
+    } catch (InvalidTokenException $e) {
+      $error_msg = $e->getMessage();
+    }
+
+    $this->assertEquals(
+      'Audience (aud) claim must be a string or array of strings present in the ID token',
+      $error_msg
+    );
+  }
+
+  public function testThatTokenWithInvalidArrayAudFails()
+  {
+    $verifier  = new IdTokenVerifier('__test_iss__', '__test_aud__', new SymmetricVerifier('__test_secret__'));
+    $builder   = SymmetricVerifierTest::getTokenBuilder()
+    ->issuedBy('__test_iss__')
+    ->withClaim('aud', ['__invalid_aud_1__', '__invalid_aud_2__']);
+    $token     = SymmetricVerifierTest::getToken('__test_secret__', $builder);
+    $error_msg = 'No exception caught';
+
+    try {
+      $verifier->verify($token);
+    } catch (InvalidTokenException $e) {
+      $error_msg = $e->getMessage();
+    }
+
+    $this->assertEquals(
+      'Audience (aud) claim mismatch in the ID token; expected "__test_aud__" was not one of "__invalid_aud_1__, __invalid_aud_2__"',
+      $error_msg
+    );
+  }
+
+  public function testThatTokenWithInvalidStringAudFails()
+  {
+    $verifier  = new IdTokenVerifier('__test_iss__', '__test_aud__', new SymmetricVerifier('__test_secret__'));
+    $builder   = SymmetricVerifierTest::getTokenBuilder()
+    ->issuedBy('__test_iss__')
+    ->permittedFor('__invalid_aud__');
+    $token     = SymmetricVerifierTest::getToken('__test_secret__', $builder);
+    $error_msg = 'No exception caught';
+
+    try {
+      $verifier->verify($token);
+    } catch (InvalidTokenException $e) {
+      $error_msg = $e->getMessage();
+    }
+
+    $this->assertEquals(
+      'Audience (aud) claim mismatch in the ID token; expected "__test_aud__", found "__invalid_aud__"',
+      $error_msg
+    );
+  }
+
+  public function testThatTokenWithMissingExpFails()
+  {
+    $verifier  = new IdTokenVerifier('__test_iss__', '__test_aud__', new SymmetricVerifier('__test_secret__'));
+    $builder   = SymmetricVerifierTest::getTokenBuilder()
+    ->issuedBy('__test_iss__')
+    ->permittedFor('__test_aud__');
+    $token     = SymmetricVerifierTest::getToken('__test_secret__', $builder);
+    $error_msg = 'No exception caught';
+
+    try {
+      $verifier->verify($token);
+    } catch (InvalidTokenException $e) {
+      $error_msg = $e->getMessage();
+    }
+
+    $this->assertEquals('Expiration Time (exp) claim must be a number present in the ID token', $error_msg);
+  }
+
+  public function testThatTokenWithNonIntExpFails()
+  {
+    $verifier  = new IdTokenVerifier('__test_iss__', '__test_aud__', new SymmetricVerifier('__test_secret__'));
+    $builder   = SymmetricVerifierTest::getTokenBuilder()
+    ->issuedBy('__test_iss__')
+    ->permittedFor('__test_aud__')
+    ->withClaim('exp', uniqid());
+    $token     = SymmetricVerifierTest::getToken('__test_secret__', $builder);
+    $error_msg = 'No exception caught';
+
+    try {
+      $verifier->verify($token);
+    } catch (InvalidTokenException $e) {
+      $error_msg = $e->getMessage();
+    }
+
+    $this->assertEquals('Expiration Time (exp) claim must be a number present in the ID token', $error_msg);
+  }
+
+  public function testThatExpiredTokenFails()
+  {
+    $verifier  = new IdTokenVerifier('__test_iss__', '__test_aud__', new SymmetricVerifier('__test_secret__'));
+    $builder   = SymmetricVerifierTest::getTokenBuilder()
+    ->issuedBy('__test_iss__')
+    ->permittedFor('__test_aud__')
+    ->withClaim('exp', 1000);
+    $token     = SymmetricVerifierTest::getToken('__test_secret__', $builder);
+    $error_msg = 'No exception caught';
+
+    try {
+      $verifier->verify($token, ['time' => 10000, 'leeway' => 10]);
+    } catch (InvalidTokenException $e) {
+      $error_msg = $e->getMessage();
+    }
+
+    $this->assertEquals(
+      'Expiration Time (exp) claim error in the ID token; current time (10000) is after expiration time (1010)',
+      $error_msg
+    );
+  }
+
+  public function testThatTokenWithMissingIatFails()
+  {
+    $verifier  = new IdTokenVerifier('__test_iss__', '__test_aud__', new SymmetricVerifier('__test_secret__'));
+    $builder   = SymmetricVerifierTest::getTokenBuilder()
+    ->issuedBy('__test_iss__')
+    ->permittedFor('__test_aud__')
+    ->withClaim('exp', time() + 1000);
+    $token     = SymmetricVerifierTest::getToken('__test_secret__', $builder);
+    $error_msg = 'No exception caught';
+
+    try {
+      $verifier->verify($token);
+    } catch (InvalidTokenException $e) {
+      $error_msg = $e->getMessage();
+    }
+
+    $this->assertEquals('Issued At (iat) claim must be a number present in the ID token', $error_msg);
+  }
+
+  public function testThatTokenWithoutNonceFails()
+  {
+    $verifier  = new IdTokenVerifier('__test_iss__', '__test_aud__', new SymmetricVerifier('__test_secret__'));
+    $builder   = SymmetricVerifierTest::getTokenBuilder()
+    ->issuedBy('__test_iss__')
+    ->permittedFor('__test_aud__')
+    ->withClaim('exp', time() + 1000)
+    ->withClaim('iat', time() - 1000);
+    $token     = SymmetricVerifierTest::getToken('__test_secret__', $builder);
+    $error_msg = 'No exception caught';
+
+    try {
+      $verifier->verify($token, ['nonce' => uniqid()]);
+    } catch (InvalidTokenException $e) {
+      $error_msg = $e->getMessage();
+    }
+
+    $this->assertEquals('Nonce (nonce) claim must be a string present in the ID token', $error_msg);
+  }
+
+  public function testThatTokenNonStringNonceFails()
+  {
+    $verifier  = new IdTokenVerifier('__test_iss__', '__test_aud__', new SymmetricVerifier('__test_secret__'));
+    $builder   = SymmetricVerifierTest::getTokenBuilder()
+    ->issuedBy('__test_iss__')
+    ->permittedFor('__test_aud__')
+    ->withClaim('exp', time() + 1000)
+    ->withClaim('iat', time() - 1000)
+    ->withClaim('nonce', 123);
+    $token     = SymmetricVerifierTest::getToken('__test_secret__', $builder);
+    $error_msg = 'No exception caught';
+
+    try {
+      $verifier->verify($token, ['nonce' => uniqid()]);
+    } catch (InvalidTokenException $e) {
+      $error_msg = $e->getMessage();
+    }
+
+    $this->assertEquals('Nonce (nonce) claim must be a string present in the ID token', $error_msg);
+  }
+
+  public function testThatTokenWithInvalidNonceFails()
+  {
+    $verifier  = new IdTokenVerifier('__test_iss__', '__test_aud__', new SymmetricVerifier('__test_secret__'));
+    $builder   = SymmetricVerifierTest::getTokenBuilder()
+    ->issuedBy('__test_iss__')
+    ->permittedFor('__test_aud__')
+    ->withClaim('exp', time() + 1000)
+    ->withClaim('iat', time() - 1000)
+    ->withClaim('nonce', '__invalid_nonce__');
+    $token     = SymmetricVerifierTest::getToken('__test_secret__', $builder);
+    $error_msg = 'No exception caught';
+
+    try {
+      $verifier->verify($token, ['nonce' => '__test_nonce__']);
+    } catch (InvalidTokenException $e) {
+      $error_msg = $e->getMessage();
+    }
+
+    $this->assertEquals(
+      'Nonce (nonce) claim mismatch in the ID token; expected "__test_nonce__", found "__invalid_nonce__"',
+      $error_msg
+    );
+  }
+
+  public function testThatTokenWithMissingAzpFails()
+  {
+    $verifier  = new IdTokenVerifier('__test_iss__', '__test_aud__', new SymmetricVerifier('__test_secret__'));
+    $builder   = SymmetricVerifierTest::getTokenBuilder()
+    ->issuedBy('__test_iss__')
+    ->withClaim('aud', ['__test_aud__', '__test_aud_2__'])
+    ->withClaim('exp', time() + 1000)
+    ->withClaim('iat', time() - 1000);
+    $token     = SymmetricVerifierTest::getToken('__test_secret__', $builder);
+    $error_msg = 'No exception caught';
+
+    try {
+      $verifier->verify($token);
+    } catch (InvalidTokenException $e) {
+      $error_msg = $e->getMessage();
+    }
+
+    $this->assertEquals(
+      'Authorized Party (azp) claim must be a string present in the ID token when Audience (aud) claim has multiple values',
+      $error_msg
+    );
+  }
+
+  public function testThatTokenWithNonStringAzpFails()
+  {
+    $verifier  = new IdTokenVerifier('__test_iss__', '__test_aud__', new SymmetricVerifier('__test_secret__'));
+    $builder   = SymmetricVerifierTest::getTokenBuilder()
+    ->issuedBy('__test_iss__')
+    ->withClaim('aud', ['__test_aud__', '__test_aud_2__'])
+    ->withClaim('exp', time() + 1000)
+    ->withClaim('iat', time() - 1000)
+    ->withClaim('azp', 123);
+    $token     = SymmetricVerifierTest::getToken('__test_secret__', $builder);
+    $error_msg = 'No exception caught';
+
+    try {
+      $verifier->verify($token);
+    } catch (InvalidTokenException $e) {
+      $error_msg = $e->getMessage();
+    }
+
+    $this->assertEquals(
+      'Authorized Party (azp) claim must be a string present in the ID token when Audience (aud) claim has multiple values',
+      $error_msg
+    );
+  }
+
+  public function testThatTokenWithInvalidAzpFails()
+  {
+    $verifier  = new IdTokenVerifier('__test_iss__', '__test_aud__', new SymmetricVerifier('__test_secret__'));
+    $builder   = SymmetricVerifierTest::getTokenBuilder()
+    ->issuedBy('__test_iss__')
+    ->withClaim('aud', ['__test_aud__', '__test_aud_2__'])
+    ->withClaim('exp', time() + 1000)
+    ->withClaim('iat', time() - 1000)
+    ->withClaim('azp', '__invalid_azp__');
+    $token     = SymmetricVerifierTest::getToken('__test_secret__', $builder);
+    $error_msg = 'No exception caught';
+
+    try {
+      $verifier->verify($token);
+    } catch (InvalidTokenException $e) {
+      $error_msg = $e->getMessage();
+    }
+
+    $this->assertEquals(
+      'Authorized Party (azp) claim mismatch in the ID token; expected "__test_aud__", found "__invalid_azp__"',
+      $error_msg
+    );
+  }
+
+  public function testThatTokenWithMissingAuthTimeFails()
+  {
+    $verifier  = new IdTokenVerifier('__test_iss__', '__test_aud__', new SymmetricVerifier('__test_secret__'));
+    $builder   = SymmetricVerifierTest::getTokenBuilder()
+    ->issuedBy('__test_iss__')
+    ->permittedFor('__test_aud__')
+    ->withClaim('exp', time() + 1000)
+    ->withClaim('iat', time() - 1000);
+    $token     = SymmetricVerifierTest::getToken('__test_secret__', $builder);
+    $error_msg = 'No exception caught';
+
+    try {
+      $verifier->verify($token, ['max_age' => uniqid()]);
+    } catch (InvalidTokenException $e) {
+      $error_msg = $e->getMessage();
+    }
+
+    $this->assertEquals(
+      'Authentication Time (auth_time) claim must be a number present in the ID token when Max Age (max_age) is specified',
+      $error_msg
+    );
+  }
+
+  public function testThatTokenWithNonIntAuthTimeFails()
+  {
+    $verifier  = new IdTokenVerifier('__test_iss__', '__test_aud__', new SymmetricVerifier('__test_secret__'));
+    $builder   = SymmetricVerifierTest::getTokenBuilder()
+    ->issuedBy('__test_iss__')
+    ->permittedFor('__test_aud__')
+    ->withClaim('exp', time() + 1000)
+    ->withClaim('iat', time() - 1000)
+    ->withClaim('auth_time', uniqid());
+    $token     = SymmetricVerifierTest::getToken('__test_secret__', $builder);
+    $error_msg = 'No exception caught';
+
+    try {
+      $verifier->verify($token, ['max_age' => uniqid()]);
+    } catch (InvalidTokenException $e) {
+      $error_msg = $e->getMessage();
+    }
+
+    $this->assertEquals(
+      'Authentication Time (auth_time) claim must be a number present in the ID token when Max Age (max_age) is specified',
+      $error_msg
+    );
+  }
+
+  public function testThatTokenWithInvalidAuthTimeTimeFails()
+  {
+    $verifier  = new IdTokenVerifier('__test_iss__', '__test_aud__', new SymmetricVerifier('__test_secret__'));
+    $builder   = SymmetricVerifierTest::getTokenBuilder()
+    ->issuedBy('__test_iss__')
+    ->permittedFor('__test_aud__')
+    ->withClaim('exp', 11000)
+    ->withClaim('iat', 9000)
+    ->withClaim('auth_time', 9000);
+    $token     = SymmetricVerifierTest::getToken('__test_secret__', $builder);
+    $error_msg = 'No exception caught';
+
+    try {
+      $verifier->setLeeway(0);
+      $verifier->verify($token, ['time' => 10000, 'max_age' => 100]);
+    } catch (InvalidTokenException $e) {
+      $error_msg = $e->getMessage();
+    }
+
+    $this->assertEquals(
+      'Authentication Time (auth_time) claim in the ID token indicates that too much time has passed since the last end-user authentication. Current time (10000) is after last auth at 9100',
+      $error_msg
+    );
+  }
+
+  /**
+  * @throws InvalidTokenException Should not be thrown in this test.
+  */
+  public function testThatValidTokenReturnsClaims()
+  {
+    $verifier = new IdTokenVerifier('__test_iss__', '__test_aud__', new SymmetricVerifier('__test_secret__'));
+    $builder  = SymmetricVerifierTest::getTokenBuilder()
+    ->issuedBy('__test_iss__')
+    ->permittedFor('__test_aud__')
+    ->withClaim('exp', time() + 1000)
+    ->withClaim('iat', time() - 1000)
+    ->withClaim('auth_time', 9000);
+    $token    = SymmetricVerifierTest::getToken('__test_secret__', $builder);
+
+    $decoded_token = $verifier->verify($token);
+
+    $this->assertEquals('__test_sub__', $decoded_token['sub']);
+  }
+}

--- a/tests/testOptionOrganization.php
+++ b/tests/testOptionOrganization.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * Contains Class TestOptionOrganization.
+ *
+ * @package WP-Auth0
+ *
+ * @since 3.11.1
+ */
+
+/**
+ * Class TestOptionOrganization.
+ * Tests that Basic > Organization functions properly.
+ */
+class TestOptionOrganization extends WP_Auth0_Test_Case {
+
+	use DomDocumentHelpers;
+
+	/**
+	 * WP_Auth0_Admin_Basic instance.
+	 *
+	 * @var WP_Auth0_Admin_Basic
+	 */
+	public static $admin;
+
+	/**
+	 * Domain settings field args
+	 *
+	 * @var array
+	 */
+	public static $field_args;
+
+	/**
+	 * Run before the test suite starts.
+	 */
+	public static function setUpBeforeClass() {
+		parent::setUpBeforeClass();
+		self::$admin      = new WP_Auth0_Admin_Basic( self::$opts );
+		self::$field_args = [
+			'label_for' => 'wpa0_organization',
+			'opt_name'  => 'organization',
+		];
+	}
+
+	public function testThatOrganizationFieldRendersProperly() {
+		ob_start();
+		self::$admin->render_organization( self::$field_args );
+		$field_html = ob_get_clean();
+
+		$input = $this->getDomListFromTagName( $field_html, 'input' );
+
+		$this->assertEquals( 1, $input->length );
+		$this->assertEquals( 'wpa0_organization', $input->item( 0 )->getAttribute( 'id' ) );
+		$this->assertEquals( 'text', $input->item( 0 )->getAttribute( 'type' ) );
+		$this->assertEquals( self::OPTIONS_NAME . '[organization]', $input->item( 0 )->getAttribute( 'name' ) );
+		$this->assertEmpty( $input->item( 0 )->getAttribute( 'value' ) );
+	}
+}

--- a/tests/testSymmetricVerifier.php
+++ b/tests/testSymmetricVerifier.php
@@ -1,0 +1,98 @@
+<?php
+use WP_Auth0_SymmetricVerifier as SymmetricVerifier;
+use WP_Auth0_InvalidIdTokenException as InvalidTokenException;
+
+use Lcobucci\JWT\Builder;
+use Lcobucci\JWT\Signer\Key;
+use Lcobucci\JWT\Signer\Hmac\Sha256 as HsSigner;
+use Lcobucci\JWT\Token;
+
+/**
+ * Class SymmetricVerifierTest.
+ *
+ * @package Auth0\Tests\unit\Helpers\Tokens
+ */
+class SymmetricVerifierTest extends WP_Auth0_Test_Case
+{
+    public function testThatFormatCheckFails()
+    {
+        $error_msg = 'No exception caught';
+
+        try {
+            $verifier = new SymmetricVerifier( '__test_secret__' );
+            $verifier->verifyAndDecode( uniqid().'.'.uniqid() );
+        } catch (InvalidTokenException $e) {
+            $error_msg = $e->getMessage();
+        }
+
+        $this->assertEquals('ID token could not be decoded', $error_msg);
+    }
+
+    public function testThatAlgorithmNoneFails()
+    {
+        $error_msg      = 'No exception caught';
+        $unsigned_token = self::getTokenBuilder()->getToken();
+
+        try {
+            $verifier = new SymmetricVerifier( '__test_secret__' );
+            $verifier->verifyAndDecode( $unsigned_token );
+        } catch (InvalidTokenException $e) {
+            $error_msg = $e->getMessage();
+        }
+
+        $this->assertEquals(
+            'Signature algorithm of "none" is not supported. Expected the ID token to be signed with "HS256".',
+            $error_msg
+        );
+    }
+
+    public function testThatInvalidSignatureFails()
+    {
+        $error_msg = 'No exception caught';
+        try {
+            $verifier = new SymmetricVerifier( '__test_secret__' );
+            $verifier->verifyAndDecode( self::getToken( '__invalid_secret__' ) );
+        } catch (InvalidTokenException $e) {
+            $error_msg = $e->getMessage();
+        }
+
+        $this->assertEquals('Invalid ID token signature', $error_msg);
+    }
+
+    /**
+     * @throws InvalidTokenException Should not be thrown in this test.
+     */
+    public function testThatTokenClaimsAreReturned()
+    {
+        $verifier     = new SymmetricVerifier( '__test_secret__' );
+        $decodedToken = $verifier->verifyAndDecode( self::getToken() );
+
+        $this->assertEquals('__test_sub__', $decodedToken->getClaim('sub'));
+    }
+
+    /*
+     * Helper methods
+     */
+
+    /**
+     * Returns a token builder with a default sub claim.
+     *
+     * @return Builder
+     */
+    public static function getTokenBuilder() : Builder
+    {
+        return (new Builder())->withClaim('sub', '__test_sub__');
+    }
+
+    /**
+     * @param string $secret Symmetric key to sign.
+     * @param Builder $builder Builder to use, null to create
+     *
+     * @return Token
+     */
+    public static function getToken(string $secret = '__test_secret__', Builder $builder = null) : Token
+    {
+        $builder = $builder ?? self::getTokenBuilder();
+        return $builder->getToken( new HsSigner(), new Key($secret));
+    }
+}

--- a/tests/testWPAuth0Helpers.php
+++ b/tests/testWPAuth0Helpers.php
@@ -82,18 +82,21 @@ class TestWPAuth0Helpers extends WP_Auth0_Test_Case {
 
 	public function testThatAuth0QueryVarsArePresent() {
 		$vars = wp_auth0_register_query_vars( [] );
-		$this->assertCount( 6, $vars );
+		$this->assertCount( 9, $vars );
 		$this->assertContains( 'error', $vars );
 		$this->assertContains( 'error_description', $vars );
 		$this->assertContains( 'a0_action', $vars );
 		$this->assertContains( 'auth0', $vars );
 		$this->assertContains( 'state', $vars );
 		$this->assertContains( 'code', $vars );
+		$this->assertContains( 'invitation', $vars );
+		$this->assertContains( 'organization', $vars );
+		$this->assertContains( 'organization_name', $vars );
 	}
 
 	public function testThatQueryVarsAreAddedProperly() {
 		$vars = wp_auth0_register_query_vars( [ '__test_var__' ] );
-		$this->assertCount( 7, $vars );
+		$this->assertCount( 10, $vars );
 		$this->assertContains( '__test_var__', $vars );
 	}
 }

--- a/tests/testWPAuth0Options.php
+++ b/tests/testWPAuth0Options.php
@@ -20,7 +20,7 @@ class TestWPAuth0Options extends WP_Auth0_Test_Case {
 	/**
 	 * Total number of options.
 	 */
-	const DEFAULT_OPTIONS_COUNT = 37;
+	const DEFAULT_OPTIONS_COUNT = 38;
 
 	/**
 	 * Test the basic options functionality.


### PR DESCRIPTION
This PR includes changes necessary for the WordPress plugin to support Auth0 Organizations.

- Adds a configurable 'Organization' option to the plugin's UI within the WordPress Admin Dashboard.
- Once defined, the Organization Id is passed along to the Universal Login Page.
- The org_id claim on JWTs is validated against the configured organization.
- Invitations (?invitation,organization,organization_name query parameters) are automatically detected and handled.
- Updated README with details about Organizations.
- Added additional tests covering these changes