### PR TITLE
Handle missing connection db records for verified auth0 sessions and improve cache handling

### DIFF
--- a/src/Actions/Authentication.php
+++ b/src/Actions/Authentication.php
@@ -408,7 +408,7 @@ final class Authentication extends Base
 
                     // Create missing account record, can be missing when resuming a session
                     // or registering on auth0 for an existing WP user.
-                    if (! $match instanceof WP_User && $verified) {
+                    if (! $match instanceof WP_User && $email === $wordpress->user_email && $verified) {
                         $this->createAccountConnection($wordpress, $sub);
 
                         return;

--- a/src/Actions/Authentication.php
+++ b/src/Actions/Authentication.php
@@ -101,6 +101,7 @@ final class Authentication extends Base
         if ($connections) {
             $database->deleteRow($table, ['user' => $userId, 'site' => $network, 'blog' => $blog], ['%d', '%s', '%s']);
             $cacheKey = 'auth0_account_' . hash('sha256', $connections[0] . '::' . $network . '!' . $blog);
+            delete_transient($cacheKey);
             wp_cache_delete($cacheKey);
 
             return $connections;

--- a/src/Actions/Authentication.php
+++ b/src/Actions/Authentication.php
@@ -70,7 +70,7 @@ final class Authentication extends Base
 
             if (null === $found) {
                 set_transient($cacheKey, $wpUser->ID, 120);
-                wp_cache_set($cacheKey, $found, 120);
+                wp_cache_set($cacheKey, $wpUser->ID, '', 120);
 
                 $database->insertRow($table, [
                     'user' => $wpUser->ID,
@@ -100,7 +100,8 @@ final class Authentication extends Base
 
         if ($connections) {
             $database->deleteRow($table, ['user' => $userId, 'site' => $network, 'blog' => $blog], ['%d', '%s', '%s']);
-            wp_cache_flush();
+            $cacheKey = 'auth0_account_' . hash('sha256', $connections[0] . '::' . $network . '!' . $blog);
+            wp_cache_delete($cacheKey);
 
             return $connections;
         }
@@ -399,7 +400,18 @@ final class Authentication extends Base
                 $sub = $session->user['sub'] ?? null;
 
                 if (null !== $sub) {
-                    $match = $this->getAccountByConnection($sub);
+                    $sub = sanitize_text_field($session->user['sub'] ?? '');
+                    $email = sanitize_text_field($session->user['email'] ?? '');
+                    $verified = $session->user['email_verified'] ?? null;
+                    $match = $this->resolveIdentity(sub: $sub, email: $email, verified: $verified);
+
+                    // Create missing account record, can be missing when resuming a session
+                    // or registering on auth0 for an existing WP user.
+                    if (! $match instanceof WP_User && $verified) {
+                        $this->createAccountConnection($wordpress, $sub);
+
+                        return;
+                    }
 
                     if (! $match instanceof WP_User || $match->ID !== $wordpress->ID) {
                         $this->getSdk()->clear();

--- a/src/Actions/Authentication.php
+++ b/src/Actions/Authentication.php
@@ -59,7 +59,10 @@ final class Authentication extends Base
         $found = false;
         wp_cache_get($cacheKey, '', false, $found);
 
-        if (! $found && false === get_transient($cacheKey)) {
+        if (! $found || false === get_transient($cacheKey)) {
+            set_transient($cacheKey, $wpUser->ID, 120);
+            wp_cache_set($cacheKey, $wpUser->ID, '', 120);
+        
             $database = $this->getPlugin()->database();
             $table = $database->getTableName(Database::CONST_TABLE_ACCOUNTS);
             $found = null;
@@ -69,9 +72,6 @@ final class Authentication extends Base
             $found = $database->selectRow('*', $table, 'WHERE `user` = %d AND `site` = %d AND `blog` = %d AND `auth0` = "%s" LIMIT 1', [$wpUser->ID, $network, $blog, $connection]);
 
             if (null === $found) {
-                set_transient($cacheKey, $wpUser->ID, 120);
-                wp_cache_set($cacheKey, $wpUser->ID, '', 120);
-
                 $database->insertRow($table, [
                     'user' => $wpUser->ID,
                     'site' => $network,
@@ -100,9 +100,11 @@ final class Authentication extends Base
 
         if ($connections) {
             $database->deleteRow($table, ['user' => $userId, 'site' => $network, 'blog' => $blog], ['%d', '%s', '%s']);
-            $cacheKey = 'auth0_account_' . hash('sha256', $connections[0] . '::' . $network . '!' . $blog);
-            delete_transient($cacheKey);
-            wp_cache_delete($cacheKey);
+            foreach ($connections as $connection) {
+                $cacheKey = 'auth0_account_' . hash('sha256', $connection . '::' . $network . '!' . $blog);
+                delete_transient($cacheKey);
+                wp_cache_delete($cacheKey);
+            }
 
             return $connections;
         }


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/.github/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

> Describe the purpose of this PR along with any background information and the impacts of the proposed change. For the benefit of the community, please do not assume prior context.
>
> Provide details that support your chosen implementation, including: breaking changes, alternatives considered, changes to the API, etc.
>
> If the UI is being changed, please provide screenshots.


This aims to fix an edge case where auth0 "resumes" a session but no account record has been created in the db so it keeps logging users out on every page request. This can happen when registering a new auth0 account for an existing WP user with a matching email address.

There are some errors in the caching here too that I needed to fix, like putting the expiry in the group parameter.

Flushing the entire cache when deleting a user is unnecessary and can be very damaging to performance on a busy site so I updated that as well, including deleting the transient.

It would be good to look into only using transients, or only `wp_cache_*` functions rather than combining them as it's not necessary and adding double the number of requests needed for sites with a separate cache server, which can degrade performance rather than improve it.

### Testing

> Describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.
>
> Please include any manual steps for testing end-to-end or functionality not covered by unit/integration tests.
>
> Also include details of the environment this PR was developed in (language/platform/browser version).

- [ ] This change adds test coverage for new/changed/fixed functionality

- Before the fix...
- Create a site with an existing WP user, administrator role
- Configure and Enable auth0
- Login again with the user and see that no `wp_auth0_accounts` record is created
- Browsing to the front end results in being logged out, after several redirects including to auth0's `resume` endpoint
- With the fix... 
- On the next page request to the front end, see that the redirects stop, and authentication is preserved, and the `wp_auth0_accounts` record is created

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not the default branch
