### PR TITLE
Fix faulty expected value for allow_fallback option

### DIFF
--- a/src/Actions/Configuration.php
+++ b/src/Actions/Configuration.php
@@ -1059,7 +1059,7 @@ final class Configuration extends Base
 
         if ('fallback_secret' === $context && $this->isPluginReady()) {
             $fallbackAllowed = $this->getPlugin()->getOption('authentication', 'allow_fallback', 0);
-            if (1 === $fallbackAllowed) {
+            if ('true' === $fallbackAllowed) {
                 $updated = get_site_transient('auth0_updated_fallback');
 
                 if (! $updated) {


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/.github/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

`allow_fallback` option was expected to return a boolean value, but is actually returning a string value of `'true'|'false'`. This blocks the fallback URI from ever being shown on the options page.

### References

#902 

### Testing

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not the default branch
