### PR TITLE
PR: force logout upon token exchange failure

### DIFF
--- a/src/Actions/Authentication.php
+++ b/src/Actions/Authentication.php
@@ -495,7 +495,7 @@ final class Authentication extends Base
                 } catch (Throwable) {
                 }
 
-                wp_redirect('/');
+                $this->onLogout();
                 exit;
             }
 


### PR DESCRIPTION
When token exchange fails, currently a redirect to '/' takes place. Force logout client in both WordPress and auth0 to reset state.

### Use case:
In our case, we we're using a custom tenant domain, which handles the token exchange to verify whether access to the WordPress admin can be granted, for the client logging in.

If the exchange fails (401/403), the user will still be logged-in at the chosen authentication option.
However, if the client wants to login again at Wordpress ("/wp-admin"), auth0 states that the user is still logged in at the preferred login method. This will result in the same token exchange failure followed by a redirect to "/" by this plugin.

With this solution we always force both a WordPress logout and a logout at Auth0, making the user also be logged-out at auth0.

### Review:
I would like this proposal to be reviewed to verify whether this solution doesn't break any logic or this solution is contradary with oauth's guidelines/standard

By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/.github/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

> Describe the purpose of this PR along with any background information and the impacts of the proposed change. For the benefit of the community, please do not assume prior context.
>
> Provide details that support your chosen implementation, including: breaking changes, alternatives considered, changes to the API, etc.
>
> If the UI is being changed, please provide screenshots.


### References

> Include any links supporting this change such as a:
>
> - GitHub Issue/PR number addressed or fixed
> - Auth0 Community post
> - StackOverflow post
> - Support forum thread
> - Related pull requests/issues from other repos
>
> If there are no references, simply delete this section.

### Testing

> Describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.
>
> Please include any manual steps for testing end-to-end or functionality not covered by unit/integration tests.
>
> Also include details of the environment this PR was developed in (language/platform/browser version).

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not the default branch
