### PR TITLE
fix(UsersRepo): pass `$value` in `auth0_update_meta` filter

### DIFF
--- a/lib/WP_Auth0_UsersRepo.php
+++ b/lib/WP_Auth0_UsersRepo.php
@@ -219,8 +219,9 @@ class WP_Auth0_UsersRepo {
 		 *
 		 * @param integer $user_id The user ID.
 		 * @param string  $key     The meta key.
+		 * @param mixed   $value   The meta value.
 		 */
-		$check = apply_filters( 'auth0_update_meta', null, $user_id, $key );
+		$check = apply_filters( 'auth0_update_meta', null, $user_id, $key, $value );
 		if ( $check !== null ) {
 			return (bool) $check;
 		}


### PR DESCRIPTION
### Description

The WP_Auth0_UsersRepo class manages WordPress user meta that is stored by Auth0.

The class contains a series of filters that allow developers to short-circuit methods. The idea behind this is that developers can implement their own way of managing user metadata stored by Auth0.

Currently the method for updating metadata does not pass the `$value` that is being updated. It only passes the key, which makes it impossible to adequately short-circuit.

### References

- #811
- #812

### Testing

The current test in [`TestUserRepoMeta::testUpdateMetaFilterWorksProperly`](https://github.com/tharsheblows/wp-auth0/blob/27bfc3a41a400caa536c91c0b4b53152c45fdf28/tests/testUserRepoMeta.php#L202-L233) does not adequately test this feature and should be updated.

This PR does not update the test.

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
  - I added the proper doc block above the filter, but otherwise none of these filters appear to be documented elsewhere.
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`
