### PR TITLE
[SDK-2785] Enable passing extra custom parameters to the New Universal Login

### DIFF
--- a/WP_Auth0.php
+++ b/WP_Auth0.php
@@ -3,7 +3,7 @@
  * Plugin Name: Login by Auth0
  * Plugin URL: https://auth0.com/docs/cms/wordpress
  * Description: Login by Auth0 provides improved username/password login, passwordless login, social login, multi-factor authentication, and single sign-on for all your sites.
- * Version: 4.3.1
+ * Version: 4.3.2
  * Author: Auth0
  * Author URI: https://auth0.com
  * Text Domain: wp-auth0

--- a/WP_Auth0.php
+++ b/WP_Auth0.php
@@ -9,7 +9,7 @@
  * Text Domain: wp-auth0
  */
 
-define( 'WPA0_VERSION', '4.3.1' );
+define( 'WPA0_VERSION', '4.3.2' );
 define( 'AUTH0_DB_VERSION', 23 );
 
 define( 'WPA0_PLUGIN_FILE', __FILE__ );

--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -64,7 +64,7 @@ jQuery(document).ready(function ($) {
         );
 
         matches.forEach(function (match) {
-          match.style.display = this.checked ? "block" : "none";
+          match.style.display = element.checked ? "block" : "none";
         });
       });
 

--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -57,23 +57,18 @@ jQuery(document).ready(function ($) {
     .querySelectorAll('[data-expand]:not([data-expand=""])')
     .forEach(function (element) {
       element.addEventListener("change", function () {
+        console.log("event fired");
         var group = (this.getAttribute("data-expand") ?? "").trim();
         var matches = document.querySelectorAll(
           ["#" + group, '[data-group*="' + group + '"]'].join(",")
         );
 
-        if (this.checked) {
-          matches.forEach(function (match) {
-            match.style.display = "none";
-          });
-        } else {
-          matches.forEach(function (match) {
-            match.style.display = "block";
-          });
-        }
+        matches.forEach(function (match) {
+          match.style.display = this.checked ? "block" : "none";
+        });
       });
 
-      document.dispatchEvent(new CustomEvent("change"));
+      element.dispatchEvent(new CustomEvent("change"));
     });
 
   /*

--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -58,6 +58,11 @@ jQuery(document).ready(function ($) {
     .forEach(function (element) {
       element.addEventListener("change", function () {
         var group = (this.getAttribute("data-expand") ?? "").trim();
+
+        if (!group.length) {
+          return;
+        }
+
         var matches = document.querySelectorAll(
           ["#" + group, '[data-group*="' + group + '"]'].join(",")
         );

--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -54,7 +54,7 @@ jQuery(document).ready(function ($) {
     Show/hide field for specific switches
      */
   document
-    .querySelectorAll('[data-expand][data-expand!=""]')
+    .querySelectorAll('[data-expand]:not([data-expand=""])')
     .forEach(function (element) {
       element.addEventListener("change", function () {
         console.log(this);

--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -1,167 +1,189 @@
 /* global jQuery, wpa0, wp */
-jQuery(document).ready(function($) {
-    //uploading files variable
-    var media_frame;
-    $(document).on('click', '#wpa0_choose_icon', function(event) {
-        event.preventDefault();
-        //If the frame already exists, reopen it
-        if (typeof(media_frame)!=="undefined") {
-            media_frame.close();
-        }
+jQuery(document).ready(function ($) {
+  //uploading files variable
+  var media_frame;
+  $(document).on("click", "#wpa0_choose_icon", function (event) {
+    event.preventDefault();
+    //If the frame already exists, reopen it
+    if (typeof media_frame !== "undefined") {
+      media_frame.close();
+    }
 
-        var related_control_id = 'wpa0_icon_url';
-        if (typeof($(this).attr('related')) != 'undefined' &&
-            $(this).attr('related') != '')
-        {
-            related_control_id = $(this).attr('related');
-        }
+    var related_control_id = "wpa0_icon_url";
+    if (
+      typeof $(this).attr("related") != "undefined" &&
+      $(this).attr("related") != ""
+    ) {
+      related_control_id = $(this).attr("related");
+    }
 
-        //Create WP media frame.
-        media_frame = wp.media.frames.customHeader = wp.media({
-            title: wpa0.media_title,
-            library: {
-                type: 'image'
-            },
-            button: {
-                text: wpa0.media_button
-            },
-            multiple: false
-        });
-
-        // Set the frame callback
-        media_frame.on('select', function() {
-            var attachment = media_frame.state().get('selection').first().toJSON();
-            $('#'+related_control_id).val(attachment.url).change();
-        });
-
-        //Open modal
-        media_frame.open();
+    //Create WP media frame.
+    media_frame = wp.media.frames.customHeader = wp.media({
+      title: wpa0.media_title,
+      library: {
+        type: "image",
+      },
+      button: {
+        text: wpa0.media_button,
+      },
+      multiple: false,
     });
 
-    /*
+    // Set the frame callback
+    media_frame.on("select", function () {
+      var attachment = media_frame.state().get("selection").first().toJSON();
+      $("#" + related_control_id)
+        .val(attachment.url)
+        .change();
+    });
+
+    //Open modal
+    media_frame.open();
+  });
+
+  /*
     Generic form confirm stop
      */
-    $('form.js-a0-confirm-submit').submit(function (e) {
-        if ( cancelAction($(this)) ) {
-            e.preventDefault();
-        }
-    });
+  $("form.js-a0-confirm-submit").submit(function (e) {
+    if (cancelAction($(this))) {
+      e.preventDefault();
+    }
+  });
 
-    /*
+  /*
     Show/hide field for specific switches
      */
-    $('[data-expand][data-expand!=""]').each( function() {
-        var $thisSwitch = $( this );
-        var $showFieldRow = $( '#' + $thisSwitch.attr( 'data-expand' ).trim() ).closest( 'tr' );
+  document
+    .querySelectorAll('[data-expand][data-expand!=""]')
+    .forEach(function (element) {
+      element.addEventListener("change", function () {
+        console.log(this);
+        var group = this.attr("data-expand").trim();
+        var matches = document.querySelectorAll(
+          join(",", ["#" + group, '[data-group*="' + group + '"]'])
+        );
 
-        if ( $showFieldRow.length ) {
-            if ( ! $thisSwitch.prop( 'checked' ) ) {
-                $showFieldRow.hide();
-            }
-            $thisSwitch.change(function() {
-                if ( $( this ).prop( 'checked' ) ) {
-                    $showFieldRow.show();
-                } else {
-                    $showFieldRow.hide();
-                }
-            } );
+        if (this.checked) {
+          matches.forEach(function (match) {
+            match.style.display = "none";
+          });
+        } else {
+          matches.forEach(function (match) {
+            match.style.display = "block";
+          });
         }
+      });
+
+      document.dispatchEvent(new CustomEvent("change"));
     });
 
-    /*
+  /*
     Admin settings tab switching
      */
-    var currentTab;
-    if ( window.location.hash ) {
-        currentTab = window.location.hash.replace( '#', '' );
-    } else if ( localStorageAvailable() && window.localStorage.getItem( 'Auth0WPSettingsTab' ) ) {
-        // Previous tab being used
-        currentTab = window.localStorage.getItem( 'Auth0WPSettingsTab' );
-    } else {
-        // Default tab if no saved tab was found
-        currentTab = 'features';
+  var currentTab;
+  if (window.location.hash) {
+    currentTab = window.location.hash.replace("#", "");
+  } else if (
+    localStorageAvailable() &&
+    window.localStorage.getItem("Auth0WPSettingsTab")
+  ) {
+    // Previous tab being used
+    currentTab = window.localStorage.getItem("Auth0WPSettingsTab");
+  } else {
+    // Default tab if no saved tab was found
+    currentTab = "features";
+  }
+
+  togglePanelVisibility(currentTab);
+  togglePanelVisibility("import");
+
+  // Controls whether the submit button is showing or not
+  var $settingsForm = $("#js-a0-settings-form");
+  $settingsForm.attr("data-tab-showing", currentTab);
+
+  // Set the tab showing on the form and persist the tab
+  $(".js-a0-settings-tabs").click(function (e) {
+    e.preventDefault();
+    window.location.hash = "";
+    var tabName = $(this).attr("id").trim().replace("tab-", "");
+    $settingsForm.attr("data-tab-showing", tabName);
+
+    if (localStorageAvailable()) {
+      window.localStorage.setItem("Auth0WPSettingsTab", tabName);
     }
 
-    togglePanelVisibility(currentTab);
-    togglePanelVisibility('import');
+    togglePanelVisibility(tabName);
+  });
 
-    // Controls whether the submit button is showing or not
-    var $settingsForm = $( '#js-a0-settings-form' );
-    $settingsForm.attr( 'data-tab-showing', currentTab );
+  // Set the tab showing on the form and persist the tab
+  $(".js-a0-import-export-tabs").click(function (e) {
+    e.preventDefault();
+    window.location.hash = "";
+    var tabName = $(this).attr("id").trim().replace("tab-", "");
+    togglePanelVisibility(tabName);
+  });
 
-    // Set the tab showing on the form and persist the tab
-    $( '.js-a0-settings-tabs' ).click( function (e) {
-        e.preventDefault();
-        window.location.hash = '';
-        var tabName = $( this ).attr( 'id' ).trim().replace( 'tab-', '' );
-        $settingsForm.attr( 'data-tab-showing', tabName );
-
-        if ( localStorageAvailable() ) {
-            window.localStorage.setItem( 'Auth0WPSettingsTab', tabName );
-        }
-
-        togglePanelVisibility(tabName);
-    } );
-
-    // Set the tab showing on the form and persist the tab
-    $( '.js-a0-import-export-tabs' ).click( function (e) {
-        e.preventDefault();
-        window.location.hash = '';
-        var tabName = $( this ).attr( 'id' ).trim().replace( 'tab-', '' );
-        togglePanelVisibility(tabName);
-    } );
-
-    function togglePanelVisibility(activeId) {
-      var $showPanel = $('#panel-' + activeId);
-      if (!$showPanel.length) {
-        return;
-      }
-      $('.tab-pane').hide();
-      $('.nav-tabs a').removeClass( 'a0-active-tab' );
-      $showPanel.show();
-      $('#tab-' + activeId).addClass( 'a0-active-tab' );
+  function togglePanelVisibility(activeId) {
+    var $showPanel = $("#panel-" + activeId);
+    if (!$showPanel.length) {
+      return;
     }
+    $(".tab-pane").hide();
+    $(".nav-tabs a").removeClass("a0-active-tab");
+    $showPanel.show();
+    $("#tab-" + activeId).addClass("a0-active-tab");
+  }
 
-    /*
+  /*
     Clear cache button on Basic settings page
      */
-    var deleteCacheId = 'auth0_delete_cache_transient';
-    var $deleteCacheButton = $( '#' + deleteCacheId );
-    $deleteCacheButton.click( function(e) {
-        e.preventDefault();
-        $deleteCacheButton.prop( 'disabled', true ).text( wpa0.ajax_working );
-        var postData = {
-            'action': deleteCacheId,
-            '_ajax_nonce': wpa0.clear_cache_nonce
-        };
+  var deleteCacheId = "auth0_delete_cache_transient";
+  var $deleteCacheButton = $("#" + deleteCacheId);
+  $deleteCacheButton.click(function (e) {
+    e.preventDefault();
+    $deleteCacheButton.prop("disabled", true).text(wpa0.ajax_working);
+    var postData = {
+      action: deleteCacheId,
+      _ajax_nonce: wpa0.clear_cache_nonce,
+    };
 
-        $.post(wpa0.ajax_url, postData, function() {
-            $deleteCacheButton.prop( 'disabled', false ).text( wpa0.ajax_done );
-        }, 'json');
-    } );
+    $.post(
+      wpa0.ajax_url,
+      postData,
+      function () {
+        $deleteCacheButton.prop("disabled", false).text(wpa0.ajax_done);
+      },
+      "json"
+    );
+  });
 
-    /*
+  /*
     Generate new migration token button on Advanced settings page
      */
-    var rotateTokenId = 'auth0_rotate_migration_token';
-    var $rotateTokenButton = $( '#' + rotateTokenId );
-    $rotateTokenButton.click( function(e) {
-        e.preventDefault();
+  var rotateTokenId = "auth0_rotate_migration_token";
+  var $rotateTokenButton = $("#" + rotateTokenId);
+  $rotateTokenButton.click(function (e) {
+    e.preventDefault();
 
-        if (cancelAction($rotateTokenButton) ) {
-            return;
-        }
+    if (cancelAction($rotateTokenButton)) {
+      return;
+    }
 
-        $rotateTokenButton.prop( 'disabled', true ).text( wpa0.ajax_working );
-        var postData = {
-            'action': rotateTokenId,
-            '_ajax_nonce': wpa0.rotate_token_nonce
-        };
-        $.post(wpa0.ajax_url, postData, function() {
-            $( '#auth0_migration_token' ).text(wpa0.refresh_prompt);
-            $rotateTokenButton.remove();
-        }, 'json');
-    } );
+    $rotateTokenButton.prop("disabled", true).text(wpa0.ajax_working);
+    var postData = {
+      action: rotateTokenId,
+      _ajax_nonce: wpa0.rotate_token_nonce,
+    };
+    $.post(
+      wpa0.ajax_url,
+      postData,
+      function () {
+        $("#auth0_migration_token").text(wpa0.refresh_prompt);
+        $rotateTokenButton.remove();
+      },
+      "json"
+    );
+  });
 
   /**
    * Show a JS confirm box to give a chance to cancel an on-page action.
@@ -170,29 +192,28 @@ jQuery(document).ready(function($) {
    *
    * @returns {boolean}
    */
-  function cancelAction( $el ) {
-      var message = $el.attr('data-confirm-msg');
-      if ( !message || !message.length ) {
-        message = wpa0.form_confirm_submit_msg;
-      }
-
-      return !window.confirm(message);
+  function cancelAction($el) {
+    var message = $el.attr("data-confirm-msg");
+    if (!message || !message.length) {
+      message = wpa0.form_confirm_submit_msg;
     }
 
-    /**
-     * Can we use localStorage?
-     *
-     * @returns {boolean}
-     */
-    function localStorageAvailable() {
-        try {
-            var x = '__Auth0_localStorage_assertion__';
-            window.localStorage.setItem(x, x);
-            window.localStorage.removeItem(x);
-            return true;
-        }
-        catch(e) {
-            return false;
-        }
+    return !window.confirm(message);
+  }
+
+  /**
+   * Can we use localStorage?
+   *
+   * @returns {boolean}
+   */
+  function localStorageAvailable() {
+    try {
+      var x = "__Auth0_localStorage_assertion__";
+      window.localStorage.setItem(x, x);
+      window.localStorage.removeItem(x);
+      return true;
+    } catch (e) {
+      return false;
     }
+  }
 });

--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -64,7 +64,9 @@ jQuery(document).ready(function ($) {
         );
 
         matches.forEach(function (match) {
-          match.style.display = element.checked ? "block" : "none";
+          match.closest("tr").style.display = element.checked
+            ? "block"
+            : "none";
         });
       });
 

--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -57,7 +57,6 @@ jQuery(document).ready(function ($) {
     .querySelectorAll('[data-expand]:not([data-expand=""])')
     .forEach(function (element) {
       element.addEventListener("change", function () {
-        console.log("event fired");
         var group = (this.getAttribute("data-expand") ?? "").trim();
         var matches = document.querySelectorAll(
           ["#" + group, '[data-group*="' + group + '"]'].join(",")

--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -65,7 +65,7 @@ jQuery(document).ready(function ($) {
 
         matches.forEach(function (match) {
           match.closest("tr").style.display = element.checked
-            ? "block"
+            ? "revert"
             : "none";
         });
       });

--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -57,8 +57,7 @@ jQuery(document).ready(function ($) {
     .querySelectorAll('[data-expand]:not([data-expand=""])')
     .forEach(function (element) {
       element.addEventListener("change", function () {
-        console.log(this);
-        var group = this.attr("data-expand").trim();
+        var group = (this.getAttribute("data-expand") ?? "").trim();
         var matches = document.querySelectorAll(
           join(",", ["#" + group, '[data-group*="' + group + '"]'])
         );

--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -59,7 +59,7 @@ jQuery(document).ready(function ($) {
       element.addEventListener("change", function () {
         var group = (this.getAttribute("data-expand") ?? "").trim();
         var matches = document.querySelectorAll(
-          join(",", ["#" + group, '[data-group*="' + group + '"]'])
+          ["#" + group, '[data-group*="' + group + '"]'].join(",")
         );
 
         if (this.checked) {

--- a/lib/WP_Auth0_LoginManager.php
+++ b/lib/WP_Auth0_LoginManager.php
@@ -449,8 +449,14 @@ class WP_Auth0_LoginManager {
 		// phpcs:disable WordPress.Security.NonceVerification.NoNonceVerification
 
 		$opts = WP_Auth0_Options::Instance();
+		$customParams = trim($opts->get('auto_login_params') ?? '');
+		$params = [];
 
-		$params = [
+		if ($customParams) {
+			parse_str($customParams, $params);
+		}
+
+		$params = array_merge($params, [
 			'connection'    => $connection,
 			'client_id'     => $opts->get( 'client_id' ),
 			'organization'  => $opts->get( 'organization' ),
@@ -460,7 +466,7 @@ class WP_Auth0_LoginManager {
 			'response_type' => 'code',
 			'response_mode' => 'query',
 			'redirect_uri'  => $opts->get_wp_auth0_url(),
-		];
+		]);
 
 		// Where should the user be redirected after logging in?
 		if ( empty( $redirect_to ) ) {

--- a/lib/WP_Auth0_Options.php
+++ b/lib/WP_Auth0_Options.php
@@ -394,6 +394,7 @@ class WP_Auth0_Options {
 
 			// Features
 			'auto_login'                => true,
+			'auto_login_params'         => '',
 			'auto_login_method'         => '',
 			'singlelogout'              => true,
 			'override_wp_avatars'       => true,

--- a/lib/admin/WP_Auth0_Admin_Features.php
+++ b/lib/admin/WP_Auth0_Admin_Features.php
@@ -101,7 +101,7 @@ class WP_Auth0_Admin_Features extends WP_Auth0_Admin_Generic {
 	 * @see add_settings_field()
 	 */
 	public function render_auto_login_params( $args = [] ) {
-		$this->render_switch( $args['label_for'], $args['opt_name'], 'wpa0_auto_login_params' );
+		$this->render_text_field( $args['label_for'], $args['opt_name'] );
 		$this->render_field_description(
 			__( 'Optional. Here you can specify additional parameters to pass to the the Universal Login Page (ULP) during authentication. ', 'wp-auth0' ) .
 			__( 'For example, you can specify <code>screen_hint=signup</code> or <code>prompt=login</code> parameters here. ', 'wp-auth0' ) .

--- a/lib/admin/WP_Auth0_Admin_Features.php
+++ b/lib/admin/WP_Auth0_Admin_Features.php
@@ -156,6 +156,7 @@ class WP_Auth0_Admin_Features extends WP_Auth0_Admin_Generic {
 	 */
 	public function basic_validation( array $input ) {
 		$input['auto_login']          = $this->sanitize_switch_val( $input['auto_login'] ?? null );
+		$input['auto_login_params']   = $this->sanitize_text_val( $input['auto_login_params'] ?? null );
 		$input['auto_login_method']   = $this->sanitize_text_val( $input['auto_login_method'] ?? null );
 		$input['singlelogout']        = $this->sanitize_switch_val( $input['singlelogout'] ?? null );
 		$input['override_wp_avatars'] = $this->sanitize_switch_val( $input['override_wp_avatars'] ?? null );

--- a/lib/admin/WP_Auth0_Admin_Features.php
+++ b/lib/admin/WP_Auth0_Admin_Features.php
@@ -156,7 +156,7 @@ class WP_Auth0_Admin_Features extends WP_Auth0_Admin_Generic {
 	 */
 	public function basic_validation( array $input ) {
 		$input['auto_login']          = $this->sanitize_switch_val( $input['auto_login'] ?? null );
-		$input['auto_login_params']   = $this->sanitize_text_val( $input['auto_login_params'] ?? null );
+		$input['auto_login_params']   = $this->sanitize_query_parameters( $input['auto_login_params'] ?? null );
 		$input['auto_login_method']   = $this->sanitize_text_val( $input['auto_login_method'] ?? null );
 		$input['singlelogout']        = $this->sanitize_switch_val( $input['singlelogout'] ?? null );
 		$input['override_wp_avatars'] = $this->sanitize_switch_val( $input['override_wp_avatars'] ?? null );

--- a/lib/admin/WP_Auth0_Admin_Features.php
+++ b/lib/admin/WP_Auth0_Admin_Features.php
@@ -82,7 +82,7 @@ class WP_Auth0_Admin_Features extends WP_Auth0_Admin_Generic {
 	 * @see add_settings_field()
 	 */
 	public function render_auto_login( $args = [] ) {
-		$this->render_switch( $args['label_for'], $args['opt_name'], 'wpa0_auto_login_method' );
+		$this->render_switch( $args['label_for'], $args['opt_name'], 'wpa0_auto_login_options' );
 		$this->render_field_description(
 			__( 'Use the Universal Login Page (ULP) for authentication and SSO. ', 'wp-auth0' ) .
 			__( 'When turned on, <code>wp-login.php</code> will redirect to the hosted login page. ', 'wp-auth0' ) .
@@ -101,7 +101,7 @@ class WP_Auth0_Admin_Features extends WP_Auth0_Admin_Generic {
 	 * @see add_settings_field()
 	 */
 	public function render_auto_login_params( $args = [] ) {
-		$this->render_text_field( $args['label_for'], $args['opt_name'] );
+		$this->render_text_field( $args['label_for'], $args['opt_name'], '', '', '', 'wpa0_auto_login_options' );
 		$this->render_field_description(
 			__( 'Optional. Here you can specify additional parameters to pass to the the Universal Login Page (ULP) during authentication. ', 'wp-auth0' ) .
 			__( 'For example, you can specify <code>screen_hint=signup</code> or <code>prompt=login</code> parameters here. ', 'wp-auth0' ) .
@@ -119,7 +119,7 @@ class WP_Auth0_Admin_Features extends WP_Auth0_Admin_Generic {
 	 * @see add_settings_field()
 	 */
 	public function render_auto_login_method( $args = [] ) {
-		$this->render_text_field( $args['label_for'], $args['opt_name'] );
+		$this->render_text_field( $args['label_for'], $args['opt_name'], '', '', '', 'wpa0_auto_login_options' );
 		$this->render_field_description(
 			__( 'Enter a name here to automatically use a single, specific connection to login . ', 'wp-auth0' ) .
 			sprintf(

--- a/lib/admin/WP_Auth0_Admin_Features.php
+++ b/lib/admin/WP_Auth0_Admin_Features.php
@@ -28,6 +28,12 @@ class WP_Auth0_Admin_Features extends WP_Auth0_Admin_Generic {
 				'function' => 'render_auto_login',
 			],
 			[
+				'name'     => __( 'ULP Login Parameters', 'wp-auth0' ),
+				'opt'      => 'auto_login_params',
+				'id'       => 'wpa0_auto_login_params',
+				'function' => 'render_auto_login_params',
+			],
+			[
 				'name'     => __( 'Auto Login Method', 'wp-auth0' ),
 				'opt'      => 'auto_login_method',
 				'id'       => 'wpa0_auto_login_method',
@@ -82,6 +88,24 @@ class WP_Auth0_Admin_Features extends WP_Auth0_Admin_Generic {
 			__( 'When turned on, <code>wp-login.php</code> will redirect to the hosted login page. ', 'wp-auth0' ) .
 			__( 'When turned off, <code>wp-login.php</code> will show an embedded login form. ', 'wp-auth0' ) .
 			$this->get_docs_link( 'guides/login/universal-vs-embedded', __( 'More on ULP vs embedded here', 'wp-auth0' ) )
+		);
+	}
+
+	/**
+	 * Render form field and description for the `auto_login_params` option.
+	 * IMPORTANT: Internal callback use only, do not call this function directly!
+	 *
+	 * @param array $args - callback args passed in from add_settings_field().
+	 *
+	 * @see WP_Auth0_Admin_Generic::init_option_section()
+	 * @see add_settings_field()
+	 */
+	public function render_auto_login_params( $args = [] ) {
+		$this->render_switch( $args['label_for'], $args['opt_name'], 'wpa0_auto_login_params' );
+		$this->render_field_description(
+			__( 'Optional. Here you can specify additional parameters to pass to the the Universal Login Page (ULP) during authentication. ', 'wp-auth0' ) .
+			__( 'For example, you can specify <code>screen_hint=signup</code> or <code>prompt=login</code> parameters here. ', 'wp-auth0' ) .
+			$this->get_docs_link( 'docs/login/universal-login/new-experience', __( 'Learn more about available ULP parameters here', 'wp-auth0' ) )
 		);
 	}
 

--- a/lib/admin/WP_Auth0_Admin_Features.php
+++ b/lib/admin/WP_Auth0_Admin_Features.php
@@ -28,7 +28,7 @@ class WP_Auth0_Admin_Features extends WP_Auth0_Admin_Generic {
 				'function' => 'render_auto_login',
 			],
 			[
-				'name'     => __( 'ULP Login Parameters', 'wp-auth0' ),
+				'name'     => __( 'Auto Login Parameters', 'wp-auth0' ),
 				'opt'      => 'auto_login_params',
 				'id'       => 'wpa0_auto_login_params',
 				'function' => 'render_auto_login_params',

--- a/lib/admin/WP_Auth0_Admin_Generic.php
+++ b/lib/admin/WP_Auth0_Admin_Generic.php
@@ -287,6 +287,8 @@ class WP_Auth0_Admin_Generic {
 			$sanitized[$this->sanitize_text_val($key)] = $this->sanitize_text_val($value);
 		}
 
-		return http_build_query(array_filter($sanitized));
+		return http_build_query(array_filter($sanitized, function($var) {
+			return ($var !== null && $var !== false && trim($var) !== '');
+		}));
 	}
 }

--- a/lib/admin/WP_Auth0_Admin_Generic.php
+++ b/lib/admin/WP_Auth0_Admin_Generic.php
@@ -274,6 +274,19 @@ class WP_Auth0_Admin_Generic {
 	}
 
 	protected function sanitize_query_parameters( $val ) {
-		return http_build_query(explode('&', sanitize_text_field(trim(strval($val)))));
+		$val = trim(strval($val));
+
+		if (strlen($val) === 0) {
+			return '';
+		}
+
+		parse_str($val, $parsed);
+		$sanitized = [];
+
+		foreach ($parsed as $key => $value) {
+			$sanitized[$this->sanitize_text_val($key)] = $this->sanitize_text_val($value);
+		}
+
+		return http_build_query($sanitized);
 	}
 }

--- a/lib/admin/WP_Auth0_Admin_Generic.php
+++ b/lib/admin/WP_Auth0_Admin_Generic.php
@@ -287,6 +287,6 @@ class WP_Auth0_Admin_Generic {
 			$sanitized[$this->sanitize_text_val($key)] = $this->sanitize_text_val($value);
 		}
 
-		return http_build_query($sanitized);
+		return http_build_query(array_filter($sanitized));
 	}
 }

--- a/lib/admin/WP_Auth0_Admin_Generic.php
+++ b/lib/admin/WP_Auth0_Admin_Generic.php
@@ -272,4 +272,8 @@ class WP_Auth0_Admin_Generic {
 	protected function sanitize_text_val( $val ) {
 		return sanitize_text_field( trim( strval( $val ) ) );
 	}
+
+	protected function sanitize_query_parameters( $val ) {
+		return http_build_query(explode('&', sanitize_text_field(trim(strval($val)))));
+	}
 }

--- a/lib/admin/WP_Auth0_Admin_Generic.php
+++ b/lib/admin/WP_Auth0_Admin_Generic.php
@@ -123,8 +123,9 @@ class WP_Auth0_Admin_Generic {
 	 * @param string $type - input type attribute
 	 * @param string $placeholder - input placeholder
 	 * @param string $style - inline CSS
+	 * @param string $grouping - A string representing a one or more items in a grouping of related settings that will have their visibility toggled by a switch state.
 	 */
-	protected function render_text_field( $id, $input_name, $type = 'text', $placeholder = '', $style = '' ) {
+	protected function render_text_field( $id, $input_name, $type = 'text', $placeholder = '', $style = '', $grouping = '' ) {
 		$value = $this->options->get( $input_name );
 
 		// Secure fields are not output by default; validation keeps last value if a new one is not entered
@@ -136,7 +137,8 @@ class WP_Auth0_Admin_Generic {
 			$this->render_const_notice( $input_name );
 		}
 		printf(
-			'<input type="%s" name="%s[%s]" id="%s" value="%s" placeholder="%s" style="%s" %s>',
+			'<input data-group="%s" type="%s" name="%s[%s]" id="%s" value="%s" placeholder="%s" style="%s" %s>',
+			esc_attr( $grouping ),
 			esc_attr( $type ),
 			esc_attr( $this->_option_name ),
 			esc_attr( $input_name ),

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Requires at least: 5.4.2
 Requires PHP: 7.3
 License: MIT
 License URI: https://github.com/auth0/wp-auth0/blob/master/LICENSE
-Stable tag: 4.3.1
+Stable tag: 4.3.2
 Contributors: auth0, auth0josh, evansims
 
 Login by Auth0 provides improved username/password login, Passwordless login, Social login and Single Sign On for all your sites.


### PR DESCRIPTION
### Description

This PR:
- Adds new UI support for toggling groups of UI elements in the plugin's WP dashboard, for making additional configuration options available when certain switch options are enabled. Previously, we could only toggle a single associated UI option, which limited what we could do with our dashboard interface.
- Adds a new login parameters configuration option for passing custom parameters to the NULP authorization redirect, enabling use of parameters like `screen_hint` and `prompt`, to customize the experience.
- Updates the dashboard UI to reflect the availability of this new configuration option, and updates the NULP switch to toggle the appearance of all dependent options.

### References

- Please see internal ticket SDK-2785 or contact me via Slack with any questions.

### Testing

I am working on a separate PR to completely rework the testing process of this library to make it more portable and require less setup effort, and which will include expanded testing support for this new behavior. PR should be available for review yet this week. In the meantime be advised that all existing tests pass successfully.

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `master`
