### PR TITLE
Add option to disable logs in Wordpress

### DIFF
--- a/lib/WP_Auth0_ErrorLog.php
+++ b/lib/WP_Auth0_ErrorLog.php
@@ -117,6 +117,14 @@ class WP_Auth0_ErrorLog {
 		return update_option( self::OPTION_NAME, $log );
 	}
 
+	public static function check_is_disabled() {
+		$flag = wp_auth0_get_option( 'auth0_disable_logging' );
+		if ( is_bool( $flag ) ) {
+			return $flag;
+		}
+		return false;
+	}
+
 	/**
 	 * Create a row in the error log.
 	 *
@@ -126,6 +134,10 @@ class WP_Auth0_ErrorLog {
 	 * @return bool
 	 */
 	public static function insert_error( $section, $error ) {
+
+		if ( self::check_is_disabled() ) {
+			return false;
+		}
 
 		$new_entry = [
 			'section' => $section,

--- a/lib/WP_Auth0_Options.php
+++ b/lib/WP_Auth0_Options.php
@@ -424,6 +424,7 @@ class WP_Auth0_Options {
 			'migration_ips'             => '',
 			'valid_proxy_ip'            => '',
 			'auth0_server_domain'       => 'auth0.auth0.com',
+			'auth0_disable_logging'     => false,
 		];
 	}
 }

--- a/lib/admin/WP_Auth0_Admin_Advanced.php
+++ b/lib/admin/WP_Auth0_Admin_Advanced.php
@@ -114,6 +114,12 @@ class WP_Auth0_Admin_Advanced extends WP_Auth0_Admin_Generic {
 				'id'       => 'wpa0_auth0_server_domain',
 				'function' => 'render_auth0_server_domain',
 			],
+			[
+				'name'     => __( 'Disable Auth0 logging in Wordpress', 'wp-auth0' ),
+				'opt'      => 'auth0_disable_logging',
+				'id'       => 'wpa0_auth0_disable_logging',
+				'function' => 'render_auth0_disable_logging',
+			],
 		];
 
 		$this->init_option_section( '', 'advanced', $options );
@@ -221,8 +227,25 @@ class WP_Auth0_Admin_Advanced extends WP_Auth0_Admin_Generic {
 	public function render_auto_provisioning( $args = [] ) {
 		$this->render_switch( $args['label_for'], $args['opt_name'] );
 		$this->render_field_description(
-			__( 'Create new users in the WordPress database when signups are off. ', 'wp-auth0' ) .
-			__( 'Signups will not be allowed but successful Auth0 logins will add the user in WordPress', 'wp-auth0' )
+			__( 'Disables Auth0 logging within WordPress. ', 'wp-auth0' ) .
+			__( 'If enabled, Auth0 logging will be disabled in WordPress. Other Auth0 logs are unaffected by this switch', 'wp-auth0' )
+		);
+	}
+
+	/**
+	 * Render form field and description for the `auth0_disable_logging` option.
+	 * IMPORTANT: Internal callback use only, do not call this function directly!
+	 *
+	 * @param array $args - callback args passed in from add_settings_field().
+	 *
+	 * @see WP_Auth0_Admin_Generic::init_option_section()
+	 * @see add_settings_field()
+	 */
+	public function render_auth0_disable_logging( $args = [] ) {
+		$this->render_switch( $args['label_for'], $args['opt_name'] );
+		$this->render_field_description(
+			__( 'A user session by default is kept for two days. ', 'wp-auth0' ) .
+			__( 'Enabling this setting will extend that and make the session be kept for 14 days', 'wp-auth0' )
 		);
 	}
 
@@ -361,8 +384,9 @@ class WP_Auth0_Admin_Advanced extends WP_Auth0_Admin_Generic {
 		// `migration_token` is sanitized in $this->migration_ws_validation() below.
 		$input['migration_ips_filter'] = $this->sanitize_switch_val( $input['migration_ips_filter'] ?? null );
 		// `migration_ips` is sanitized in $this->migration_ips_validation() below.
-		$input['valid_proxy_ip']      = ( isset( $input['valid_proxy_ip'] ) ? $input['valid_proxy_ip'] : null );
-		$input['auth0_server_domain'] = $this->sanitize_text_val( $input['auth0_server_domain'] ?? null );
+		$input['valid_proxy_ip']        = ( isset( $input['valid_proxy_ip'] ) ? $input['valid_proxy_ip'] : null );
+		$input['auth0_server_domain']   = $this->sanitize_text_val( $input['auth0_server_domain'] ?? null );
+		$input['auth0_disable_logging'] = $this->sanitize_switch_val( $input['auth0_disable_logging'] ?? null );
 		return $input;
 	}
 

--- a/tests/Unit/ErrorLogTest.php
+++ b/tests/Unit/ErrorLogTest.php
@@ -75,6 +75,38 @@ class ErrorLogTEst extends WP_Auth0_Test_Case {
 	}
 
 	/**
+	 * Test that the error does not log when logging is disabled.
+	 */
+	public function testErrorDoesNotLogWhenDisabled() {
+		self::$opts->set( 'auth0_disable_logging', true );
+
+		$error_code = 999;
+		$error_msg  = uniqid();
+		$wp_error   = new WP_Error( $error_code, $error_msg );
+		WP_Auth0_ErrorLog::insert_error( __METHOD__, $wp_error );
+
+		$this->assertEmpty( self::$error_log->get() );
+	}
+
+	/**
+	 * Test that the error does log when logging is enabled.
+	 */
+	public function testErrorDoesLogWhenLoggingEnabled() {
+		self::$opts->set( 'auth0_disable_logging', false );
+
+		$error_code = 999;
+		$error_msg  = 'testmsg';
+		$wp_error   = new WP_Error( $error_code, $error_msg );
+		WP_Auth0_ErrorLog::insert_error( __METHOD__, $wp_error );
+		$log = self::$error_log->get();
+
+		$this->assertEmpty( self::$error_log->get() );
+		$this->assertEquals( 1, $log[0]['count'] );
+		$this->assertEquals( $error_code, $log[0]['code'] );
+		$this->assertEquals( $error_msg, $log[0]['message'] );
+	}
+
+	/**
 	 * Test that a basic added log entries are properly stored.
 	 */
 	public function testAddLogEntries() {


### PR DESCRIPTION

### Description

This PR allows the ability to disable the logging of Auth0 errors in Wordpress. This is useful to reduce load, especially in hosted multisite configurations which can have many instances of `auth0_error_log` forced to stay in memory and to load on every request.

### References

> Include any links supporting this change such as a:
>
> - GitHub Issue/PR number addressed or fixed
> - Auth0 Community post
> - StackOverflow post
> - Support forum thread
> - Related pull requests/issues from other repos
>
> If there are no references, simply delete this section.

### Testing

> Describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.
>
> Please include any manual steps for testing end-to-end or functionality not covered by unit/integration tests.
>
> Also include details of the environment this PR was developed in (language/platform/browser version).

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `master`
