### PR TITLE
refactor: PHP 8.0+ compatibility improvements

### DIFF
--- a/lib/WP_Auth0_Nonce_Handler.php
+++ b/lib/WP_Auth0_Nonce_Handler.php
@@ -44,10 +44,7 @@ class WP_Auth0_Nonce_Handler {
 	 */
 	private function __clone() {}
 
-	/**
-	 * Private to prevent unserializing.
-	 */
-	private function __wakeup() {}
+	public function __wakeup() {}
 
 	/**
 	 * WP_Auth0_Nonce_Handler constructor.


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/.github/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

Change made to the `WP_Auth0_Nonce_Handler` class to refactoring access on function `__wakeup()` from _private_ to _public_, in support of PHP 8. According to the documentation [here](https://www.php.net/manual/en/language.oop5.magic.php), `E_WARNING` is now emitted for `__wakeup()` and the like where previously it was not.

### Testing

Tested against latest installable plugin from the Wordpress site.

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not the default branch
