### PR TITLE
Reuse existing session token when refreshing sessions

### DIFF
--- a/src/Actions/Authentication.php
+++ b/src/Actions/Authentication.php
@@ -579,12 +579,37 @@ final class Authentication extends Base
         if ('false' !== $this->getPlugin()->getOption('sessions', 'rolling_sessions')) {
             $store = $this->getSdk()->configuration()->getSessionStorage();
 
-            /**
-             * @var CookieStore $store
-             */
-            $store->setState(true);
+            if ($store instanceof CookieStore) {
+                $store->setState(true);
+            }
 
-            wp_set_auth_cookie(get_current_user_id(), true);
+            // Extend the existing session token's expiry and reissue the browser cookies.
+            //
+            // The naive approach — calling wp_set_auth_cookie() with no token — rotates the
+            // session token. Because nonces are cryptographically bound to the session token,
+            // any nonce generated during the current request (with the old token) becomes
+            // invalid the moment the new cookie is sent, causing REST requests to fail with
+            // rest_cookie_invalid_nonce.
+            //
+            // wp_set_auth_cookie() accepts a $token argument. Passing the existing token
+            // reissues the browser cookies with a fresh expiration without rotating the token,
+            // so nonces remain valid and the full rolling-session behaviour is preserved.
+            $userId = get_current_user_id();
+            $token  = wp_get_session_token();
+
+            if ('' !== $token) {
+                /** This filter is documented in wp-includes/pluggable.php */
+                $expiration = apply_filters('auth_cookie_expiration', 14 * DAY_IN_SECONDS, $userId, true);
+
+                // Update the server-side session record (wp_set_auth_cookie does not do this
+                // when a token is supplied).
+                \WP_Session_Tokens::get_instance($userId)->update($token, [
+                    'expiration' => time() + $expiration,
+                ]);
+
+                // Reissue the browser cookies with the same token and new expiration.
+                wp_set_auth_cookie($userId, true, '', $token);
+            }
         }
     }
 

--- a/src/Actions/Authentication.php
+++ b/src/Actions/Authentication.php
@@ -601,11 +601,17 @@ final class Authentication extends Base
                 /** This filter is documented in wp-includes/pluggable.php */
                 $expiration = apply_filters('auth_cookie_expiration', 14 * DAY_IN_SECONDS, $userId, true);
 
-                // Update the server-side session record (wp_set_auth_cookie does not do this
-                // when a token is supplied).
-                \WP_Session_Tokens::get_instance($userId)->update($token, [
-                    'expiration' => time() + $expiration,
-                ]);
+                // Update the expiration date in the server-side session record
+                // (wp_set_auth_cookie does not do this when a token is supplied).
+                $manager = \WP_Session_Tokens::get_instance( $userId );
+                $session = $manager->get( $token );
+
+                if ( ! is_array( $session ) ) {
+                    return;
+                }
+
+                $session['expiration'] = time() + $expiration;
+                $manager->update( $token, $session );
 
                 // Reissue the browser cookies with the same token and new expiration.
                 wp_set_auth_cookie($userId, true, '', $token);


### PR DESCRIPTION
Fixes a bug when the rolling sessions functionality would update a user's session token on every pageview, invalidating any nonce checks before they're run. See #934 for examples of the issues this caused end users.

The root cause of the issue is:
* this plugin calls `wp_set_auth_cookie()` on a shutdown hook of every pageview, which causes a new session token to be issued for the user
* Ajax functionality triggered from the page will be passing a nonce which is generated from the previous session token.
* Any wp-ajax or REST handlers responding to these request will be checking the old nonce against a value generated from the user's new session token, causing any actions that depend on CSRF check to fail.

This change preserves the existing session token by passing it in to wp_set_auth_cookie(). In addition, the lifetime of the token itself needs to be extended so that it doesn't expire before the logged-in cookies.

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not the default branch
