### PR TITLE
Fix error message sanitization

### DIFF
--- a/lib/WP_Auth0_Email_Verification.php
+++ b/lib/WP_Auth0_Email_Verification.php
@@ -51,6 +51,6 @@ class WP_Auth0_Email_Verification
 
 		$html = apply_filters('auth0_verify_email_page', $html, $userinfo, '');
 
-		wp_die(wp_kses($html, ['p' => [], 'a' => ['id' => true, 'href' => true], 'script' => ['src' => true]]));
+		wp_die(wp_kses_post($html));
 	}
 }

--- a/lib/WP_Auth0_LoginManager.php
+++ b/lib/WP_Auth0_LoginManager.php
@@ -616,7 +616,7 @@ class WP_Auth0_LoginManager
 
 		$html = apply_filters('auth0_die_on_login_output', esc_html($html), esc_html($msg), esc_html($code), false);
 
-		wp_die(wp_kses($html, ['br' => [], 'a' => ['href' => []]]));
+		wp_die(wp_kses_post($html));
 	}
 
 	/**


### PR DESCRIPTION
### Description

After upgrading from 4.6.0 to 4.6.2 the error messages have started to be interpreted as text instead of HTML. To the projects that use `auth0_verify_email_page` this can break the entire error page. This bug was reported on issue #910. 

My solution was to use `wp_kses_post` instead of just `wp_kses` to sanitize the error messages. This allows the projects to use any HTML tag already allowed in any WordPress post, so it's a safe way to sanitize the error messages.

### References

Issue #910 

### Testing

You can test it by generating authentication errors and checking if the error message is correctly interpreted as HTML instead of text.

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not the default branch
