### PR TITLE
Do not update_option for DB version on every request

### DIFF
--- a/lib/WP_Auth0_DBManager.php
+++ b/lib/WP_Auth0_DBManager.php
@@ -19,7 +19,11 @@ class WP_Auth0_DBManager
 			$current_ver = (int) get_site_option('auth0_db_version', 0);
 		}
 
-		if (empty($current_ver) || $current_ver === AUTH0_DB_VERSION) {
+		if ($current_ver === AUTH0_DB_VERSION) {
+			return;
+		}
+
+		if (empty($current_ver)) {
 			update_option('auth0_db_version', AUTH0_DB_VERSION);
 			return;
 		}


### PR DESCRIPTION
> By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/.github/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

(👍)

### Description

The install_db function is hooked into the plugins loaded action, but includes an `update_option` call which is fired even when the stored option DOES match.

This is inefficient, and can cause unnecessary DB write load. It is especially problematic on some enterprise hosting where an UPDATE call causes all subsequent reads in a request to go through a Writer database instead of a read replica, overwhelming production DB servers.

### References

Example query monitor output demonstrating UPDATE call on average pageview

<img width="829" alt="image" src="https://github.com/user-attachments/assets/87d19366-3400-4b5c-83ca-136a25e3b22f">

### Testing

Using Query Monitor, inspect the DB requests triggered by frontend traffic on a site. There should not be an identical UPDATE call on every request.

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not the default branch
